### PR TITLE
Add Cloud Context and deprate RoleName and RoleInstance on device

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/DeviceContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/DeviceContextTest.cs
@@ -144,32 +144,40 @@
         public void RoleNameIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
             var context = new DeviceContext(new Dictionary<string, string>());
+#pragma warning disable 618
             Assert.Null(context.RoleName);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void RoleNameCanBeChangedByUserSpecifyACustomValue()
         {
             var context = new DeviceContext(new Dictionary<string, string>());
+#pragma warning disable 618
             context.RoleName = "Testing role name";
 
             Assert.Equal("Testing role name", context.RoleName);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void RoleInstanceIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
             var context = new DeviceContext(new Dictionary<string, string>());
+#pragma warning disable 618
             Assert.Null(context.RoleInstance);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void RoleInstanceCanBeChangedByUserSpecifyACustomValue()
         {
             var context = new DeviceContext(new Dictionary<string, string>());
+#pragma warning disable 618
             context.RoleInstance = "Testing role name";
 
             Assert.Equal("Testing role name", context.RoleInstance);
+#pragma warning restore 618
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
+++ b/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
@@ -19,6 +19,7 @@
 
         private ComponentContext component;
         private DeviceContext device;
+        private CloudContext cloud;
         private SessionContext session;
         private UserContext user;
         private OperationContext operation;
@@ -70,6 +71,14 @@
         public DeviceContext Device
         {
             get { return LazyInitializer.EnsureInitialized(ref this.device, () => new DeviceContext(this.Tags)); }
+        }
+
+        /// <summary>
+        /// Gets the object describing the cloud tracked by this <see cref="TelemetryContext"/>.
+        /// </summary>
+        public CloudContext Cloud
+        {
+            get { return LazyInitializer.EnsureInitialized(ref this.cloud, () => new CloudContext(this.Tags)); }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
@@ -1,0 +1,42 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
+
+    /// <summary>
+    /// Encapsulates information about a cloud where an application is running.
+    /// </summary>
+    public sealed class CloudContext : IJsonSerializable
+    {
+        private readonly IDictionary<string, string> tags;
+
+        internal CloudContext(IDictionary<string, string> tags)
+        {
+            this.tags = tags;
+        }
+        
+        /// <summary>
+        /// Gets or sets the role name.
+        /// </summary>
+        public string RoleName
+        {
+            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceRoleName); }
+            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceRoleName, value); }
+        }
+
+        /// <summary>
+        /// Gets or sets the role instance.
+        /// </summary>
+        public string RoleInstance
+        {
+            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceRoleInstance); }
+            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceRoleInstance, value); }
+        }
+
+        void IJsonSerializable.Serialize(IJsonWriter writer)
+        {
+            // empty: serialized by Device context now.
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
@@ -92,6 +93,7 @@
         /// <summary>
         /// Gets or sets the role name.
         /// </summary>
+        [Obsolete("Use TelemetryContext.Cloud.RoleName")]
         public string RoleName
         {
             get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceRoleName); }
@@ -101,6 +103,7 @@
         /// <summary>
         /// Gets or sets the role instance.
         /// </summary>
+        [Obsolete("Use TelemetryContext.Cloud.RoleInstance")]
         public string RoleInstance
         {
             get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceRoleInstance); }
@@ -118,8 +121,10 @@
             writer.WriteProperty("network", this.NetworkType);
             writer.WriteProperty("resolution", this.ScreenResolution);
             writer.WriteProperty("locale", this.Language);
+#pragma warning disable 618
             writer.WriteProperty("roleName", this.RoleName);
             writer.WriteProperty("roleInstance", this.RoleInstance);
+#pragma warning restore 618
             writer.WriteEndObject();
         }
     }

--- a/src/Core/Managed/Shared/Shared.projitems
+++ b/src/Core/Managed/Shared/Shared.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\IDebugOutput.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\ComponentContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\DebugOutput.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CloudContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\DeviceContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\ExceptionConverter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Clock.cs" />


### PR DESCRIPTION
This is a beginning of Cloud context that will be extended in future. Long wished moving server properties out of Device.