### PR TITLE
Make ISupportSampling public and add unit tests for SamplingPercentage Serialization

### DIFF
--- a/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -165,6 +165,17 @@
             Assert.NotNull(telemetry as ISupportSampling);
         }
 
+        [TestMethod]
+        public void DependencyTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
+        {
+            var telemetry = this.CreateRemoteDependencyTelemetry("mycommand");
+            ((ISupportSampling)telemetry).SamplingPercentage = 10;
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, DataPlatformModel.RemoteDependencyData>(telemetry);
+
+            Assert.Equal(10, item.SampleRate);
+        }
+
         private DependencyTelemetry CreateRemoteDependencyTelemetry()
         {
             DependencyTelemetry item = new DependencyTelemetry

--- a/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
@@ -129,5 +129,16 @@
 
             Assert.NotNull(telemetry as ISupportSampling);
         }
+
+        [TestMethod]
+        public void EventTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
+        {
+            var telemetry = new EventTelemetry("my event");
+            ((ISupportSampling)telemetry).SamplingPercentage = 10;
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<EventTelemetry, DataPlatformModel.EventData>(telemetry);
+
+            Assert.Equal(10, item.SampleRate);
+        }
     }
 }

--- a/Test/CoreSDK.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -423,6 +423,17 @@
             Assert.NotNull(telemetry as ISupportSampling);
         }
 
+        [TestMethod]
+        public void ExceptionTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
+        {
+            var telemetry = new ExceptionTelemetry();
+            ((ISupportSampling)telemetry).SamplingPercentage = 10;
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, DataPlatformModel.ExceptionData>(telemetry);
+
+            Assert.Equal(10, item.SampleRate);
+        }
+
         private static Exception CreateExceptionWithStackTrace()
         {
             try

--- a/Test/CoreSDK.Test/Shared/DataContracts/PageViewTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/PageViewTelemetryTest.cs
@@ -125,5 +125,16 @@
 
             Assert.NotNull(telemetry as ISupportSampling);
         }
+
+        [TestMethod]
+        public void PageViewTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
+        {
+            var telemetry = new PageViewTelemetry("my page view");
+            ((ISupportSampling)telemetry).SamplingPercentage = 10;
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<PageViewTelemetry, DataPlatformModel.PageViewData>(telemetry);
+
+            Assert.Equal(10, item.SampleRate);
+        }
     }
 }

--- a/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -205,5 +205,17 @@
 
             Assert.NotNull(telemetry as ISupportSampling);
         }
+
+        [TestMethod]
+        public void RequestTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
+        {
+            var telemetry = new RequestTelemetry { Id = null };
+            ((ISupportSampling)telemetry).SamplingPercentage = 10;
+            ((ITelemetry)telemetry).Sanitize();
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, DataPlatformModel.RequestData>(telemetry);
+
+            Assert.Equal(10, item.SampleRate);
+        }
     }
 }

--- a/Test/CoreSDK.Test/Shared/DataContracts/TraceTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/TraceTelemetryTest.cs
@@ -88,7 +88,7 @@
             ((ITelemetry)expected).Sanitize();
 
             var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TraceTelemetry, DataPlatformModel.MessageData>(expected);
-            
+
             Assert.Equal(Developer.Analytics.DataCollection.Model.v2.SeverityLevel.Information, item.Data.BaseData.SeverityLevel.Value);
         }
 
@@ -128,17 +128,28 @@
             var telemetry = new TraceTelemetry { Message = null };
 
             ((ITelemetry)telemetry).Sanitize();
-            
+
             Assert.Contains("message", telemetry.Message, StringComparison.OrdinalIgnoreCase);
             Assert.Contains("required", telemetry.Message, StringComparison.OrdinalIgnoreCase);
         }
 
-        [TestMethod]		
+        [TestMethod]
         public void TraceTelemetryImplementsISupportSamplingContract()
         {
             var telemetry = new TraceTelemetry();
 
-            Assert.NotNull(telemetry as ISupportSampling);	
+            Assert.NotNull(telemetry as ISupportSampling);
         }
-}
+
+        [TestMethod]
+        public void TraceTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
+        {
+            var telemetry = new TraceTelemetry("my trace");
+            ((ISupportSampling)telemetry).SamplingPercentage = 10;
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TraceTelemetry, DataPlatformModel.MessageData>(telemetry);
+
+            Assert.Equal(10, item.SampleRate);
+        }
+    }
 }

--- a/src/Core/Managed/Shared/DataContracts/ISupportSampling.cs
+++ b/src/Core/Managed/Shared/DataContracts/ISupportSampling.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represent objects that support data sampling.
     /// </summary>
-    internal interface ISupportSampling
+    public interface ISupportSampling
     {
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).


### PR DESCRIPTION
Since Internals are not visible to other SDKs which need to make use of SamplingPercentage property, making ISupportSampling public.

@SergeyKanzhelev, @vitalyf007, @JakubOleksy  please have a look.