### PR TITLE
remove RequestTelemetry.Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 - The max length limit for the ```Name``` property of ```EventTelemetry``` was set to 512.
 - Property ```Name``` of ```OperationContext``` was renamed to ```RootName```
-- Property ```Id``` of ```RequestTelemetry``` was marked obsolete.
+- Property ```Id``` of ```RequestTelemetry``` was removed.
+- Property ```Id``` and ```Context.Operation.Id``` of ```RequestTelemetry``` would not be initialized when creating new ```RequestTelemetry```.
 - New properties of ```OperationContext```: ```CorrelationVector```, ```ParentId``` and ```RootId``` to support end-to-end telemetry items correlation.
 
 ## Version 2.0.0-beta1

--- a/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -30,7 +30,6 @@
         public void ParameterlessConstructorInitializesRequiredFields()
         {
             var request = new RequestTelemetry();
-            Assert.False(string.IsNullOrEmpty(request.Id));
             Assert.Equal("200", request.ResponseCode);
             Assert.Equal(true, request.Success);
         }
@@ -74,7 +73,6 @@
         {
             RequestTelemetry original = new RequestTelemetry();
             original.HttpMethod = null;
-            original.Id = null;
             original.Name = null;
             original.ResponseCode = null;
             original.Url = null;
@@ -89,7 +87,6 @@
         {
             var expected = new RequestTelemetry();
             expected.Timestamp = DateTimeOffset.Now;
-            expected.Id = "a1b2c3d4e5f6h7h8i9j10";
             expected.Name = "GET /WebForm.aspx";
             expected.Duration = TimeSpan.FromSeconds(4);
             expected.ResponseCode = "200";
@@ -109,7 +106,6 @@
             Assert.Equal(typeof(DataPlatformModel.RequestData).Name, item.Data.BaseType);
 
             Assert.Equal(2, item.Data.BaseData.Ver);
-            Assert.Equal(expected.Id, item.Data.BaseData.Id);
             Assert.Equal(expected.Name, item.Data.BaseData.Name);
             Assert.Equal(expected.Timestamp, item.Data.BaseData.StartTime);
             Assert.Equal(expected.Duration, item.Data.BaseData.Duration);
@@ -152,7 +148,6 @@
             telemetry.Metrics.Add(new string('Y', Property.MaxDictionaryNameLength) + 'X', 42.0);
             telemetry.Metrics.Add(new string('Y', Property.MaxDictionaryNameLength) + 'Y', 42.0);
             telemetry.Url = new Uri("http://foo.com/" + new string('Y', Property.MaxUrlLength + 1));
-            telemetry.Id = new string('1', Property.MaxNameLength);
 
             ((ITelemetry)telemetry).Sanitize();
 
@@ -169,22 +164,6 @@
             Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "001", telemetry.Metrics.Keys.ToArray()[1]);
 
             Assert.Equal(new Uri("http://foo.com/" + new string('Y', Property.MaxUrlLength - 15)), telemetry.Url);
-
-            Assert.Equal(new string('1', Property.MaxNameLength), telemetry.Id);
-        }
-
-        [TestMethod]
-        public void SanitizePopulatesIdWithErrorBecauseItIsRequiredByEndpoint()
-        {
-            var telemetry = new RequestTelemetry { Id = null };
-
-            ((ITelemetry)telemetry).Sanitize();
-
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, DataPlatformModel.RequestData>(telemetry);
-
-            // RequestTelemetry.Id is deprecated and you cannot access it. Method above will validate that all required fields would be populated
-            // Assert.Contains("id", telemetry.Id, StringComparison.OrdinalIgnoreCase);
-            // Assert.Contains("required", telemetry.Id, StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -209,7 +188,7 @@
         [TestMethod]
         public void RequestTelemetryHasCorrectValueOfSamplingPercentageAfterSerialization()
         {
-            var telemetry = new RequestTelemetry { Id = null };
+            var telemetry = new RequestTelemetry();
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
             ((ITelemetry)telemetry).Sanitize();
 

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -35,8 +35,6 @@
             this.Data = new RequestData();
             this.context = new TelemetryContext(this.Data.properties, new Dictionary<string, string>());
 
-            // Initialize required fields
-            this.Context.Operation.Id = WeakConcurrentRandom.Instance.Next().ToString(CultureInfo.InvariantCulture);
             this.ResponseCode = "200";
             this.Success = true;
         }
@@ -84,15 +82,6 @@
         public override TelemetryContext Context
         {
             get { return this.context; }
-        }
-
-        /// <summary>
-        /// Gets or sets Request ID. This method is redundant. Will be marked obsolete in future versions. Use Context.Operation.Id property instead.
-        /// </summary>
-        public string Id
-        {
-            get { return this.Context.Operation.Id; }
-            set { this.Context.Operation.Id = value; }
         }
 
         /// <summary>
@@ -219,10 +208,8 @@
             this.Metrics.SanitizeMeasurements();
             this.Url = this.Url.SanitizeUri();
             
-            // Set for backward compatibility:
-            this.Data.id = this.Context.Operation.Id;
-            this.Data.id = this.Data.id.SanitizeName();
-            this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
+            // Set to a space to comply to the schema
+            this.Data.id = " ";
             this.ResponseCode = Utils.PopulateRequiredStringValue(this.ResponseCode, "responseCode", typeof(RequestTelemetry).FullName);
         }
 


### PR DESCRIPTION
Removing ```RequestTelemetry.Id```. Instead ```RequestTelemetry.Context.Operation.Id``` will be used. Also automatic id generation was turned off as long term we will decide whether to use CorrelationVector or Id depending on the context.