### PR TITLE
set limit for event name to be 512

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 ## Version 2.0.0-beta2
 
+- The max length limit for the ```Name``` property of ```EventTelemetry``` was set to 512.
 - Property ```Id``` of ```RequestTelemetry``` was marked obsolete.
 - New properties of ```OperationContext```: ```CorrelationVector```, ```ParentId``` and ```RootId``` to support end-to-end telemetry items correlation.
 

--- a/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
@@ -90,7 +90,7 @@
         public void SanitizeWillTrimAppropriateFields()
         {
             EventTelemetry telemetry = new EventTelemetry();
-            telemetry.Name = new string('Z', Property.MaxNameLength + 1);
+            telemetry.Name = new string('Z', Property.MaxEventNameLength + 1);
             telemetry.Properties.Add(new string('X', Property.MaxDictionaryNameLength) + 'X', new string('X', Property.MaxValueLength + 1));
             telemetry.Properties.Add(new string('X', Property.MaxDictionaryNameLength) + 'Y', new string('X', Property.MaxValueLength + 1));
             telemetry.Metrics.Add(new string('Y', Property.MaxDictionaryNameLength) + 'X', 42.0);
@@ -98,7 +98,7 @@
 
             ((ITelemetry)telemetry).Sanitize();
 
-            Assert.Equal(new string('Z', Property.MaxNameLength), telemetry.Name);
+            Assert.Equal(new string('Z', Property.MaxEventNameLength), telemetry.Name);
 
             Assert.Equal(2, telemetry.Properties.Count);
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), telemetry.Properties.Keys.ToArray()[0]);

--- a/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
@@ -95,7 +95,7 @@
         /// </summary>
         void ITelemetry.Sanitize()
         {
-            this.Name = this.Name.SanitizeName();
+            this.Name = this.Name.SanitizeEventName();
             this.Name = Utils.PopulateRequiredStringValue(this.Name, "name", typeof(EventTelemetry).FullName);
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
@@ -18,6 +18,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         public const int MaxDictionaryNameLength = 150;
         public const int MaxDependencyTypeLength = 1024;
         public const int MaxValueLength = 8 * 1024;
+        public const int MaxEventNameLength = 512;
         public const int MaxNameLength = 1024;
         public const int MaxMessageLength = 32768;
         public const int MaxUrlLength = 2048;
@@ -56,6 +57,11 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             {
                 property = value;
             }
+        }
+
+        public static string SanitizeEventName(this string name)
+        {
+            return TrimAndTruncate(name, Property.MaxEventNameLength);
         }
 
         public static string SanitizeName(this string name)


### PR DESCRIPTION
Fixing https://github.com/Microsoft/ApplicationInsights-dotnet/issues/61
