### PR TITLE
first version of call context based operation

### DIFF
--- a/Microsoft.ApplicationInsights.sln
+++ b/Microsoft.ApplicationInsights.sln
@@ -79,20 +79,31 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Core.Net46.Tests", "Test\Co
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestFramework.Net46", "Test\CoreSDK.Test\TestFramework\Net46\TestFramework.Net46.csproj", "{D7D4E3F5-EC0D-47C9-90CC-56F612976122}"
 EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Operation.CC.Shared", "src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.shproj", "{21350114-0BF7-4F90-9732-5395840E8CE0}"
+EndProject
+Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Operation.CC.Tests.Shared", "Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.shproj", "{4DC2927F-BB78-4363-8428-0F02955064BC}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
+		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{412659ca-49b0-4834-bfbf-8183055083c8}*SharedItemsImports = 4
 		src\Core\Managed\Shared\Shared.projitems*{412659ca-49b0-4834-bfbf-8183055083c8}*SharedItemsImports = 4
 		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{9f9c3d52-abb9-461a-b1b6-a01bb5cecd93}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{30717095-904b-47b6-a76b-3d7a21f14e18}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{0927e682-4a56-46b6-8125-94fa066b2f57}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{0927e682-4a56-46b6-8125-94fa066b2f57}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{0927e682-4a56-45b6-8125-94fa066b2f57}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{0927e682-4a56-45b6-8125-94fa066b2f57}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{4dc2927f-bb78-4363-8428-0f02955064bc}*SharedItemsImports = 13
 		src\Core\Managed\Shared\Shared.projitems*{862b97af-f620-43fd-9b65-7e5423f3b7e3}*SharedItemsImports = 4
 		src\Core\Managed\Shared\Shared.projitems*{3a820d7a-f63c-460d-b2bd-ddac9433b4e9}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{394a78e5-2f8f-4d2d-ae08-027380c9f6b2}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{394a78e5-2f8f-4d2d-ae08-027380c9f6b2}*SharedItemsImports = 4
 		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{f76c6cbd-29b0-4564-bdcb-c969f8fec136}*SharedItemsImports = 13
+		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{958cfe53-53b7-4e26-846d-da3f214013e6}*SharedItemsImports = 4
 		src\Core\Managed\Shared\Shared.projitems*{958cfe53-53b7-4e26-846d-da3f214013e6}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{6587b432-e16a-4d26-93e1-bf12449fdb32}*SharedItemsImports = 4
 		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{b3ad9230-7e7a-4c82-8a7e-f297eeef8bb8}*SharedItemsImports = 4
+		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{cd752cd2-6711-4ad7-b5c8-f8c23cf076b1}*SharedItemsImports = 4
 		src\Core\Managed\Shared\Shared.projitems*{cd752cd2-6711-4ad7-b5c8-f8c23cf076b1}*SharedItemsImports = 4
 		src\Core\Managed\Shared\Shared.projitems*{50368b2b-a526-460e-8ad9-ab2e7951dab2}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{ff8678db-8ff0-4507-a793-2ff896fc7ad7}*SharedItemsImports = 4
@@ -101,6 +112,7 @@ Global
 		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{c4a0db5b-0988-4e04-b9b8-bcf3b0842000}*SharedItemsImports = 13
 		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{1ad07f5f-80e4-4020-b944-ee20756e3b24}*SharedItemsImports = 4
 		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{804af8fd-87f5-48ae-90c8-70433018b76e}*SharedItemsImports = 4
+		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{21350114-0bf7-4f90-9732-5395840e8ce0}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -497,5 +509,7 @@ Global
 		{958CFE53-53B7-4E26-846D-DA3F214013E6} = {68CC2924-E162-44BE-8D7A-DBA385365585}
 		{0927E682-4A56-46B6-8125-94FA066B2F57} = {C2FEEDE5-8CAE-41A4-8932-42D284A86EA7}
 		{D7D4E3F5-EC0D-47C9-90CC-56F612976122} = {BED5EB47-4AB1-4387-98B6-83CC327D6D16}
+		{21350114-0BF7-4F90-9732-5395840E8CE0} = {68CC2924-E162-44BE-8D7A-DBA385365585}
+		{4DC2927F-BB78-4363-8428-0F02955064BC} = {C2FEEDE5-8CAE-41A4-8932-42D284A86EA7}
 	EndGlobalSection
 EndGlobal

--- a/Test/CoreSDK.Test/Net40/Core.Net40.Tests.csproj
+++ b/Test/CoreSDK.Test/Net40/Core.Net40.Tests.csproj
@@ -55,6 +55,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
@@ -85,8 +86,8 @@
     </None>
   </ItemGroup>
   <Import Project="..\Shared\Core.Shared.Tests.projitems" Label="Shared" />
-  <Import Project="..\Shared.Net\Core.Shared.Net.Tests.projitems" Label="Shared" Condition="Exists('..\Shared.Net\Core.Shared.Net.Tests.projitems')" />
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets"/>
+  <Import Project="..\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems" Label="Shared" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />

--- a/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
+++ b/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
@@ -86,7 +87,7 @@
     </None>
   </ItemGroup>
   <Import Project="..\Shared\Core.Shared.Tests.projitems" Label="Shared" />
-  <Import Project="..\Shared.Net\Core.Shared.Net.Tests.projitems" Label="Shared" Condition="Exists('..\Shared.Net\Core.Shared.Net.Tests.projitems')" />
+  <Import Project="..\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems" Label="Shared" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />

--- a/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
+++ b/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
@@ -70,11 +70,9 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Core\Managed\Net45\Core.Net45.csproj">
-      <Project>{958cfe53-53b7-4e26-846d-da3f214013e6}</Project>
       <Name>Core.Net45</Name>
     </ProjectReference>
     <ProjectReference Include="..\TestFramework\Net45\TestFramework.Net45.csproj">
-      <Project>{d7d4e3f5-ec0d-47c9-90cc-56f612976122}</Project>
       <Name>TestFramework.Net45</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Test/CoreSDK.Test/Net46/Core.Net46.Tests.csproj
+++ b/Test/CoreSDK.Test/Net46/Core.Net46.Tests.csproj
@@ -51,6 +51,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
@@ -86,7 +87,7 @@
     </None>
   </ItemGroup>
   <Import Project="..\Shared\Core.Shared.Tests.projitems" Label="Shared" />
-  <Import Project="..\Shared.Net\Core.Shared.Net.Tests.projitems" Label="Shared" Condition="Exists('..\Shared.Net\Core.Shared.Net.Tests.projitems')" />
+  <Import Project="..\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems" Label="Shared" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/CallContextBasedOperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/CallContextBasedOperationCorrelationTelemetryInitializerTests.cs
@@ -1,0 +1,90 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Runtime.Remoting.Messaging;
+    using Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Operation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class CallContextBasedOperationCorrelationTelemetryInitializerTests
+    {
+        [TestMethod]
+        public void InitializerDoesNotFailOnNullContextStore()
+        {
+            var telemetry = new DependencyTelemetry();
+            this.SetOperationContextToCallContext(null);
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.IsNull(telemetry.Context.Operation.ParentId);
+        }
+
+        [TestMethod]
+        public void TelemetryContextIsUpdatedWithOperationIdForDependencyTelemetry()
+        {
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { ParentOperationId = "ParentOperationId" });
+            var telemetry = new DependencyTelemetry();
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.AreEqual("ParentOperationId", telemetry.Context.Operation.ParentId);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestMethod]
+        public void InitializeDoesNotUpdateOperationIdIfItExists()
+        {
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { ParentOperationId = "ParentOperationId" });
+            var telemetry = new DependencyTelemetry();
+            telemetry.Context.Operation.ParentId = "OldParentOperationId";
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.AreEqual("OldParentOperationId", telemetry.Context.Operation.ParentId);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestMethod]
+        public void TelemetryContextIsUpdatedWithRootOperationIdForDependencyTelemetry()
+        {
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { RootOperationId = "RootOperationId" });
+            var telemetry = new DependencyTelemetry();
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.AreEqual("RootOperationId", telemetry.Context.Operation.RootId);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestMethod]
+        public void InitializeDoesNotUpdateRootOperationIdIfItExists()
+        {
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { RootOperationId = "RootOperationId" });
+            var telemetry = new DependencyTelemetry();
+            telemetry.Context.Operation.RootId = "OldRootOperationId";
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.AreEqual("OldRootOperationId", telemetry.Context.Operation.RootId);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestMethod]
+        public void TelemetryContextIsUpdatedWithOperationNameForDependencyTelemetry()
+        {
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { OperationName = "OperationName" });
+            var telemetry = new DependencyTelemetry();
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.AreEqual(telemetry.Context.Operation.RootName, "OperationName");
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestMethod]
+        public void InitializeDoesNotUpdateOperationNameIfItExists()
+        {
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { OperationName = "OperationName" });
+            var telemetry = new DependencyTelemetry();
+            telemetry.Context.Operation.RootName = "OldOperationName";
+            (new CallContextBasedOperationCorrelationTelemetryInitializer()).Initialize(telemetry);
+            Assert.AreEqual(telemetry.Context.Operation.RootName, "OldOperationName");
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        private void SetOperationContextToCallContext(OperationContextForCallContext operationContext)
+        {
+            CallContext.LogicalSetData(CallContextHelpers.OperationContextSlotName, operationContext);
+        }
+    }
+}

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/CallContextBasedOperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/CallContextBasedOperationCorrelationTelemetryInitializerTests.cs
@@ -4,7 +4,6 @@
     using System.Runtime.Remoting.Messaging;
     using Extensibility.Implementation;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Operation;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Extensibility/Implementation/CallContextBasedOperationHolderTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Extensibility/Implementation/CallContextBasedOperationHolderTests.cs
@@ -1,0 +1,42 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// Tests corresponding to TelemetryClientExtension methods.
+    /// </summary>
+    [TestClass]
+    public class CallContextBasedOperationHolderTests
+    {
+        /// <summary>
+        /// Tests the scenario if OperationItem throws ArgumentNullException with null telemetry client.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void CreatingOperationItemWithNullTelemetryClientThrowsArgumentNullException()
+        {
+            var operationItem = new CallContextBasedOperationHolder<DependencyTelemetry>(null, new DependencyTelemetry());
+        }
+
+        /// <summary>
+        /// Tests the scenario if OperationItem throws ArgumentNullException with null telemetry.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void CreatingOperationItemWithNullTelemetryThrowsArgumentNullException()
+        {
+            var operationItem = new CallContextBasedOperationHolder<DependencyTelemetry>(new TelemetryClient(), null);
+        }
+
+        /// <summary>
+        /// Tests the scenario if creating OperationItem does not throw exception if arguments are not null.
+        /// </summary>
+        [TestMethod]
+        public void CreatingOperationItemDoesNotThrowOnPassingValidArguments()
+        {
+            var operationItem = new CallContextBasedOperationHolder<DependencyTelemetry>(new TelemetryClient(), new DependencyTelemetry());
+        }
+    }
+}

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Operation.CC.Tests.Shared.projitems
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Operation.CC.Tests.Shared.projitems
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="SharedProjectFile_SccProperties">
+    <SharedProjectFile_ProjectGuid>{9D7715BB-E4D0-499C-B8A3-63466FC8AA5D}</SharedProjectFile_ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>395e03bb-d061-4c9d-9d47-18676566444d</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Microsoft.ApplicationInsights.Extensions.Tests</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextBasedOperationHolderTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CallContextBasedOperationCorrelationTelemetryInitializerTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientExtensionAsyncTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientExtensionTests.cs" />
+  </ItemGroup>
+</Project>

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Operation.CC.Tests.Shared.shproj
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Operation.CC.Tests.Shared.shproj
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>4dc2927f-bb78-4363-8428-0f02955064bc</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="Operation.CC.Tests.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
@@ -1,0 +1,134 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Net;
+    using System.Net.Http;
+    using System.Runtime.Remoting.Messaging;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Operation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using TestFramework;
+
+    /// <summary>
+    /// Tests corresponding to TelemetryClientExtension methods.
+    /// </summary>
+    [TestClass]
+    public class TelemetryClientExtensionAsyncTests
+    {
+        private TelemetryClient telemetryClient;
+        private List<ITelemetry> sendItems;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            var configuration = new TelemetryConfiguration();
+            this.sendItems = new List<ITelemetry>();
+            configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
+            configuration.InstrumentationKey = Guid.NewGuid().ToString();
+            configuration.TelemetryInitializers.Add(new CallContextBasedOperationCorrelationTelemetryInitializer());
+            this.telemetryClient = new TelemetryClient(configuration);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName); 
+        }
+
+        /// <summary>
+        /// Ensure that context being propagated via async/await.
+        /// </summary>
+        [TestMethod]
+        public void ContextPropogatesThruAsyncAwait()
+        {
+            var task = this.TestAsync();
+            task.Wait();
+        }
+
+        /// <summary>
+        /// Actual async test method.
+        /// </summary>
+        /// <returns>Task to await.</returns>
+        public async Task TestAsync()
+        {
+            using (var op = this.telemetryClient.StartOperation<RequestTelemetry>("request"))
+            {
+                var id1 = Thread.CurrentThread.ManagedThreadId;
+                this.telemetryClient.TrackTrace("trace1");
+
+                HttpClient client = new HttpClient();
+                await client.GetStringAsync("http://bing.com");
+
+                var id2 = Thread.CurrentThread.ManagedThreadId;
+                this.telemetryClient.TrackTrace("trace2");
+
+                Assert.AreNotEqual(id1, id2);
+            }
+
+            Assert.AreEqual(3, this.sendItems.Count);
+            var id = this.sendItems[this.sendItems.Count - 1].Context.Operation.Id;
+            Assert.IsFalse(string.IsNullOrEmpty(id));
+
+            foreach (var item in this.sendItems)
+            {
+                if (item is TraceTelemetry)
+                {
+                    Assert.AreEqual(id, item.Context.Operation.ParentId);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Ensure that context being propagated via Begin/End.
+        /// </summary>
+        [TestMethod]
+        public void ContextPropogatesThruBeginEnd()
+        {
+            var op = this.telemetryClient.StartOperation<RequestTelemetry>("request");
+            var id1 = Thread.CurrentThread.ManagedThreadId;
+            int id2 = 0;
+            this.telemetryClient.TrackTrace("trace1");
+
+            HttpWebRequest request = WebRequest.Create(new Uri("http://bing.com")) as HttpWebRequest;
+            var result = request.BeginGetResponse(
+                (r) => 
+                    {
+                        id2 = Thread.CurrentThread.ManagedThreadId;
+                        this.telemetryClient.TrackTrace("trace2");
+
+                        this.telemetryClient.StopOperation(op);
+
+                        (r.AsyncState as HttpWebRequest).EndGetResponse(r);
+                    }, 
+                null);
+
+            while (!result.IsCompleted)
+            {
+                Thread.Sleep(10);
+            }
+
+            Thread.Sleep(100);
+
+            Assert.AreNotEqual(id1, id2);
+
+            Assert.AreEqual(3, this.sendItems.Count);
+            var id = this.sendItems[this.sendItems.Count - 1].Context.Operation.Id;
+            Assert.IsFalse(string.IsNullOrEmpty(id));
+
+            foreach (var item in this.sendItems)
+            {
+                if (item is TraceTelemetry)
+                {
+                    Assert.AreEqual(id, item.Context.Operation.ParentId);
+                }
+            }
+        }
+    }
+}

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionTests.cs
@@ -1,0 +1,212 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Runtime.Remoting.Messaging;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Extensibility.Implementation;
+    using TestFramework;
+
+    /// <summary>
+    /// Tests corresponding to TelemetryClientExtension methods.
+    /// </summary>
+    [TestClass]
+    public class TelemetryClientExtensionTests
+    {
+        private TelemetryClient telemetryClient;
+        private List<ITelemetry> sendItems;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            var configuration = new TelemetryConfiguration();
+            this.sendItems = new List<ITelemetry>();
+            configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sendItems.Add(item) };
+            configuration.InstrumentationKey = Guid.NewGuid().ToString();
+            this.telemetryClient = new TelemetryClient(configuration);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName); 
+        }
+
+        /// <summary>
+        /// Tests the scenario if StartOperation returns operation with telemetry item of same type.
+        /// </summary>
+        [TestMethod]
+        public void StartDependencyTrackingReturnsOperationWithSameTelemetryItem()
+        {
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>(null);
+            Assert.IsNotNull(operation);
+            Assert.IsNotNull(operation.Telemetry);
+
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        /// <summary>
+        /// Tests the scenario if StartOperation assigns operation name to the telemetry item.
+        /// </summary>
+        [TestMethod]
+        public void StartDependencyTrackingReturnsOperationWithInitializedOperationName()
+        {
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
+            Assert.AreEqual("TestOperationName", operation.Telemetry.Context.Operation.RootName);
+        }
+
+        /// <summary>
+        /// Tests the scenario if StartOperation throws exception when telemetry client is null.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void StartDependencyTrackingThrowsExceptionWithNullTelemetryClient()
+        {
+            TelemetryClient tc = null;
+            tc.StartOperation<DependencyTelemetry>(null);
+        }
+
+        /// <summary>
+        /// Tests the scenario if StartOperation returns operation with timestamp.
+        /// </summary>
+        [TestMethod]
+        public void StartDependencyTrackingCreatesADependencyTelemetryItemWithTimeStamp()
+        {
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>(null);
+            Assert.AreEqual(operation.Telemetry.StartTime, operation.Telemetry.Timestamp);
+            Assert.AreNotEqual(operation.Telemetry.StartTime, DateTimeOffset.MinValue);
+
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        /// <summary>
+        /// Tests the scenario if CallContext is updated with the telemetry item with StartOperation.
+        /// </summary>
+        [TestMethod]
+        public void StartDependencyTrackingAddsOperationContextStoreToCallContext()
+        {
+            Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>(null);
+            Assert.IsNotNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        /// <summary>
+        /// Tests the scenario if operation item is disposed and telemetry is sent with using.
+        /// </summary>
+        [TestMethod]
+        public void UsingSendsTelemetryAndDisposesOperationItem()
+        {
+            Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+            using (var operation = this.telemetryClient.StartOperation<DependencyTelemetry>(null))
+            {
+            }
+
+            Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+            Assert.AreEqual(1, this.sendItems.Count);
+            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
+        }
+
+        /// <summary>
+        /// Tests the scenario if operation item is disposed and telemetry is sent with using.
+        /// </summary>
+        [TestMethod]
+        public void UsingWithStopOperationSendsTelemetryAndDisposesOperationItemOnlyOnce()
+        {
+            Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+            using (var operation = this.telemetryClient.StartOperation<DependencyTelemetry>(null))
+            {
+                this.telemetryClient.StopOperation(operation);
+            }
+
+            Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+            Assert.AreEqual(1, this.sendItems.Count);
+        }
+
+        /// <summary>
+        /// Tests the scenario if CallContext is updated with multiple operations.
+        /// </summary>
+        [TestMethod]
+        public void StartDependencyTrackingHandlesMultipleContextStoresInCallContext()
+        {
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as CallContextBasedOperationHolder<DependencyTelemetry>;
+            var parentContextStore = CallContextHelpers.GetCurrentOperationContextFromCallContext();
+            Assert.AreEqual(operation.Telemetry.Context.Operation.Id, parentContextStore.ParentOperationId);
+            Assert.AreEqual(operation.Telemetry.Context.Operation.RootName, parentContextStore.OperationName);
+
+            var childOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as CallContextBasedOperationHolder<DependencyTelemetry>;
+            var childContextStore = CallContextHelpers.GetCurrentOperationContextFromCallContext();
+            Assert.AreEqual(childOperation.Telemetry.Context.Operation.Id, childContextStore.ParentOperationId);
+            Assert.AreEqual(childOperation.Telemetry.Context.Operation.RootName, childContextStore.OperationName);
+
+            Assert.IsNull(operation.ParentContext);
+            Assert.AreEqual(parentContextStore, childOperation.ParentContext);
+
+            this.telemetryClient.StopOperation(childOperation);
+            Assert.AreEqual(parentContextStore, CallContextHelpers.GetCurrentOperationContextFromCallContext());
+            this.telemetryClient.StopOperation(operation);
+            Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
+        }
+
+        /// <summary>
+        /// Tests the scenario if StopOperation does not fail when call context is not initialized.
+        /// </summary>
+        [TestMethod]
+        public void StopOperationDoesNotFailOnNullOperation()
+        {
+            TelemetryClient tc = new TelemetryClient();
+            tc.StopOperation<DependencyTelemetry>(null);
+        }
+
+        /// <summary>
+        /// Tests the scenario if StopOperation throws exception when telemetry client is null.
+        /// </summary>
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void StopDependencyTrackingThrowsExceptionWithNullTelemetryClient()
+        {
+            var operationItem = new CallContextBasedOperationHolder<DependencyTelemetry>(this.telemetryClient, new DependencyTelemetry());
+            TelemetryClient tc = null;
+            tc.StopOperation(operationItem);
+        }
+
+        /// <summary>
+        /// Tests the scenario if stop operation does not throw exception when a parent operation is being stopped before the child operation.
+        /// </summary>
+        [TestMethod]
+        public void StopOperationDoesNotThrowExceptionIfParentOpertionIsStoppedBeforeChildOperation()
+        {
+            using (var parentOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("operationName"))
+            {
+                using (var childOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("operationName"))
+                {
+                    this.telemetryClient.StopOperation(parentOperation);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Tests the scenario if stop operation works fine with nested operations.
+        /// </summary>
+        [TestMethod]
+        public void StopOperationWorksFineWithNestedOperations()
+        {
+            using (var parentOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("operationName"))
+            {
+                using (var childOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("operationName"))
+                {
+                    this.telemetryClient.StopOperation(childOperation);
+                }
+
+                this.telemetryClient.StopOperation(parentOperation);
+            }
+
+            Assert.AreEqual(2, this.sendItems.Count);
+        }
+    }
+}

--- a/Test/CoreSDK.Test/Shared/Core.Shared.Tests.projitems
+++ b/Test/CoreSDK.Test/Shared/Core.Shared.Tests.projitems
@@ -28,6 +28,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\TraceTelemetryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\ClockTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\JsonSerializerTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationWatchTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\ExtensionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\SequencePropertyInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\ComponentContextTest.cs" />
@@ -68,6 +69,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\SdkVersionPropertyContextInitializerTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TelemetryConfigurationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TimestampPropertyInitializerTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)OperationTelemetryExtensionsTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Thread.cs" />

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/OperationWatchTests.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/OperationWatchTests.cs
@@ -1,0 +1,49 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
+    using System.Globalization;
+    using System.Reflection;
+    using System.Threading;
+#if WINDOWS_PHONE || WINDOWS_STORE
+    using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+    using Assert = Xunit.Assert;
+#if WINRT
+    using TaskEx = System.Threading.Tasks.Task;
+#endif 
+
+    [TestClass]
+    public class OperationWatchTests
+    {
+        [TestMethod]
+        [SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1118:ParameterMustNotSpanMultipleLines",
+            Justification = "Assert text parameters span multiple lines - no point separating them")]
+        public void OperationWatchMatchesDateTimeOffset()
+        {
+            long elapsedTicks = OperationWatch.ElapsedTicks;
+            DateTimeOffset now = DateTimeOffset.UtcNow;
+
+            DateTimeOffset nowAccordingToOperationWatch = OperationWatch.Timestamp(elapsedTicks);
+
+            // since getting elapsed ticks and 'utcnow' on DateTimeOffset
+            // are two different operations, the timestamps are going to
+            // be different but close
+            const int DeltaMilliseconds = 100;
+
+            Assert.True(
+                nowAccordingToOperationWatch >= now.AddMilliseconds(-DeltaMilliseconds)
+                && nowAccordingToOperationWatch <= now.AddMilliseconds(DeltaMilliseconds),
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "Timestamp per operation watch {0} differs from timestamp of test {1} by {2} which is outside of the tolerance of {3}ms",
+                    nowAccordingToOperationWatch.ToString("O", CultureInfo.InvariantCulture),
+                    now.ToString("O", CultureInfo.InvariantCulture),
+                    (now - nowAccordingToOperationWatch).ToString("G", CultureInfo.InvariantCulture),
+                    DeltaMilliseconds));
+        }
+    }
+}

--- a/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
+++ b/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
@@ -1,0 +1,76 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Threading;
+    using Microsoft.ApplicationInsights.DataContracts;
+#if WINDOWS_PHONE || WINDOWS_STORE
+    using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
+#else
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+#endif
+    using Assert = Xunit.Assert;
+#if WINRT
+    using TaskEx = System.Threading.Tasks.Task;
+#endif 
+
+    /// <summary>
+    /// Tests corresponding to OperationExtension methods.
+    /// </summary>
+    [TestClass]
+    public class OperationTelemetryExtensionsTests
+    {
+        /// <summary>
+        /// Tests the scenario if StartOperation returns operation with telemetry item of same type.
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryStartInitializesTimeStampAndStartTimeToTelemetry()
+        {
+            var telemetry = new DependencyTelemetry();
+            Assert.Equal(telemetry.StartTime, DateTimeOffset.MinValue);
+            Assert.Equal(telemetry.Timestamp, DateTimeOffset.MinValue);
+            telemetry.Start();
+            Assert.Equal(telemetry.StartTime, telemetry.Timestamp);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Stop does not change start time and timestamp after start is called.
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryStopDoesNotAffectTimeStampAndStartTimeAfterStart()
+        {
+            var telemetry = new DependencyTelemetry();
+            telemetry.Start();
+            DateTimeOffset actualTime = telemetry.Timestamp;
+            telemetry.Stop();
+            Assert.Equal(actualTime, telemetry.Timestamp);
+            Assert.Equal(actualTime, telemetry.StartTime);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Stop computes the duration of the telemetry.
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryStopComputesDurationAfterStart()
+        {
+            var telemetry = new DependencyTelemetry();
+            telemetry.Start();
+            Thread.Sleep(2000);
+            Assert.Equal(TimeSpan.Zero, telemetry.Duration);
+            telemetry.Stop();
+            Assert.True(telemetry.Duration.TotalMilliseconds > 0);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Stop computes assigns current time to start time and time stamp and assigns 0 to duration without start().
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryStopAssignsCurrentTimeAsStartTimeAndTimeStampWithoutStart()
+        {
+            var telemetry = new DependencyTelemetry();
+            telemetry.Stop();
+            Assert.NotEqual(DateTimeOffset.MinValue, telemetry.StartTime);
+            Assert.Equal(telemetry.StartTime, telemetry.Timestamp);
+            Assert.Equal(telemetry.Duration, TimeSpan.Zero);
+        }
+    }
+}

--- a/Test/CoreSDK.Test/TestFramework/Shared/StubClock.cs
+++ b/Test/CoreSDK.Test/TestFramework/Shared/StubClock.cs
@@ -1,8 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework
 {
     using System;
-    using System.Collections.Generic;
-    using System.Text;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
     internal class StubClock : IClock

--- a/src/Core/Managed/Net40/Core.Net40.csproj
+++ b/src/Core/Managed/Net40/Core.Net40.csproj
@@ -74,6 +74,7 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
+  <Import Project="..\Operation.CC.Shared\Operation.CC.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.14\tools\Microsoft.Bcl.Build.targets')" />

--- a/src/Core/Managed/Net45/Core.Net45.csproj
+++ b/src/Core/Managed/Net45/Core.Net45.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Extensibility\Implementation\External\Tags.cs" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
+  <Import Project="..\Operation.CC.Shared\Operation.CC.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Core/Managed/Net46/Core.Net46.csproj
+++ b/src/Core/Managed/Net46/Core.Net46.csproj
@@ -48,6 +48,7 @@
     <Compile Include="Extensibility\Implementation\External\Tags.cs" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
+  <Import Project="..\Operation.CC.Shared\Operation.CC.Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.1\build\StyleCop.MSBuild.Targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">

--- a/src/Core/Managed/Operation.CC.Shared/CallContextBasedOperationCorrelationTelemetryInitializer.cs
+++ b/src/Core/Managed/Operation.CC.Shared/CallContextBasedOperationCorrelationTelemetryInitializer.cs
@@ -1,0 +1,46 @@
+﻿namespace Microsoft.ApplicationInsights.Operation
+{
+    using Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// Telemetry initializer that populates OperationContext for the telemetry item based on context stored in CallContext.
+    /// </summary>
+    public class CallContextBasedOperationCorrelationTelemetryInitializer : ITelemetryInitializer
+    {
+        /// <summary>
+        /// Initializes/Adds operation id to the existing telemetry item.
+        /// </summary>
+        /// <param name="telemetryItem">Target telemetry item to add operation id.</param>
+        public void Initialize(ITelemetry telemetryItem)
+        {
+            var itemContext = telemetryItem.Context.Operation;
+
+            if (string.IsNullOrEmpty(itemContext.ParentId) || string.IsNullOrEmpty(itemContext.RootId) || string.IsNullOrEmpty(itemContext.RootName))
+            {
+                var parentContext = CallContextHelpers.GetCurrentOperationContextFromCallContext();
+                if (parentContext != null)
+                {
+                    if (string.IsNullOrEmpty(itemContext.ParentId)
+                        && !string.IsNullOrEmpty(parentContext.ParentOperationId))
+                    {
+                        itemContext.ParentId = parentContext.ParentOperationId;
+                    }
+
+                    if (string.IsNullOrEmpty(itemContext.RootId)
+                        && !string.IsNullOrEmpty(parentContext.RootOperationId))
+                    {
+                        itemContext.RootId = parentContext.RootOperationId;
+                    }
+
+                    if (string.IsNullOrEmpty(itemContext.RootName)
+                        && !string.IsNullOrEmpty(parentContext.OperationName))
+                    {
+                        itemContext.RootName = parentContext.OperationName;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationCorrelationTelemetryInitializer.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationCorrelationTelemetryInitializer.cs
@@ -1,13 +1,12 @@
-﻿namespace Microsoft.ApplicationInsights.Operation
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
-    using Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
 
     /// <summary>
     /// Telemetry initializer that populates OperationContext for the telemetry item based on context stored in CallContext.
     /// </summary>
-    public class CallContextBasedOperationCorrelationTelemetryInitializer : ITelemetryInitializer
+    internal class CallContextBasedOperationCorrelationTelemetryInitializer : ITelemetryInitializer
     {
         /// <summary>
         /// Initializes/Adds operation id to the existing telemetry item.

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationHolder.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationHolder.cs
@@ -1,0 +1,92 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using Extensibility.Implementation.Tracing;
+
+    /// <summary>
+    /// Operation class that holds the telemetry item and the corresponding telemetry client.
+    /// </summary>
+    internal class CallContextBasedOperationHolder<T> : IOperationHolder<T>
+    {
+        /// <summary>
+        /// Parent context store that is used to restore call context.
+        /// </summary>
+        public OperationContextForCallContext ParentContext;
+
+        private TelemetryClient telemetryClient;
+        private T telemetry;
+        private bool isDisposed = false;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CallContextBasedOperationHolder{T}"/> class.
+        /// Initializes telemetry client.
+        /// </summary>
+        /// <param name="telemetryClient">Initializes telemetry client object.</param>
+        /// <param name="telemetry">Operation telemetry item that is assigned to the telemetry associated to the current operation item.</param>
+        public CallContextBasedOperationHolder(TelemetryClient telemetryClient, T telemetry)
+        {
+            if (telemetry == null)
+            {
+                throw new ArgumentNullException("telemetry");
+            }
+
+            if (telemetryClient == null)
+            {
+                throw new ArgumentNullException("telemetryClient");
+            }
+
+            this.telemetryClient = telemetryClient;
+            this.telemetry = telemetry;
+        }
+
+        /// <summary>
+        /// Gets Telemetry item of interest that is created when StartOperation function of ClientExtensions is invoked.
+        /// </summary>
+        public T Telemetry
+        {
+            get { return this.telemetry; }
+        }
+
+        /// <summary>
+        /// Dispose method to clear the variables.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Computes the duration and tracks the respective telemetry item on dispose.
+        /// </summary>
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing && !this.isDisposed)
+            {
+                // We need to compare the operation id and name of telemetry with opeartion id and name of current call context before tracking it 
+                // to make sure that the customer is tracking the right telemetry.
+                lock (this)
+                {
+                    if (!this.isDisposed)
+                    {
+                        var telemetry = this.Telemetry as OperationTelemetry;
+
+                        var currentOperationContext = CallContextHelpers.GetCurrentOperationContextFromCallContext();
+                        if (telemetry.Context.Operation.Id != currentOperationContext.ParentOperationId ||
+                            telemetry.Context.Operation.RootName != currentOperationContext.OperationName)
+                        {
+                            CoreEventSource.Log.InvalidOperationToStopError();
+                            return;
+                        }
+
+                        telemetry.Stop();
+                        this.telemetryClient.Track(telemetry);
+                        CallContextHelpers.RestoreCallContext(this.ParentContext);
+                    }
+
+                    this.isDisposed = true;
+                }
+            }
+        }
+    }
+}

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextHelpers.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextHelpers.cs
@@ -1,0 +1,43 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System.Runtime.Remoting.Messaging;
+
+    internal static class CallContextHelpers
+    {
+        /// <summary>
+        /// Name of the operation context store item present in the context.
+        /// </summary>
+        internal const string OperationContextSlotName = "Microsoft.ApplicationInsights.Operation.OperationContextStore";
+
+        /// <summary>
+        /// Saves the context store to the call context.
+        /// </summary>
+        /// <param name="operationContext">Operation context store instance.</param>
+        internal static void SaveOperationContextToCallContext(OperationContextForCallContext operationContext)
+        {
+            CallContext.FreeNamedDataSlot(OperationContextSlotName);
+            CallContext.LogicalSetData(OperationContextSlotName, operationContext);
+        }
+
+        /// <summary>
+        /// Returns the current operation context store present in the call context.
+        /// </summary>
+        internal static OperationContextForCallContext GetCurrentOperationContextFromCallContext()
+        { 
+            return CallContext.LogicalGetData(OperationContextSlotName) as OperationContextForCallContext;
+        }
+
+        /// <summary>
+        /// Clears the call context and restores the parent operation.
+        /// </summary>
+        /// <param name="parentContext">Parent operation context store to replace child operation context store.</param>
+        internal static void RestoreCallContext(OperationContextForCallContext parentContext)
+        {
+            CallContext.FreeNamedDataSlot(OperationContextSlotName);
+            if (parentContext != null)
+            {
+                CallContext.LogicalSetData(OperationContextSlotName, parentContext);
+            }
+        }
+    }
+}

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/OperationContextForCallContext.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/OperationContextForCallContext.cs
@@ -1,0 +1,27 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+
+    /// <summary>
+    /// Operation class that holds operation id and operation name for the current call context.
+    /// </summary>
+    [Serializable]
+    internal class OperationContextForCallContext : MarshalByRefObject
+    {
+        /// <summary>
+        /// Operation id that will be assigned to all the child telemetry items.
+        /// Parent Operation id that will be assigned to all the child telemetry items.
+        /// </summary>
+        public string ParentOperationId;
+
+        /// <summary>
+        /// Root Operation id that will be assigned to all the child telemetry items.
+        /// </summary>
+        public string RootOperationId;
+
+        /// <summary>
+        /// Operation name that will be assigned to all the child telemetry items.
+        /// </summary>
+        public string OperationName;
+    }
+}

--- a/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.projitems
+++ b/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.projitems
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="SharedProjectFile_SccProperties">
+    <SharedProjectFile_ProjectGuid>{C6425564-9EFE-49B3-B309-4D5FB55A5355}</SharedProjectFile_ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup>
+    <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
+    <HasSharedItems>true</HasSharedItems>
+    <SharedGUID>669e7e58-072d-4b0a-a4dd-4eb2ae2ea4d4</SharedGUID>
+  </PropertyGroup>
+  <PropertyGroup Label="Configuration">
+    <Import_RootNamespace>Microsoft.ApplicationInsights.Operation</Import_RootNamespace>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CallContextBasedOperationCorrelationTelemetryInitializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextBasedOperationHolder.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationContextForCallContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientExtensions.cs" />
+  </ItemGroup>
+</Project>

--- a/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.projitems
+++ b/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.projitems
@@ -12,10 +12,11 @@
     <Import_RootNamespace>Microsoft.ApplicationInsights.Operation</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <Compile Include="$(MSBuildThisFileDirectory)CallContextBasedOperationCorrelationTelemetryInitializer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextBasedOperationCorrelationTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextBasedOperationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationContextForCallContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)TelemetryConfigurationExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.shproj
+++ b/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.shproj
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>21350114-0bf7-4f90-9732-5395840e8ce0</ProjectGuid>
+  </PropertyGroup>
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.Default.props" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.Common.props" />
+  <PropertyGroup />
+  <Import Project="Operation.CC.Shared.projitems" Label="Shared" />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\CodeSharing\Microsoft.CodeSharing.CSharp.targets" />
+</Project>

--- a/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
+++ b/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
@@ -1,0 +1,76 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using Extensibility;
+    using Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+    /// <summary>
+    /// Extension class to telemetry client that creates operation object with the respective fields initialized.
+    /// </summary>
+    public static class TelemetryClientExtensions
+    {
+        /// <summary>
+        /// Start operation creates an operation object with a respective telemetry item. 
+        /// </summary>
+        /// <typeparam name="T">Type of the telemetry item.</typeparam>
+        /// <param name="telemetryClient">Telemetry client object.</param>
+        /// <param name="operationName">Name of the operation that customer is planning to propagate.</param>
+        /// <returns>Operation item object with a new telemetry item having current start time and timestamp.</returns>
+        public static IOperationHolder<T> StartOperation<T>(this TelemetryClient telemetryClient, string operationName) where T : OperationTelemetry, new()
+        {
+            if (telemetryClient == null)
+            {
+                throw new ArgumentNullException("Telemetry client cannot be null.");
+            }
+
+            var operation = new CallContextBasedOperationHolder<T>(telemetryClient, new T());
+            operation.Telemetry.Start();
+
+            // Parent context store is assigned to operation that is used to restore call context.
+            operation.ParentContext = CallContextHelpers.GetCurrentOperationContextFromCallContext();
+
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.RootName) && !string.IsNullOrEmpty(operationName))
+            {
+                operation.Telemetry.Context.Operation.RootName = operationName;
+            }
+
+            telemetryClient.Initialize(operation.Telemetry);
+
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Id))
+            {
+                operation.Telemetry.GenerateOperationId();
+            }
+
+            // Update the call context to store certain fields that can be used for subsequent operations.
+            var operationContext = new OperationContextForCallContext();
+            operationContext.ParentOperationId = operation.Telemetry.Context.Operation.Id;
+            operationContext.RootOperationId = operation.Telemetry.Context.Operation.RootId;
+            operationContext.OperationName = operation.Telemetry.Context.Operation.RootName;
+            CallContextHelpers.SaveOperationContextToCallContext(operationContext);
+
+            return operation;
+        }
+
+        /// <summary>
+        /// Stop operation computes the duration of the operation and tracks it using the respective telemetry client.
+        /// </summary>
+        /// <param name="telemetryClient">Telemetry client object.</param>
+        /// <param name="operation">Operation object to compute duration and track.</param>
+        public static void StopOperation<T>(this TelemetryClient telemetryClient, IOperationHolder<T> operation)
+        {
+            if (telemetryClient == null)
+            {
+                throw new ArgumentNullException("telemetryClient");
+            }
+
+            if (operation == null)
+            {
+                CoreEventSource.Log.OperationIsNullWarning();
+                return;
+            }
+
+            operation.Dispose();
+        }
+    }
+}

--- a/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
+++ b/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights
 {
     using System;
+    using System.ComponentModel;
     using Extensibility;
     using Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -8,6 +9,7 @@
     /// <summary>
     /// Extension class to telemetry client that creates operation object with the respective fields initialized.
     /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
     public static class TelemetryClientExtensions
     {
         /// <summary>

--- a/src/Core/Managed/Operation.CC.Shared/TelemetryConfigurationExtensions.cs
+++ b/src/Core/Managed/Operation.CC.Shared/TelemetryConfigurationExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System.ComponentModel;
+    using Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// Extension methods for TelemetryConfiguration class.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class TelemetryConfigurationExtensions
+    {
+        /// <summary>
+        /// Adds logic to track operations correlation.
+        /// </summary>
+        /// <param name="configuraton">Telemetry configuration object to add track operation correlation for.</param>
+        public static void AddOperationsApi(this TelemetryConfiguration configuraton)
+        {
+            configuraton.TelemetryInitializers.Insert(0, new CallContextBasedOperationCorrelationTelemetryInitializer());
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/IOperationHolder.cs
+++ b/src/Core/Managed/Shared/Extensibility/IOperationHolder.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility
+{
+    using System;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+    /// <summary>
+    /// Represents the operation item that holds telemetry which is tracked on end request. Operation can be associated with either WEB or SQL dependencies.
+    /// </summary>
+    public interface IOperationHolder<T> : IDisposable
+    {
+        /// <summary>
+        /// Gets Telemetry item of interest that is created when StartOperation function of ClientExtensions is invoked.
+        /// </summary>
+        T Telemetry { get; }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/Implementation/OperationWatch.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/OperationWatch.cs
@@ -1,0 +1,69 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Diagnostics;
+
+    /// <summary>
+    /// Single high precision clock used by operations.
+    /// </summary>
+    internal static class OperationWatch
+    {
+        /// <summary>
+        /// High precision stopwatch.
+        /// </summary>
+        private static readonly Stopwatch Watch;
+
+        /// <summary>
+        /// Number of 100 nanoseconds per high-precision clock tick.
+        /// </summary>
+        private static readonly double HundredNanosecondsPerTick;
+
+        /// <summary>
+        /// The time clock started.
+        /// </summary>
+        private static readonly DateTimeOffset StartTime;
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline",
+            Justification = "Cannot really do Start() operation on stop watch in the variable initialization - need static ctor")]
+        static OperationWatch()
+        {
+            StartTime = DateTimeOffset.UtcNow;
+
+            Watch = new Stopwatch();
+            Watch.Start();
+
+            HundredNanosecondsPerTick = (1000.0 * 1000.0 * 10.0) / Stopwatch.Frequency;
+        }
+
+        /// <summary>
+        /// Gets number of ticks elapsed on the clock since the start.
+        /// </summary>
+        public static long ElapsedTicks
+        {
+#if ALLOW_AGGRESSIVE_INLIGNING_ATTRIBUTE
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+            get
+            {
+                return Watch.ElapsedTicks;
+            }
+        }
+
+        /// <summary>
+        /// Converts time on the operation clock (in ticks) to date and time structure.
+        /// </summary>
+        /// <param name="elapsedTicks">Ticks elapsed according to operation watch.</param>
+        /// <returns>Date time structure representing the date and time that corresponds to the operation clock reading.</returns>
+#if ALLOW_AGGRESSIVE_INLIGNING_ATTRIBUTE
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+#endif
+        public static DateTimeOffset Timestamp(long elapsedTicks)
+        {
+            // Stopwatch ticks are different from DateTime.Ticks. 
+            // Each tick in the DateTime.Ticks value represents one 100-nanosecond interval. 
+            // Each tick in the ElapsedTicks value represents the time interval equal to 
+            // 1 second divided by the Frequency.
+            return StartTime.AddTicks(Convert.ToInt64(elapsedTicks * HundredNanosecondsPerTick));
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -15,6 +15,25 @@
         public static readonly CoreEventSource Log = new CoreEventSource();
 
         private readonly ApplicationNameProvider nameProvider = new ApplicationNameProvider();
+
+        /// <summary>
+        /// Logs the information when there operation to track is null.
+        /// </summary>
+        [Event(1, Message = "Operation object is null.", Level = EventLevel.Warning)]
+        public void OperationIsNullWarning(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(1, this.nameProvider.Name);
+        }
+
+        /// <summary>
+        /// Logs the information when there operation to stop does not match the current operation.
+        /// </summary>
+        [Event(2, Message = "Operation to stop does not match the current operation.", Level = EventLevel.Error)]
+        public void InvalidOperationToStopError(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(2, this.nameProvider.Name);
+        }
+
         [Event(
             10,
             Keywords = Keywords.VerboseFailure,

--- a/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
+++ b/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
@@ -1,0 +1,52 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.ComponentModel;
+    using System.Globalization;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+
+    /// <summary>
+    /// Extension functions to operation telemetry that start and stop the timer.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class OperationTelemetryExtensions
+    {
+        /// <summary>
+        /// An extension to telemetry item that starts the timer for the the respective telemetry.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
+        public static void Start(this OperationTelemetry telemetry)
+        {
+            var startTime = OperationWatch.Timestamp(OperationWatch.ElapsedTicks);
+            telemetry.StartTime = startTime;
+            telemetry.Timestamp = startTime;
+        }
+
+        /// <summary>
+        /// An extension method to telemetry item that stops the timer and computes the duration of the request or dependency.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
+        public static void Stop(this OperationTelemetry telemetry)
+        {
+            if (telemetry.StartTime != DateTimeOffset.MinValue)
+            {
+                telemetry.Duration = OperationWatch.Timestamp(OperationWatch.ElapsedTicks) - telemetry.StartTime;
+            }
+            else
+            {
+                telemetry.Timestamp = OperationWatch.Timestamp(OperationWatch.ElapsedTicks);
+                telemetry.StartTime = telemetry.Timestamp;
+                telemetry.Duration = TimeSpan.Zero;
+            }
+        }
+
+        /// <summary>
+        /// Generate random operation Id and set it to OperationContext.
+        /// </summary>
+        /// <param name="telemetry">Telemetry to initialize Operation id for.</param>
+        public static void GenerateOperationId(this OperationTelemetry telemetry)
+        {
+            telemetry.Context.Operation.Id = WeakConcurrentRandom.Instance.Next().ToString(CultureInfo.InvariantCulture);
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Shared.projitems
+++ b/src/Core/Managed/Shared/Shared.projitems
@@ -57,6 +57,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\LocationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationTelemetry.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationWatch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Platform\PlatformSingleton.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Property.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SessionContext.cs" />
@@ -105,6 +106,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\UserContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\WeakConcurrentRandom.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\XorshiftRandomBatchGenerator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\IOperationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\ITelemetryModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\ITelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\SdkVersionPropertyContextInitializer.cs" />
@@ -113,6 +115,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TelemetryModules.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TimestampPropertyInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GlobalSuppressions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)OperationTelemetryExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryClient.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Utils.cs" />


### PR DESCRIPTION
Implemented CallContext-based operation tracking API. This API will only be available in FW40, FW 4.5 and FW 4.6 and not currently available for WRT, WP8 and PCL. Next iteration will bring [AsyncLocal](https://msdn.microsoft.com/en-us/library/dn906268.aspx)-based implementation