### PR TITLE
initialize RootId and use OperationTelemetry.Name istead of RootName …

### DIFF
--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
@@ -78,6 +78,13 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
+                    Assert.Equal(id, item.Context.Operation.RootId);
+                }
+                else
+                {
+                    Assert.Equal(id, item.Context.Operation.Id);
+                    Assert.Equal(id, item.Context.Operation.RootId);
+                    Assert.Null(item.Context.Operation.ParentId);
                 }
             }
         }
@@ -95,7 +102,7 @@
 
             HttpWebRequest request = WebRequest.Create(new Uri("http://bing.com")) as HttpWebRequest;
             var result = request.BeginGetResponse(
-                (r) => 
+                (r) =>
                     {
                         id2 = Thread.CurrentThread.ManagedThreadId;
                         this.telemetryClient.TrackTrace("trace2");
@@ -103,7 +110,7 @@
                         this.telemetryClient.StopOperation(op);
 
                         (r.AsyncState as HttpWebRequest).EndGetResponse(r);
-                    }, 
+                    },
                 null);
 
             while (!result.IsCompleted)
@@ -124,6 +131,14 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
+                    Assert.Equal(id, item.Context.Operation.RootId);
+                }
+                else
+                {
+                    Assert.Equal(id, item.Context.Operation.Id);
+                    Assert.Equal(id, item.Context.Operation.RootId);
+                    Assert.Null(item.Context.Operation.ParentId);
+
                 }
             }
         }

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionTests.cs
@@ -10,9 +10,6 @@
     using Extensibility.Implementation;
     using TestFramework;
 
-    /// <summary>
-    /// Tests corresponding to TelemetryClientExtension methods.
-    /// </summary>
     [TestClass]
     public class TelemetryClientExtensionTests
     {
@@ -36,9 +33,6 @@
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName); 
         }
 
-        /// <summary>
-        /// Tests the scenario if StartOperation returns operation with telemetry item of same type.
-        /// </summary>
         [TestMethod]
         public void StartDependencyTrackingReturnsOperationWithSameTelemetryItem()
         {
@@ -49,19 +43,27 @@
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
         }
 
-        /// <summary>
-        /// Tests the scenario if StartOperation assigns operation name to the telemetry item.
-        /// </summary>
         [TestMethod]
         public void StartDependencyTrackingReturnsOperationWithInitializedOperationName()
         {
             var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
-            Assert.AreEqual("TestOperationName", operation.Telemetry.Context.Operation.RootName);
+            Assert.AreEqual("TestOperationName", operation.Telemetry.Name);
         }
 
-        /// <summary>
-        /// Tests the scenario if StartOperation throws exception when telemetry client is null.
-        /// </summary>
+        [TestMethod]
+        public void StartDependencyTrackingReturnsOperationWithInitializedOperationId()
+        {
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
+            Assert.IsNotNull(operation.Telemetry.Context.Operation.Id);
+        }
+
+        [TestMethod]
+        public void StartDependencyTrackingReturnsOperationWithInitializedOperationRootId()
+        {
+            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
+            Assert.IsNotNull(operation.Telemetry.Context.Operation.RootId);
+        }
+
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void StartDependencyTrackingThrowsExceptionWithNullTelemetryClient()
@@ -70,9 +72,6 @@
             tc.StartOperation<DependencyTelemetry>(null);
         }
 
-        /// <summary>
-        /// Tests the scenario if StartOperation returns operation with timestamp.
-        /// </summary>
         [TestMethod]
         public void StartDependencyTrackingCreatesADependencyTelemetryItemWithTimeStamp()
         {
@@ -83,9 +82,6 @@
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
         }
 
-        /// <summary>
-        /// Tests the scenario if CallContext is updated with the telemetry item with StartOperation.
-        /// </summary>
         [TestMethod]
         public void StartDependencyTrackingAddsOperationContextStoreToCallContext()
         {
@@ -96,9 +92,6 @@
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
         }
 
-        /// <summary>
-        /// Tests the scenario if operation item is disposed and telemetry is sent with using.
-        /// </summary>
         [TestMethod]
         public void UsingSendsTelemetryAndDisposesOperationItem()
         {
@@ -112,9 +105,6 @@
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
         }
 
-        /// <summary>
-        /// Tests the scenario if operation item is disposed and telemetry is sent with using.
-        /// </summary>
         [TestMethod]
         public void UsingWithStopOperationSendsTelemetryAndDisposesOperationItemOnlyOnce()
         {
@@ -128,9 +118,6 @@
             Assert.AreEqual(1, this.sendItems.Count);
         }
 
-        /// <summary>
-        /// Tests the scenario if CallContext is updated with multiple operations.
-        /// </summary>
         [TestMethod]
         public void StartDependencyTrackingHandlesMultipleContextStoresInCallContext()
         {
@@ -153,9 +140,6 @@
             Assert.IsNull(CallContextHelpers.GetCurrentOperationContextFromCallContext());
         }
 
-        /// <summary>
-        /// Tests the scenario if StopOperation does not fail when call context is not initialized.
-        /// </summary>
         [TestMethod]
         public void StopOperationDoesNotFailOnNullOperation()
         {
@@ -163,9 +147,6 @@
             tc.StopOperation<DependencyTelemetry>(null);
         }
 
-        /// <summary>
-        /// Tests the scenario if StopOperation throws exception when telemetry client is null.
-        /// </summary>
         [TestMethod]
         [ExpectedException(typeof(ArgumentNullException))]
         public void StopDependencyTrackingThrowsExceptionWithNullTelemetryClient()
@@ -175,9 +156,6 @@
             tc.StopOperation(operationItem);
         }
 
-        /// <summary>
-        /// Tests the scenario if stop operation does not throw exception when a parent operation is being stopped before the child operation.
-        /// </summary>
         [TestMethod]
         public void StopOperationDoesNotThrowExceptionIfParentOpertionIsStoppedBeforeChildOperation()
         {
@@ -190,9 +168,6 @@
             }
         }
 
-        /// <summary>
-        /// Tests the scenario if stop operation works fine with nested operations.
-        /// </summary>
         [TestMethod]
         public void StopOperationWorksFineWithNestedOperations()
         {

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationHolder.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationHolder.cs
@@ -69,19 +69,19 @@
                 {
                     if (!this.isDisposed)
                     {
-                        var telemetry = this.Telemetry as OperationTelemetry;
+                        var operationTelemetry = this.Telemetry as OperationTelemetry;
 
                         var currentOperationContext = CallContextHelpers.GetCurrentOperationContextFromCallContext();
-                        if (telemetry.Context.Operation.Id != currentOperationContext.ParentOperationId ||
-                            telemetry.Context.Operation.RootName != currentOperationContext.OperationName)
+                        if (operationTelemetry.Context.Operation.Id != currentOperationContext.ParentOperationId ||
+                            operationTelemetry.Context.Operation.RootName != currentOperationContext.OperationName)
                         {
                             CoreEventSource.Log.InvalidOperationToStopError();
                             return;
                         }
 
-                        telemetry.Stop();
-                        this.telemetryClient.Track(telemetry);
+                        operationTelemetry.Stop();
                         CallContextHelpers.RestoreCallContext(this.ParentContext);
+                        this.telemetryClient.Track(operationTelemetry);
                     }
 
                     this.isDisposed = true;

--- a/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
+++ b/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
@@ -32,9 +32,9 @@
             // Parent context store is assigned to operation that is used to restore call context.
             operation.ParentContext = CallContextHelpers.GetCurrentOperationContextFromCallContext();
 
-            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.RootName) && !string.IsNullOrEmpty(operationName))
+            if (string.IsNullOrEmpty(operation.Telemetry.Name) && !string.IsNullOrEmpty(operationName))
             {
-                operation.Telemetry.Context.Operation.RootName = operationName;
+                operation.Telemetry.Name = operationName;
             }
 
             telemetryClient.Initialize(operation.Telemetry);
@@ -42,6 +42,11 @@
             if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Id))
             {
                 operation.Telemetry.GenerateOperationId();
+            }
+
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.RootId))
+            {
+                operation.Telemetry.Context.Operation.RootId = operation.Telemetry.Context.Operation.Id;
             }
 
             // Update the call context to store certain fields that can be used for subsequent operations.


### PR DESCRIPTION
…of OperationContext

This was already signed off by @abaranch in another repository