### PR TITLE
Fix application lockups when calling into app insights from Task sche…

### DIFF
--- a/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
@@ -44,7 +44,7 @@ namespace Microsoft.ApplicationInsights.Channel
             this.buffer.OnFull = this.OnBufferFull;
 
             // Starting the Runner
-            Task.Factory.StartNew(this.Runner, TaskCreationOptions.LongRunning)
+            Task.Factory.StartNew(this.Runner, CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default)
                 .ContinueWith(
                     task => 
                     {


### PR DESCRIPTION
…duled

on UI thread
- It is currently possible for the long-running InMemoryTransmitter.Runner
  task to be executed (and thereby block during WaitOne) on the UI thread when
  called by a task scheduled on the UI thread. This fix guarantees that
  InMemoryTransmitter.Runner never blocks the main thread by explicitly
  specifying TaskScheduler.Default when calling StartNew.

We recently ran into this issue in Node.js Tools for VS, and managed to work around it by using TaskCreationOptions.HideScheduler, but it would be great to fix it at the source. 
* https://github.com/Microsoft/nodejstools/issues/427#issuecomment-147409676

And here's a blog post that provides a little more context on the issue:
http://blogs.msdn.com/b/pfxteam/archive/2012/09/22/new-taskcreationoptions-and-taskcontinuationoptions-in-net-4-5.aspx

[Moving PR from #76 to develop branch]