### PR TITLE
Changes for Web SDK blackfield

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -109,14 +109,14 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>1</SemanticVersionMajor>
-    <SemanticVersionMinor>2</SemanticVersionMinor>
+    <SemanticVersionMinor>3</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
 
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.
     -->
-    <SemanticVersionDate>2015-7-17</SemanticVersionDate>
+    <SemanticVersionDate>2015-10-27</SemanticVersionDate>
 
     <!-- 
       Pre-release version is used to distinguish internally built NuGet packages.

--- a/Test/CoreSDK.Test/Shared/TelemetryClientTest.cs
+++ b/Test/CoreSDK.Test/Shared/TelemetryClientTest.cs
@@ -653,6 +653,74 @@
             Assert.Null(actualMessage);
         }
 
+#if WINRT
+        [TestMethod]
+        public void TrackDoesNotWriteTelemetryToDebugOutputIfIKeyEmptyInWinRt()
+        {
+            string actualMessage = null;
+            var debugOutput = new StubDebugOutput { OnWriteLine = message => actualMessage = message };
+            
+            PlatformSingleton.Current = new StubPlatform { OnGetDebugOutput = () => debugOutput };
+            var channel = new StubTelemetryChannel { DeveloperMode = true };
+            var configuration = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel,
+                InstrumentationKey = ""
+                
+            };
+            var client = new TelemetryClient(configuration);
+
+            client.Track(new StubTelemetry());
+            PlatformSingleton.Current = null;
+            Assert.Null(actualMessage);
+        }
+
+#endif
+#if NET40 || NET45
+        [TestMethod]
+        public void TrackWritesTelemetryToDebugOutputIfIKeyEmptyInDotNet()
+        {
+            string actualMessage = null;
+            var debugOutput = new StubDebugOutput { OnWriteLine = message => actualMessage = message };
+            
+            PlatformSingleton.Current = new StubPlatform { OnGetDebugOutput = () => debugOutput };
+            var channel = new StubTelemetryChannel { DeveloperMode = true };
+            var configuration = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel,
+                InstrumentationKey = ""
+                
+            };
+            var client = new TelemetryClient(configuration);
+
+            client.Track(new StubTelemetry());
+            PlatformSingleton.Current = null;
+            Assert.True(actualMessage.StartsWith("Application Insights Telemetry (unconfigured): "));
+        }
+
+        [TestMethod]
+        public void TrackWritesTelemetryToDebugOutputIfIKeyNotEmptyInDotNet()
+        {
+            string actualMessage = null;
+            var debugOutput = new StubDebugOutput { OnWriteLine = message => actualMessage = message };
+
+            PlatformSingleton.Current = new StubPlatform { OnGetDebugOutput = () => debugOutput };
+            var channel = new StubTelemetryChannel { DeveloperMode = true };
+            var configuration = new TelemetryConfiguration
+            {
+                TelemetryChannel = channel,
+                InstrumentationKey = "123"
+
+            };
+            var client = new TelemetryClient(configuration);
+
+            client.Track(new StubTelemetry());
+            PlatformSingleton.Current = null;
+            Assert.True(actualMessage.StartsWith("Application Insights Telemetry: "));
+        }
+
+#endif
+
         [TestMethod]
         public void TrackCopiesPropertiesFromClientToTelemetry()
         {
@@ -701,7 +769,7 @@
             Assert.Equal(client.Context.Properties[PropertyName], valueInInitializer);
         }
 
-        #endregion
+#endregion
 
         private TelemetryClient InitializeTelemetryClient(ICollection<ITelemetry> sentTelemetry)
         {

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -4,7 +4,6 @@
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Globalization;
-    using System.IO;
     using System.Threading;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -314,6 +313,85 @@
             this.Track(telemetry);
         }
 
+        //// Preserve original version of 'Track' with TelemetryInitializer being called after iKey check for Devices SDK till we completely move to a different SDK.
+#if NET40 || NET45
+
+        /// <summary>
+        /// This method is an internal part of Application Insights infrastructure. Do not call.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Track(ITelemetry telemetry)
+        {
+            // TALK TO YOUR TEAM MATES BEFORE CHANGING THIS.
+            // This method needs to be public so that we can build and ship new telemetry types without having to ship core.
+            // It is hidden from intellisense to prevent customer confusion.
+            if (this.IsEnabled())
+            {
+                this.Initialize(telemetry);
+
+                if (System.Diagnostics.Debugger.IsAttached)
+                {
+                    this.WriteTelemetryToDebugOutput(telemetry);
+                }
+
+                if (string.IsNullOrEmpty(telemetry.Context.InstrumentationKey))
+                {
+                    return;
+                }
+
+                telemetry.Sanitize();
+
+                this.Channel.Send(telemetry);                
+            }
+        }
+
+        /// <summary>
+        /// This method is an internal part of Application Insights infrastructure. Do not call.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item to initialize.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Initialize(ITelemetry telemetry)
+        {
+            string instrumentationKey = this.Context.InstrumentationKey;
+
+            if (string.IsNullOrEmpty(instrumentationKey))
+            {
+                instrumentationKey = this.configuration.InstrumentationKey;
+            }
+
+            var telemetryWithProperties = telemetry as ISupportProperties;
+            if (telemetryWithProperties != null)
+            {
+                if ((this.configuration.TelemetryChannel != null) && (this.configuration.TelemetryChannel.DeveloperMode.HasValue && this.configuration.TelemetryChannel.DeveloperMode.Value))
+                {
+                    if (!telemetryWithProperties.Properties.ContainsKey("DeveloperMode"))
+                    {
+                        telemetryWithProperties.Properties.Add("DeveloperMode", "true");
+                    }
+                }
+
+                Utils.CopyDictionary(this.Context.Properties, telemetryWithProperties.Properties);
+            }
+
+            telemetry.Context.Initialize(this.Context, instrumentationKey);
+            foreach (ITelemetryInitializer initializer in this.configuration.TelemetryInitializers)
+            {
+                try
+                {
+                    initializer.Initialize(telemetry);
+                }
+                catch (Exception exception)
+                {
+                    CoreEventSource.Log.LogError(string.Format(
+                                                    CultureInfo.InvariantCulture,
+                                                    "Exception while initializing {0}, exception message - {1}",
+                                                    initializer.GetType().FullName,
+                                                    exception));
+                }
+            }
+        }
+
+#else
         /// <summary>
         /// This method is an internal part of Application Insights infrastructure. Do not call.
         /// </summary>
@@ -378,6 +456,7 @@
                 }
             }
         }
+#endif
 
         /// <summary>
         /// Send information about the page viewed in the application.
@@ -453,11 +532,12 @@
         {
             if (this.debugOutput.IsLogging())
             {
-                using (var stringWriter = new StringWriter(CultureInfo.InvariantCulture))
-                {
-                    string serializedTelemetry = JsonSerializer.SerializeAsString(telemetry);
-                    this.debugOutput.WriteLine("Application Insights Telemetry: " + serializedTelemetry);
-                }
+                string prefix = string.IsNullOrEmpty(telemetry.Context.InstrumentationKey) ? 
+                    "Application Insights Telemetry (unconfigured): " : 
+                    "Application Insights Telemetry: ";
+
+                string serializedTelemetry = JsonSerializer.SerializeAsString(telemetry);
+                this.debugOutput.WriteLine(prefix + serializedTelemetry);
             }
         }
     }


### PR DESCRIPTION
For .Net 4.0 and .Net 4.5 write to VS debug output window even if iKey is not configured.