### PR TITLE
Return RequestTelemetry.Id and remove RootID

### DIFF
--- a/Test/CoreSDK.Test/Operation.AL.Shared.Tests/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/CoreSDK.Test/Operation.AL.Shared.Tests/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -39,44 +39,23 @@
         }
 
         [TestMethod]
-        public void TelemetryContextIsUpdatedWithRootOperationIdForDependencyTelemetry()
-        {
-            AsyncLocalHelpers.SaveOperationContext(new OperationContextForAsyncLocal { RootOperationId = "RootOperationId" });
-            var telemetry = new DependencyTelemetry();
-            (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual("RootOperationId", telemetry.Context.Operation.RootId);
-            AsyncLocalHelpers.SaveOperationContext(null);
-        }
-
-        [TestMethod]
-        public void InitializeDoesNotUpdateRootOperationIdIfItExists()
-        {
-            AsyncLocalHelpers.SaveOperationContext(new OperationContextForAsyncLocal { RootOperationId = "RootOperationId" });
-            var telemetry = new DependencyTelemetry();
-            telemetry.Context.Operation.RootId = "OldRootOperationId";
-            (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual("OldRootOperationId", telemetry.Context.Operation.RootId);
-            AsyncLocalHelpers.SaveOperationContext(null);
-        }
-
-        [TestMethod]
         public void TelemetryContextIsUpdatedWithOperationNameForDependencyTelemetry()
         {
-            AsyncLocalHelpers.SaveOperationContext(new OperationContextForAsyncLocal { OperationName = "OperationName" });
+            AsyncLocalHelpers.SaveOperationContext(new OperationContextForAsyncLocal { RootOperationName = "OperationName" });
             var telemetry = new DependencyTelemetry();
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual(telemetry.Context.Operation.RootName, "OperationName");
+            Assert.AreEqual(telemetry.Context.Operation.Name, "OperationName");
             AsyncLocalHelpers.SaveOperationContext(null);
         }
 
         [TestMethod]
         public void InitializeDoesNotUpdateOperationNameIfItExists()
         {
-            AsyncLocalHelpers.SaveOperationContext(new OperationContextForAsyncLocal { OperationName = "OperationName" });
+            AsyncLocalHelpers.SaveOperationContext(new OperationContextForAsyncLocal { RootOperationName = "OperationName" });
             var telemetry = new DependencyTelemetry();
-            telemetry.Context.Operation.RootName = "OldOperationName";
+            telemetry.Context.Operation.Name = "OldOperationName";
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual(telemetry.Context.Operation.RootName, "OldOperationName");
+            Assert.AreEqual(telemetry.Context.Operation.Name, "OldOperationName");
             AsyncLocalHelpers.SaveOperationContext(null);
         }
     }

--- a/Test/CoreSDK.Test/Operation.AL.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
+++ b/Test/CoreSDK.Test/Operation.AL.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
@@ -70,7 +70,7 @@
             }
 
             Assert.Equal(3, this.sendItems.Count);
-            var id = this.sendItems[this.sendItems.Count - 1].Context.Operation.Id;
+            var id = ((RequestTelemetry)this.sendItems[this.sendItems.Count - 1]).Id;
             Assert.False(string.IsNullOrEmpty(id));
 
             foreach (var item in this.sendItems)
@@ -78,12 +78,12 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
-                    Assert.Equal(id, item.Context.Operation.RootId);
+                    Assert.Equal(id, item.Context.Operation.Id);
                 }
                 else
                 {
+                    Assert.Equal(id, ((RequestTelemetry)item).Id);
                     Assert.Equal(id, item.Context.Operation.Id);
-                    Assert.Equal(id, item.Context.Operation.RootId);
                     Assert.Null(item.Context.Operation.ParentId);
                 }
             }
@@ -123,7 +123,7 @@
             Assert.NotEqual(id1, id2);
 
             Assert.Equal(3, this.sendItems.Count);
-            var id = this.sendItems[this.sendItems.Count - 1].Context.Operation.Id;
+            var id = ((RequestTelemetry)this.sendItems[this.sendItems.Count - 1]).Id;
             Assert.False(string.IsNullOrEmpty(id));
 
             foreach (var item in this.sendItems)
@@ -131,12 +131,12 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
-                    Assert.Equal(id, item.Context.Operation.RootId);
+                    Assert.Equal(id, item.Context.Operation.Id);
                 }
                 else
                 {
+                    Assert.Equal(id, ((RequestTelemetry)item).Id);
                     Assert.Equal(id, item.Context.Operation.Id);
-                    Assert.Equal(id, item.Context.Operation.RootId);
                     Assert.Null(item.Context.Operation.ParentId);
 
                 }

--- a/Test/CoreSDK.Test/Operation.AL.Shared.Tests/TelemetryClientExtensionTests.cs
+++ b/Test/CoreSDK.Test/Operation.AL.Shared.Tests/TelemetryClientExtensionTests.cs
@@ -55,14 +55,7 @@
         public void StartDependencyTrackingReturnsOperationWithInitializedOperationId()
         {
             var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
-            Assert.IsNotNull(operation.Telemetry.Context.Operation.Id);
-        }
-
-        [TestMethod]
-        public void StartDependencyTrackingReturnsOperationWithInitializedOperationRootId()
-        {
-            var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
-            Assert.IsNotNull(operation.Telemetry.Context.Operation.RootId);
+            Assert.IsNotNull(operation.Telemetry.Id);
         }
 
         [TestMethod]
@@ -81,7 +74,6 @@
             Assert.AreNotEqual(operation.Telemetry.StartTime, DateTimeOffset.MinValue);
 
             AsyncLocalHelpers.SaveOperationContext(null);
-
         }
 
         [TestMethod]
@@ -127,12 +119,12 @@
             var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as AsyncLocalBasedOperationHolder<DependencyTelemetry>;
             var parentContextStore = AsyncLocalHelpers.GetCurrentOperationContext();
             Assert.AreEqual(operation.Telemetry.Context.Operation.Id, parentContextStore.ParentOperationId);
-            Assert.AreEqual(operation.Telemetry.Context.Operation.RootName, parentContextStore.OperationName);
+            Assert.AreEqual(operation.Telemetry.Context.Operation.Name, parentContextStore.RootOperationName);
 
             var childOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as AsyncLocalBasedOperationHolder<DependencyTelemetry>;
             var childContextStore = AsyncLocalHelpers.GetCurrentOperationContext();
             Assert.AreEqual(childOperation.Telemetry.Context.Operation.Id, childContextStore.ParentOperationId);
-            Assert.AreEqual(childOperation.Telemetry.Context.Operation.RootName, childContextStore.OperationName);
+            Assert.AreEqual(childOperation.Telemetry.Context.Operation.Name, childContextStore.RootOperationName);
 
             Assert.IsNull(operation.ParentContext);
             Assert.AreEqual(parentContextStore, childOperation.ParentContext);

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -39,44 +39,23 @@
         }
 
         [TestMethod]
-        public void TelemetryContextIsUpdatedWithRootOperationIdForDependencyTelemetry()
-        {
-            this.SetOperationContextToCallContext(new OperationContextForCallContext { RootOperationId = "RootOperationId" });
-            var telemetry = new DependencyTelemetry();
-            (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual("RootOperationId", telemetry.Context.Operation.RootId);
-            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
-        }
-
-        [TestMethod]
-        public void InitializeDoesNotUpdateRootOperationIdIfItExists()
-        {
-            this.SetOperationContextToCallContext(new OperationContextForCallContext { RootOperationId = "RootOperationId" });
-            var telemetry = new DependencyTelemetry();
-            telemetry.Context.Operation.RootId = "OldRootOperationId";
-            (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual("OldRootOperationId", telemetry.Context.Operation.RootId);
-            CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
-        }
-
-        [TestMethod]
         public void TelemetryContextIsUpdatedWithOperationNameForDependencyTelemetry()
         {
-            this.SetOperationContextToCallContext(new OperationContextForCallContext { OperationName = "OperationName" });
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { RootOperationName = "OperationName" });
             var telemetry = new DependencyTelemetry();
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual(telemetry.Context.Operation.RootName, "OperationName");
+            Assert.AreEqual(telemetry.Context.Operation.Name, "OperationName");
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
         }
 
         [TestMethod]
         public void InitializeDoesNotUpdateOperationNameIfItExists()
         {
-            this.SetOperationContextToCallContext(new OperationContextForCallContext { OperationName = "OperationName" });
+            this.SetOperationContextToCallContext(new OperationContextForCallContext { RootOperationName = "OperationName" });
             var telemetry = new DependencyTelemetry();
-            telemetry.Context.Operation.RootName = "OldOperationName";
+            telemetry.Context.Operation.Name = "OldOperationName";
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
-            Assert.AreEqual(telemetry.Context.Operation.RootName, "OldOperationName");
+            Assert.AreEqual(telemetry.Context.Operation.Name, "OldOperationName");
             CallContext.FreeNamedDataSlot(CallContextHelpers.OperationContextSlotName);
         }
 

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionAsyncTests.cs
@@ -70,7 +70,7 @@
             }
 
             Assert.Equal(3, this.sendItems.Count);
-            var id = this.sendItems[this.sendItems.Count - 1].Context.Operation.Id;
+            var id = ((RequestTelemetry)this.sendItems[this.sendItems.Count - 1]).Id;
             Assert.False(string.IsNullOrEmpty(id));
 
             foreach (var item in this.sendItems)
@@ -78,12 +78,12 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
-                    Assert.Equal(id, item.Context.Operation.RootId);
+                    Assert.Equal(id, item.Context.Operation.Id);
                 }
                 else
                 {
+                    Assert.Equal(id, ((RequestTelemetry)item).Id);
                     Assert.Equal(id, item.Context.Operation.Id);
-                    Assert.Equal(id, item.Context.Operation.RootId);
                     Assert.Null(item.Context.Operation.ParentId);
                 }
             }
@@ -123,7 +123,7 @@
             Assert.NotEqual(id1, id2);
 
             Assert.Equal(3, this.sendItems.Count);
-            var id = this.sendItems[this.sendItems.Count - 1].Context.Operation.Id;
+            var id = ((RequestTelemetry)this.sendItems[this.sendItems.Count - 1]).Id;
             Assert.False(string.IsNullOrEmpty(id));
 
             foreach (var item in this.sendItems)
@@ -131,12 +131,12 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
-                    Assert.Equal(id, item.Context.Operation.RootId);
+                    Assert.Equal(id, item.Context.Operation.Id);
                 }
                 else
                 {
+                    Assert.Equal(id, ((RequestTelemetry)item).Id);
                     Assert.Equal(id, item.Context.Operation.Id);
-                    Assert.Equal(id, item.Context.Operation.RootId);
                     Assert.Null(item.Context.Operation.ParentId);
 
                 }

--- a/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionTests.cs
+++ b/Test/CoreSDK.Test/Operation.CC.Shared.Tests/TelemetryClientExtensionTests.cs
@@ -61,7 +61,7 @@
         public void StartDependencyTrackingReturnsOperationWithInitializedOperationRootId()
         {
             var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("TestOperationName");
-            Assert.IsNotNull(operation.Telemetry.Context.Operation.RootId);
+            Assert.IsNotNull(operation.Telemetry.Context.Operation.Id);
         }
 
         [TestMethod]
@@ -123,13 +123,13 @@
         {
             var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as CallContextBasedOperationHolder<DependencyTelemetry>;
             var parentContextStore = CallContextHelpers.GetCurrentOperationContext();
-            Assert.AreEqual(operation.Telemetry.Context.Operation.Id, parentContextStore.ParentOperationId);
-            Assert.AreEqual(operation.Telemetry.Context.Operation.RootName, parentContextStore.OperationName);
+            Assert.AreEqual(operation.Telemetry.Id, parentContextStore.ParentOperationId);
+            Assert.AreEqual(operation.Telemetry.Context.Operation.Name, parentContextStore.RootOperationName);
 
             var childOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as CallContextBasedOperationHolder<DependencyTelemetry>;
             var childContextStore = CallContextHelpers.GetCurrentOperationContext();
-            Assert.AreEqual(childOperation.Telemetry.Context.Operation.Id, childContextStore.ParentOperationId);
-            Assert.AreEqual(childOperation.Telemetry.Context.Operation.RootName, childContextStore.OperationName);
+            Assert.AreEqual(childOperation.Telemetry.Id, childContextStore.ParentOperationId);
+            Assert.AreEqual(childOperation.Telemetry.Context.Operation.Name, childContextStore.RootOperationName);
 
             Assert.IsNull(operation.ParentContext);
             Assert.AreEqual(parentContextStore, childOperation.ParentContext);

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/OperationContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/OperationContextTest.cs
@@ -35,7 +35,7 @@
         public void NameIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
             var operation = new OperationContext(new Dictionary<string, string>());
-            Assert.Null(operation.RootName);
+            Assert.Null(operation.Name);
         }
 
         [TestMethod]
@@ -56,7 +56,7 @@
         public void RootIdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
             var operation = new OperationContext(new Dictionary<string, string>());
-            Assert.Null(operation.RootId);
+            Assert.Null(operation.Id);
         }
 
         [TestMethod]
@@ -79,8 +79,8 @@
         public void NameCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
             var operation = new OperationContext(new Dictionary<string, string>());
-            operation.RootName = "SampleOperationName";
-            Assert.Equal("SampleOperationName", operation.RootName);
+            operation.Name = "SampleOperationName";
+            Assert.Equal("SampleOperationName", operation.Name);
         }
 
         [TestMethod]
@@ -97,14 +97,6 @@
             var operation = new OperationContext(new Dictionary<string, string>());
             operation.ParentId = "ParentId";
             Assert.Equal("ParentId", operation.ParentId);
-        }
-
-        [TestMethod]
-        public void RootIdCanBeChangedByUserToSupplyApplicationDefinedValue()
-        {
-            var operation = new OperationContext(new Dictionary<string, string>());
-            operation.RootId = "RootId";
-            Assert.Equal("RootId", operation.RootId);
         }
 
         [TestMethod]

--- a/src/Core/Managed/Operation.AL.Shared/Extensibility/Implementation/AsyncLocalBasedOperationHolder.cs
+++ b/src/Core/Managed/Operation.AL.Shared/Extensibility/Implementation/AsyncLocalBasedOperationHolder.cs
@@ -72,8 +72,8 @@
                         var operationTelemetry = this.Telemetry as OperationTelemetry;
 
                         var currentOperationContext = AsyncLocalHelpers.GetCurrentOperationContext();
-                        if (operationTelemetry.Context.Operation.Id != currentOperationContext.ParentOperationId ||
-                            operationTelemetry.Context.Operation.RootName != currentOperationContext.OperationName)
+                        if (operationTelemetry.Id != currentOperationContext.ParentOperationId ||
+                            operationTelemetry.Context.Operation.Name != currentOperationContext.RootOperationName)
                         {
                             CoreEventSource.Log.InvalidOperationToStopError();
                             return;

--- a/src/Core/Managed/Operation.AL.Shared/Extensibility/Implementation/OperationContextForAsyncLocal.cs
+++ b/src/Core/Managed/Operation.AL.Shared/Extensibility/Implementation/OperationContextForAsyncLocal.cs
@@ -21,6 +21,6 @@
         /// <summary>
         /// Operation name that will be assigned to all the child telemetry items.
         /// </summary>
-        public string OperationName;
+        public string RootOperationName;
     }
 }

--- a/src/Core/Managed/Operation.AL.Shared/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Core/Managed/Operation.AL.Shared/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -16,7 +16,7 @@
         {
             var itemContext = telemetryItem.Context.Operation;
 
-            if (string.IsNullOrEmpty(itemContext.ParentId) || string.IsNullOrEmpty(itemContext.RootId) || string.IsNullOrEmpty(itemContext.RootName))
+            if (string.IsNullOrEmpty(itemContext.ParentId) || string.IsNullOrEmpty(itemContext.Id) || string.IsNullOrEmpty(itemContext.Name))
             {
                 var parentContext = AsyncLocalHelpers.GetCurrentOperationContext();
                 if (parentContext != null)
@@ -27,16 +27,16 @@
                         itemContext.ParentId = parentContext.ParentOperationId;
                     }
 
-                    if (string.IsNullOrEmpty(itemContext.RootId)
+                    if (string.IsNullOrEmpty(itemContext.Id)
                         && !string.IsNullOrEmpty(parentContext.RootOperationId))
                     {
-                        itemContext.RootId = parentContext.RootOperationId;
+                        itemContext.Id = parentContext.RootOperationId;
                     }
 
-                    if (string.IsNullOrEmpty(itemContext.RootName)
-                        && !string.IsNullOrEmpty(parentContext.OperationName))
+                    if (string.IsNullOrEmpty(itemContext.Name)
+                        && !string.IsNullOrEmpty(parentContext.RootOperationName))
                     {
-                        itemContext.RootName = parentContext.OperationName;
+                        itemContext.Name = parentContext.RootOperationName;
                     }
                 }
             }

--- a/src/Core/Managed/Operation.AL.Shared/TelemetryClientExtensions.cs
+++ b/src/Core/Managed/Operation.AL.Shared/TelemetryClientExtensions.cs
@@ -39,21 +39,29 @@
 
             telemetryClient.Initialize(operation.Telemetry);
 
-            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Id))
+            // Initialize operation id if it wasn't initialized by telemetry initializers
+            if (string.IsNullOrEmpty(operation.Telemetry.Id))
             {
                 operation.Telemetry.GenerateOperationId();
             }
 
-            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.RootId))
+            // If operation do not executes in a context of any other operaiton - 
+            // set it's name and id as a context (root) operation name and id
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Id))
             {
-                operation.Telemetry.Context.Operation.RootId = operation.Telemetry.Context.Operation.Id;
+                operation.Telemetry.Context.Operation.Id = operation.Telemetry.Id;
+            }
+
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Name))
+            {
+                operation.Telemetry.Context.Operation.Name = operation.Telemetry.Name;
             }
 
             // Update the call context to store certain fields that can be used for subsequent operations.
             var operationContext = new OperationContextForAsyncLocal();
-            operationContext.ParentOperationId = operation.Telemetry.Context.Operation.Id;
-            operationContext.RootOperationId = operation.Telemetry.Context.Operation.RootId;
-            operationContext.OperationName = operation.Telemetry.Context.Operation.RootName;
+            operationContext.ParentOperationId = operation.Telemetry.Id;
+            operationContext.RootOperationId = operation.Telemetry.Context.Operation.Id;
+            operationContext.RootOperationName = operation.Telemetry.Context.Operation.Name;
             AsyncLocalHelpers.SaveOperationContext(operationContext);
 
             return operation;

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationHolder.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/CallContextBasedOperationHolder.cs
@@ -72,8 +72,8 @@
                         var operationTelemetry = this.Telemetry as OperationTelemetry;
 
                         var currentOperationContext = CallContextHelpers.GetCurrentOperationContext();
-                        if (operationTelemetry.Context.Operation.Id != currentOperationContext.ParentOperationId ||
-                            operationTelemetry.Context.Operation.RootName != currentOperationContext.OperationName)
+                        if (currentOperationContext == null || operationTelemetry.Id != currentOperationContext.ParentOperationId ||
+                            operationTelemetry.Context.Operation.Name != currentOperationContext.RootOperationName)
                         {
                             CoreEventSource.Log.InvalidOperationToStopError();
                             return;

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/OperationContextForCallContext.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/Implementation/OperationContextForCallContext.cs
@@ -22,6 +22,6 @@
         /// <summary>
         /// Operation name that will be assigned to all the child telemetry items.
         /// </summary>
-        public string OperationName;
+        public string RootOperationName;
     }
 }

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -16,7 +16,7 @@
         {
             var itemContext = telemetryItem.Context.Operation;
 
-            if (string.IsNullOrEmpty(itemContext.ParentId) || string.IsNullOrEmpty(itemContext.RootId) || string.IsNullOrEmpty(itemContext.RootName))
+            if (string.IsNullOrEmpty(itemContext.ParentId) || string.IsNullOrEmpty(itemContext.Id) || string.IsNullOrEmpty(itemContext.Name))
             {
                 var parentContext = CallContextHelpers.GetCurrentOperationContext();
                 if (parentContext != null)
@@ -27,16 +27,16 @@
                         itemContext.ParentId = parentContext.ParentOperationId;
                     }
 
-                    if (string.IsNullOrEmpty(itemContext.RootId)
+                    if (string.IsNullOrEmpty(itemContext.Id)
                         && !string.IsNullOrEmpty(parentContext.RootOperationId))
                     {
-                        itemContext.RootId = parentContext.RootOperationId;
+                        itemContext.Id = parentContext.RootOperationId;
                     }
 
-                    if (string.IsNullOrEmpty(itemContext.RootName)
-                        && !string.IsNullOrEmpty(parentContext.OperationName))
+                    if (string.IsNullOrEmpty(itemContext.Name)
+                        && !string.IsNullOrEmpty(parentContext.RootOperationName))
                     {
-                        itemContext.RootName = parentContext.OperationName;
+                        itemContext.Name = parentContext.RootOperationName;
                     }
                 }
             }

--- a/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
+++ b/src/Core/Managed/Operation.CC.Shared/TelemetryClientExtensions.cs
@@ -39,21 +39,29 @@
 
             telemetryClient.Initialize(operation.Telemetry);
 
-            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Id))
+            // Initialize operation id if it wasn't initialized by telemetry initializers
+            if (string.IsNullOrEmpty(operation.Telemetry.Id))
             {
                 operation.Telemetry.GenerateOperationId();
             }
 
-            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.RootId))
+            // If operation do not executes in a context of any other operaiton - 
+            // set it's name and id as a context (root) operation name and id
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Id))
             {
-                operation.Telemetry.Context.Operation.RootId = operation.Telemetry.Context.Operation.Id;
+                operation.Telemetry.Context.Operation.Id = operation.Telemetry.Id;
+            }
+
+            if (string.IsNullOrEmpty(operation.Telemetry.Context.Operation.Name))
+            {
+                operation.Telemetry.Context.Operation.Name = operation.Telemetry.Name;
             }
 
             // Update the call context to store certain fields that can be used for subsequent operations.
             var operationContext = new OperationContextForCallContext();
-            operationContext.ParentOperationId = operation.Telemetry.Context.Operation.Id;
-            operationContext.RootOperationId = operation.Telemetry.Context.Operation.RootId;
-            operationContext.OperationName = operation.Telemetry.Context.Operation.RootName;
+            operationContext.ParentOperationId = operation.Telemetry.Id;
+            operationContext.RootOperationId = operation.Telemetry.Context.Operation.Id;
+            operationContext.RootOperationName = operation.Telemetry.Context.Operation.Name;
             CallContextHelpers.SaveOperationContext(operationContext);
 
             return operation;

--- a/src/Core/Managed/Shared/Channel/Transmission.cs
+++ b/src/Core/Managed/Shared/Channel/Transmission.cs
@@ -59,7 +59,7 @@ namespace Microsoft.ApplicationInsights.Channel
             this.ContentType = contentType;
             this.ContentEncoding = contentEncoding;
             this.Timeout = timeout == default(TimeSpan) ? DefaultTimeout : timeout;
-            this.Id = WeakConcurrentRandom.Instance.Next().ToString(CultureInfo.InvariantCulture);
+            this.Id = Convert.ToBase64String(BitConverter.GetBytes(WeakConcurrentRandom.Instance.Next()));
 #if CORE_PCL || UWP
             this.client = new HttpClient() { Timeout = this.Timeout };
 #endif

--- a/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
@@ -65,7 +65,12 @@ namespace Microsoft.ApplicationInsights.DataContracts
         {
             get { return this.context; }
         }
-        
+
+        /// <summary>  
+        /// Gets or sets Dependency ID.
+        /// </summary>  
+        public override string Id { get; set; }
+
         /// <summary>
         /// Gets or sets resource name.
         /// </summary>

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -34,6 +34,7 @@
         {
             this.Data = new RequestData();
             this.context = new TelemetryContext(this.Data.properties, new Dictionary<string, string>());
+            this.Id = Convert.ToBase64String(BitConverter.GetBytes(WeakConcurrentRandom.Instance.Next()));
 
             this.ResponseCode = "200";
             this.Success = true;
@@ -82,6 +83,15 @@
         public override TelemetryContext Context
         {
             get { return this.context; }
+        }
+
+        /// <summary>  
+        /// Gets or sets Request ID.
+        /// </summary>  
+        public override string Id  
+        {  
+            get { return this.Data.id; }  
+            set { this.Data.id = value; }  
         }
 
         /// <summary>
@@ -207,9 +217,11 @@
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
             this.Url = this.Url.SanitizeUri();
-            
-            // Set to a space to comply to the schema
-            this.Data.id = " ";
+
+            // Set for backward compatibility:  
+            this.Data.id = this.Data.id.SanitizeName();
+            this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
+
             this.ResponseCode = Utils.PopulateRequiredStringValue(this.ResponseCode, "responseCode", typeof(RequestTelemetry).FullName);
         }
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/OperationContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/OperationContext.cs
@@ -17,7 +17,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the application-defined operation ID.
+        /// Gets or sets the application-defined operation ID for the topmost operation.
         /// </summary>
         public string Id
         {
@@ -28,21 +28,10 @@
         /// <summary>
         /// Gets or sets the parent operation ID.
         /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
         public string ParentId
         {
             get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationParentId); }
             set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationParentId, value); }
-        }
-
-        /// <summary>
-        /// Gets or sets the root operation ID.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public string RootId
-        {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationRootId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationRootId, value); }
         }
 
         /// <summary>
@@ -56,9 +45,9 @@
         }
 
         /// <summary>
-        /// Gets or sets the application-defined operation's root operation NAME.
+        /// Gets or sets the application-defined topmost operation's name.
         /// </summary>
-        public string RootName
+        public string Name
         {
             get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationName); }
             set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationName, value); }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/OperationTelemetry.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/OperationTelemetry.cs
@@ -15,6 +15,11 @@
         /// </summary>
         public abstract DateTimeOffset StartTime { get; set;  }
 
+        /// <summary>  
+        /// Gets or sets Operation ID.
+        /// </summary>  
+        public abstract string Id { get; set; }
+
         /// <summary>
         /// Gets or sets the name of the operation.
         /// </summary>

--- a/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
+++ b/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
@@ -46,7 +46,7 @@
         /// <param name="telemetry">Telemetry to initialize Operation id for.</param>
         public static void GenerateOperationId(this OperationTelemetry telemetry)
         {
-            telemetry.Context.Operation.Id = WeakConcurrentRandom.Instance.Next().ToString(CultureInfo.InvariantCulture);
+            telemetry.Id = Convert.ToBase64String(BitConverter.GetBytes(WeakConcurrentRandom.Instance.Next()));
         }
     }
 }


### PR DESCRIPTION
Addressing https://github.com/Microsoft/ApplicationInsights-dotnet/issues/47
```DependencyTelemetry``` will not send it's own ```id``` to the backend as we don't use it and don't have in schema now. Will be working on adding it to the schema