### PR TITLE
Move Sanitize to JsonSerializer

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/JsonSerializerTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/JsonSerializerTest.cs
@@ -32,5 +32,19 @@
             Assert.Equal("Microsoft.ApplicationInsights.Exception", obj["name"].ToString());
             Assert.Equal("Unhandled", obj["data"]["baseData"]["handledAt"].ToString());
         }
+
+        [TestMethod]
+        public void SanitizesTelemetryItem()
+        {
+            string name = new string('Z', 10000);
+            EventTelemetry t = new EventTelemetry(name);
+
+            string exceptionAsJson = JsonSerializer.SerializeAsString(t);
+
+            JObject obj = JsonConvert.DeserializeObject<JObject>(exceptionAsJson);
+            
+            Assert.Equal(512, obj["data"]["baseData"]["name"].ToString().Length);
+        }
+
     }
 }

--- a/Test/CoreSDK.Test/Shared/TelemetryClientTest.cs
+++ b/Test/CoreSDK.Test/Shared/TelemetryClientTest.cs
@@ -55,18 +55,6 @@
         }
 
         [TestMethod]
-        public void TrackEventWillUseRequiredFieldTextForTheEventNameWhenTheEventNameIsEmptyToHideUserErrors()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackEvent((string)null);
-
-            var eventTelemetry = (EventTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, eventTelemetry.Name, StringComparison.OrdinalIgnoreCase);
-        }
-
-        [TestMethod]
         public void TrackEventSendsEventTelemetryWithSpecifiedObjectTelemetry()
         {
             var sentTelemetry = new List<ITelemetry>();
@@ -76,18 +64,6 @@
 
             var eventTelemetry = (EventTelemetry)sentTelemetry.Single();
             Assert.Equal("TestEvent", eventTelemetry.Name);
-        }
-
-        [TestMethod]
-        public void TrackEventWillUseABlankObjectAsTheEventToHideUserErrors()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackEvent((EventTelemetry)null);
-
-            var eventTelemetry = (EventTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, eventTelemetry.Name, StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -120,19 +96,6 @@
         }
 
         [TestMethod]
-        public void TrackMetricPopulatesRequiredNameWhenItIsNullOrEmptyToLetUserKnowAboutTheProblem()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackMetric(null, 42);
-
-            var metric = (MetricTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, metric.Name, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(42, metric.Value);
-        }
-
-        [TestMethod]
         public void TrackMetricSendsSpecifiedMetricTelemetry()
         {
             var sentTelemetry = new List<ITelemetry>();
@@ -143,19 +106,6 @@
             var metric = (MetricTelemetry)sentTelemetry.Single();
             Assert.Equal("TestMetric", metric.Name);
             Assert.Equal(42, metric.Value);
-        }
-
-        [TestMethod]
-        public void TrackMetricSendsNewMetricTelemetryGivenNullMetricTElemetryToHideUserErrors()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackMetric(null);
-
-            var metric = (MetricTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, metric.Name, StringComparison.OrdinalIgnoreCase);
-            Assert.Equal(0, metric.Value);
         }
 
         [TestMethod]
@@ -203,18 +153,6 @@
         }
 
         [TestMethod]
-        public void TrackTraceWillUseRequiredFieldAsTextForTheTraceNameWhenTheTraceNameIsEmptyToHideUserErrors()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackTrace((string)null);
-
-            var trace = (TraceTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, trace.Message, StringComparison.OrdinalIgnoreCase);
-        }
-
-        [TestMethod]
         public void TrackTraceSendsTraceTelemetryWithSpecifiedObjectTelemetry()
         {
             var sentTelemetry = new List<ITelemetry>();
@@ -224,18 +162,6 @@
 
             var trace = (TraceTelemetry)sentTelemetry.Single();
             Assert.Equal("TestTrace", trace.Message);
-        }
-
-        [TestMethod]
-        public void TrackTraceWillUseABlankObjectAsTheTraceToHideUserErrors()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackTrace((TraceTelemetry)null);
-
-            var trace = (TraceTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, trace.Message, StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]
@@ -343,18 +269,6 @@
 
             var pageView = (PageViewTelemetry)sentTelemetry.Single();
             Assert.Equal("TestName", pageView.Name);
-        }
-
-        [TestMethod]
-        public void TrackPageViewWillUseRequiredFieldAsTextForThePageNameWhenTheNameIsEmptyToHideUserErrors()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var client = this.InitializeTelemetryClient(sentTelemetry);
-
-            client.TrackPageView((string)null);
-
-            var pageViewTelemetry = (PageViewTelemetry)sentTelemetry.Single();
-            Assert.Contains(RequiredFieldText, pageViewTelemetry.Name, StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Wp80/Extensibility/Implementation/TelemetryConfigurationFactoryTest.cs
+++ b/Test/CoreSDK.Test/Wp80/Extensibility/Implementation/TelemetryConfigurationFactoryTest.cs
@@ -41,7 +41,7 @@
             var configuration = new TelemetryConfiguration();
             TelemetryConfigurationFactory.Instance.Initialize(configuration);
 
-            Assert.AreEqual(2, configuration.TelemetryInitializers.Count);
+            Assert.AreEqual(1, configuration.TelemetryInitializers.Count);
             Assert.IsInstanceOfType(configuration.TelemetryChannel, typeof(InMemoryChannel));
         }
 

--- a/src/Core/Managed/Shared/Extensibility/IDebugOutput.cs
+++ b/src/Core/Managed/Shared/Extensibility/IDebugOutput.cs
@@ -21,9 +21,9 @@ namespace Microsoft.ApplicationInsights.Extensibility
         bool IsLogging();
 
         /// <summary>
-        /// Checks to see if debugger is attached
+        /// Checks to see if debugger is attached.
         /// </summary>
-        /// <returns>true if debugger is attached</returns>
+        /// <returns>true if debugger is attached.</returns>
         bool IsAttached();
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/JsonSerializer.cs
@@ -280,6 +280,7 @@
                     streamWriter.Write(Environment.NewLine);
                 }
 
+                telemetryItem.Sanitize();
                 SerializeTelemetryItem(telemetryItem, jsonWriter);
             }
         }

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -317,8 +317,6 @@
                     return;
                 }
 
-                telemetry.Sanitize();
-
                 if (telemetry.Timestamp == default(DateTimeOffset))
                 {
                     telemetry.Timestamp = Clock.Instance.Time;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -176,14 +176,17 @@
         /// </summary>
         public void Send(ITelemetry item)
         {
-            if (item != null && TelemetryChannelEventSource.Log.IsVerboseEnabled)
+            if (item != null)
             {
-                TelemetryChannelEventSource.Log.TelemetryChannelSend(
-                    item.ToString(), 
-                    item.Context.InstrumentationKey.Substring(0, Math.Min(item.Context.InstrumentationKey.Length, 8)));
-            }
+                if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
+                {
+                    TelemetryChannelEventSource.Log.TelemetryChannelSend(
+                        item.ToString(),
+                        item.Context.InstrumentationKey.Substring(0, Math.Min(item.Context.InstrumentationKey.Length, 8)));
+                }
 
-            this.TelemetryProcessor.Process(item);
+                this.TelemetryProcessor.Process(item);
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fixing issue #112 
Moved Sanitize to JsonSerializer instead of all the channels by 2 reasons:
- All channels use same Serializer
- Serialization happens on a different thread that will improve performance