### PR TITLE
Track every telemetry item as a rich payload ETW

### DIFF
--- a/Test/CoreSDK.Test/Net46/Core.Net46.Tests.csproj
+++ b/Test/CoreSDK.Test/Net46/Core.Net46.Tests.csproj
@@ -66,6 +66,7 @@
     <Compile Include="..\Net40\Extensibility\Implementation\Tracing\CoreEventSourceTest.cs">
       <Link>Extensibility\Implementation\Tracing\CoreEventSourceTest.cs</Link>
     </Compile>
+    <Compile Include="Extensibility\Implementation\RichPayloadEventSourceTest.cs" />
     <Compile Include="FailOnAssertSetup.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/CoreSDK.Test/Net46/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/CoreSDK.Test/Net46/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -1,0 +1,246 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Linq;
+
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+
+    public class RichPayloadEventSourceTest
+    {
+        [TestMethod]
+        public void RichPayloadEventSourceRequestSentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.Requests);
+
+                var item = new RequestTelemetry("TestRequest", DateTimeOffset.Now, TimeSpan.FromMilliseconds(10), "200", true);
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackRequest(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+
+        [TestMethod]
+        public void RichPayloadEventSourceTraceSentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.Traces);
+
+                var item = new TraceTelemetry("TestTrace", SeverityLevel.Information);
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackTrace(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+
+        [TestMethod]
+        public void RichPayloadEventSourceEventSentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.Events);
+
+                var item = new EventTelemetry("TestEvent");
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackEvent(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+
+        [TestMethod]
+        public void RichPayloadEventSourceExceptionSentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.Exceptions);
+
+                var item = new ExceptionTelemetry(new SystemException("Test"));
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackException(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+
+        [TestMethod]
+        public void RichPayloadEventSourceMetricSentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.Metrics);
+
+                var item = new MetricTelemetry("TestMetric", 1);
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackMetric(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+
+        [TestMethod]
+        public void RichPayloadEventSourceDependencySentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.Dependencies);
+
+                var item = new DependencyTelemetry("TestDependency", "TestCommand", DateTimeOffset.Now, TimeSpan.Zero, true);
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackDependency(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+
+        [TestMethod]
+        public void RichPayloadEventSourcePageViewSentTest()
+        {
+            var client = new TelemetryClient();
+            client.InstrumentationKey = Guid.NewGuid().ToString();
+
+            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            {
+                listener.EnableEvents(RichPayloadEventSource.Log.eventSource, EventLevel.Verbose, RichPayloadEventSource.Keywords.PageViews);
+
+                var item = new PageViewTelemetry("TestPage");
+                item.Context.Properties.Add("property1", "value1");
+                item.Context.User.Id = "testUserId";
+                item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                client.TrackPageView(item);
+
+                var actualEvent = listener.Messages.FirstOrDefault();
+
+                Assert.IsNotNull(actualEvent);
+                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                object[] tags = actualEvent.Payload[1] as object[];
+                Assert.AreEqual("ai.user.id", ((Dictionary<string, object>)(tags[0]))["Key"]);
+                Assert.AreEqual("testUserId", ((Dictionary<string, object>)(tags[0]))["Value"]);
+
+                Assert.AreEqual("ai.operation.id", ((Dictionary<string, object>)(tags[1]))["Key"]);
+                Assert.AreEqual(item.Context.Operation.Id, ((Dictionary<string, object>)(tags[1]))["Value"]);
+
+                Assert.IsNotNull(actualEvent.Payload[2]);
+            }
+        }
+    }
+}

--- a/src/Core/Managed/Net46/Core.Net46.csproj
+++ b/src/Core/Managed/Net46/Core.Net46.csproj
@@ -38,6 +38,7 @@
     <Compile Include="..\Net40\Extensibility\Implementation\TelemetryConfigurationFactory.cs">
       <Link>Extensibility\Implementation\TelemetryConfigurationFactory.cs</Link>
     </Compile>
+    <Compile Include="Extensibility\Implementation\RichPayloadEventSource.cs" />
   </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="..\Operation.AL.Shared\Operation.AL.Shared.projitems" Label="Shared" />

--- a/src/Core/Managed/Net46/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Core/Managed/Net46/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -20,7 +20,7 @@
         internal readonly EventSource eventSource;
 
         /// <summary>Event provider name.</summary>
-        private const string EventProviderName = "Microsoft-ApplicationInsights";
+        private const string EventProviderName = "Microsoft-ApplicationInsights-Data";
 
         /// <summary>
         /// Initializes a new instance of the RichPayloadEventSource class.
@@ -29,9 +29,7 @@
         {
             this.eventSource = new EventSource(
                EventProviderName,
-               EventSourceSettings.EtwSelfDescribingEventFormat,
-               "ETW_GROUP",
-               "{E3AFA6F4-0FEA-4757-AFFF-80B5CA685BB8}");
+               EventSourceSettings.EtwSelfDescribingEventFormat);
         }
 
         /// <summary>

--- a/src/Core/Managed/Net46/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Core/Managed/Net46/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -1,0 +1,268 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Globalization;
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    internal sealed class RichPayloadEventSource : IDisposable
+    {
+        /// <summary>RichPayloadEventSource instance.</summary>
+        public static readonly RichPayloadEventSource Log = new RichPayloadEventSource();
+        
+        /// <summary>Event source.</summary>
+        internal readonly EventSource eventSource;
+
+        /// <summary>Event provider name.</summary>
+        private const string EventProviderName = "Microsoft-ApplicationInsights";
+
+        /// <summary>
+        /// Initializes a new instance of the RichPayloadEventSource class.
+        /// </summary>
+        public RichPayloadEventSource()
+        {
+            this.eventSource = new EventSource(
+               EventProviderName,
+               EventSourceSettings.EtwSelfDescribingEventFormat,
+               "ETW_GROUP",
+               "{E3AFA6F4-0FEA-4757-AFFF-80B5CA685BB8}");
+        }
+
+        /// <summary>
+        /// Process a collected telemetry item.
+        /// </summary>
+        /// <param name="item">A collected Telemetry item.</param>
+        public void Process(ITelemetry item)
+        {
+            if (item is RequestTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.Requests))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as RequestTelemetry;
+                this.WriteEvent(
+                    RequestTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data, 
+                    Keywords.Requests);
+            }
+            else if (item is TraceTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.Traces))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as TraceTelemetry;
+                this.WriteEvent(
+                    TraceTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.Traces);
+            }
+            else if (item is EventTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.Events))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as EventTelemetry;
+                this.WriteEvent(
+                    EventTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.Events);
+            }
+            else if (item is DependencyTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.Dependencies))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as DependencyTelemetry;
+                this.WriteEvent(
+                    DependencyTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.Dependencies);
+            }
+            else if (item is MetricTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.Metrics))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as MetricTelemetry;
+                this.WriteEvent(
+                    MetricTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.Metrics);
+            }
+            else if (item is ExceptionTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.Exceptions))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as ExceptionTelemetry;
+                this.WriteEvent(
+                    ExceptionTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.Exceptions);
+            }
+            else if (item is PerformanceCounterTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.PerformanceCounters))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as PerformanceCounterTelemetry;
+                this.WriteEvent(
+                    PerformanceCounterTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.PerformanceCounters);
+            }
+            else if (item is PageViewTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.PageViews))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as PageViewTelemetry;
+                this.WriteEvent(
+                    PageViewTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.PageViews);
+            }
+            else if (item is SessionStateTelemetry)
+            {
+                if (!this.eventSource.IsEnabled(EventLevel.Verbose, Keywords.SessionState))
+                {
+                    return;
+                }
+
+                var telemetryItem = item as SessionStateTelemetry;
+                this.WriteEvent(
+                    SessionStateTelemetry.TelemetryName,
+                    telemetryItem.Context.InstrumentationKey,
+                    telemetryItem.Context.Tags,
+                    telemetryItem.Data,
+                    Keywords.SessionState);
+            }
+            else
+            {
+                string msg = string.Format(CultureInfo.InvariantCulture, "Unknown telemetry type: {0}", item.GetType());
+                CoreEventSource.Log.LogVerbose(msg);
+            }
+        }
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        /// <param name="disposing">True if disposing.</param>
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (this.eventSource != null)
+                {
+                    this.eventSource.Dispose();
+                }
+            }
+        }
+
+        private void WriteEvent<T>(string eventName, string instrumentationKey, IDictionary<string, string> tags, T data, EventKeywords keywords)
+        {
+            this.eventSource.Write(
+                eventName,
+                new EventSourceOptions() { Keywords = keywords },
+                new { PartA_iKey = instrumentationKey, PartA_Tags = tags, _B = data });
+        }
+
+        /// <summary>
+        /// Keywords for the RichPayloadEventSource.
+        /// </summary>
+        public sealed class Keywords
+        {
+            /// <summary>
+            /// Keyword for requests.
+            /// </summary>
+            public const EventKeywords Requests = (EventKeywords)0x1;
+
+            /// <summary>
+            /// Keyword for traces.
+            /// </summary>
+            public const EventKeywords Traces = (EventKeywords)0x2;
+
+            /// <summary>
+            /// Keyword for events.
+            /// </summary>
+            public const EventKeywords Events = (EventKeywords)0x4;
+
+            /// <summary>
+            /// Keyword for exceptions.
+            /// </summary>
+            public const EventKeywords Exceptions = (EventKeywords)0x8;
+
+            /// <summary>
+            /// Keyword for dependencies.
+            /// </summary>
+            public const EventKeywords Dependencies = (EventKeywords)0x10;
+
+            /// <summary>
+            /// Keyword for metrics.
+            /// </summary>
+            public const EventKeywords Metrics = (EventKeywords)0x20;
+
+            /// <summary>
+            /// Keyword for page views.
+            /// </summary>
+            public const EventKeywords PageViews = (EventKeywords)0x40;
+
+            /// <summary>
+            /// Keyword for performance counters.
+            /// </summary>
+            public const EventKeywords PerformanceCounters = (EventKeywords)0x80;
+
+            /// <summary>
+            /// Keyword for session state.
+            /// </summary>
+            public const EventKeywords SessionState = (EventKeywords)0x100;
+        }
+    }
+}

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -324,6 +324,11 @@
                     telemetry.Timestamp = Clock.Instance.Time;
                 }
 
+#if NET46
+                // logs rich payload ETW event for any partners to process it
+                RichPayloadEventSource.Log.Process(telemetry);
+#endif
+
                 // invokes the Process in the first processor in the chain
                 this.configuration.TelemetryProcessors.Process(telemetry);
             }

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -324,13 +324,13 @@
                     telemetry.Timestamp = Clock.Instance.Time;
                 }
 
+                // invokes the Process in the first processor in the chain
+                this.configuration.TelemetryProcessors.Process(telemetry);
+
 #if NET46
                 // logs rich payload ETW event for any partners to process it
                 RichPayloadEventSource.Log.Process(telemetry);
 #endif
-
-                // invokes the Process in the first processor in the chain
-                this.configuration.TelemetryProcessors.Process(telemetry);
             }
         }
 


### PR DESCRIPTION
Track every telemetry item as a rich payload ETW - for integration with ServiceProfiler