### PR TITLE
Move ResponseCode and Success population to Sanitize

### DIFF
--- a/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -182,13 +182,57 @@
         }
 
         [TestMethod]
-        public void SanitizeWillInitializeSuccess()
+        public void SanitizeWillInitializeSucessIfStatusCodeNotProvided()
         {
             RequestTelemetry telemetry = new RequestTelemetry();
 
             ((ITelemetry)telemetry).Sanitize();
 
             Assert.True(telemetry.Success.Value);
+        }
+
+        [TestMethod]
+        public void SanitizeWillInitializeSuccessIfStatusCodeNaN()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+            telemetry.ResponseCode = "NaN";
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.True(telemetry.Success.Value);
+        }
+
+        [TestMethod]
+        public void SanitizeWillInitializeSuccessIfStatusCodeLess400()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+            telemetry.ResponseCode = "300";
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.True(telemetry.Success.Value);
+        }
+
+        [TestMethod]
+        public void SanitizeWillInitializeSuccessIfStatusCode401()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+            telemetry.ResponseCode = "300";
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.True(telemetry.Success.Value);
+        }
+
+        [TestMethod]
+        public void SanitizeWillInitializeSuccessIfStatusCode500()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+            telemetry.ResponseCode = "500";
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.False(telemetry.Success.Value);
         }
 
         [TestMethod]  

--- a/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -31,8 +31,6 @@
         {
             var request = new RequestTelemetry();
             Assert.False(string.IsNullOrEmpty(request.Id));
-            Assert.Equal("200", request.ResponseCode);
-            Assert.Equal(true, request.Success);
         }
 
         [TestMethod]
@@ -172,7 +170,27 @@
 
             Assert.Equal(new string('1', Property.MaxNameLength), telemetry.Id);
         }
-  
+
+        [TestMethod]
+        public void SanitizeWillInitializeStatusCode()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.Equal("200", telemetry.ResponseCode);
+        }
+
+        [TestMethod]
+        public void SanitizeWillInitializeSuccess()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.True(telemetry.Success.Value);
+        }
+
         [TestMethod]  
         public void SanitizePopulatesIdWithErrorBecauseItIsRequiredByEndpoint()
         {  
@@ -185,17 +203,6 @@
             // RequestTelemetry.Id is deprecated and you cannot access it. Method above will validate that all required fields would be populated  
             // Assert.Contains("id", telemetry.Id, StringComparison.OrdinalIgnoreCase);  
             // Assert.Contains("required", telemetry.Id, StringComparison.OrdinalIgnoreCase);  
-        }
-
-    [TestMethod]
-        public void SanitizePopulatesResponseCodeWithErrorBecauseItIsRequiredByEndpoint()
-        {
-            var telemetry = new RequestTelemetry { ResponseCode = null };
-
-            ((ITelemetry)telemetry).Sanitize();
-
-            Assert.Contains("responseCode", telemetry.ResponseCode, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("required", telemetry.ResponseCode, StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -35,9 +35,6 @@
             this.Data = new RequestData();
             this.context = new TelemetryContext(this.Data.properties, new Dictionary<string, string>());
             this.Id = Convert.ToBase64String(BitConverter.GetBytes(WeakConcurrentRandom.Instance.Next()));
-
-            this.ResponseCode = "200";
-            this.Success = true;
         }
 
         /// <summary>
@@ -123,10 +120,8 @@
                 {
                     return this.Data.success;
                 }
-                else
-                {
-                    return null;
-                }
+
+                return null;
             }
 
             set
@@ -222,7 +217,17 @@
             this.Data.id = this.Data.id.SanitizeName();
             this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
 
-            this.ResponseCode = Utils.PopulateRequiredStringValue(this.ResponseCode, "responseCode", typeof(RequestTelemetry).FullName);
+            // Required field
+            if (string.IsNullOrEmpty(this.ResponseCode))
+            {
+                this.ResponseCode = "200";
+            }
+
+            // Required field
+            if (!this.Success.HasValue)
+            {
+                this.Success = true;
+            }
         }
 
         private DateTimeOffset ValidateDateTimeOffset(string value)

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -221,12 +221,22 @@
             if (string.IsNullOrEmpty(this.ResponseCode))
             {
                 this.ResponseCode = "200";
+                this.Success = true;
             }
 
             // Required field
             if (!this.Success.HasValue)
             {
-                this.Success = true;
+                int responseCode;
+
+                if (int.TryParse(this.ResponseCode, NumberStyles.Any, CultureInfo.InvariantCulture, out responseCode))
+                {
+                    this.Success = (responseCode < 400) || (responseCode == 401);
+                }
+                else
+                {
+                    this.Success = true;
+                }
             }
         }
 


### PR DESCRIPTION
Move ResponseCode and Success population to Sanitize so in telemetry initializers we can distinguish whether these fields were populated by customer's code