### PR TITLE
Expose reading config from text\xml

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
@@ -281,7 +281,7 @@
             Type configurationInstanceType = configuration.GetType();
             Dictionary<string, PropertyInfo> properties = configurationInstanceType.GetProperties().ToDictionary(p => p.Name);
             PropertyInfo property;
-            Assert.True(properties.TryGetValue("TelemetryProcessors", out property));                            
+            Assert.True(properties.TryGetValue("TelemetryProcessors", out property));
             Assert.True(property.CanWrite);
         }
 
@@ -291,10 +291,38 @@
             var configuration = new TelemetryConfiguration();
             var tp = configuration.TelemetryProcessors;
 
-            Assert.IsType<TransmissionProcessor>(tp.FirstTelemetryProcessor);            
+            Assert.IsType<TransmissionProcessor>(tp.FirstTelemetryProcessor);
         }
         #endregion
 
+        #region Serialized Configuration
+        [TestMethod]
+        public void TelemetryConfigThrowsIfSerializedConfigIsNull()
+        {
+            Assert.Throws(typeof(ArgumentNullException), () =>
+             {
+                 TelemetryConfiguration.CreateFromConfiguration(null);
+             });
+        }
+
+        [TestMethod]
+        public void TelemetryConfigThrowsIfSerializedConfigIsEmpty()
+        {
+            Assert.Throws(typeof(ArgumentNullException), () =>
+            {
+                TelemetryConfiguration.CreateFromConfiguration(String.Empty);
+            });
+        }
+
+        [TestMethod]
+        public void TelemetryConfigThrowsIfSerializedConfigIsWhitespace()
+        {
+            Assert.Throws(typeof(ArgumentNullException), () =>
+            {
+                TelemetryConfiguration.CreateFromConfiguration(" ");
+            });
+        }
+        #endregion
         private class TestableTelemetryModules : TelemetryModules
         {
         }

--- a/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -22,7 +22,7 @@
         private static readonly XNamespace XmlNamespace = "http://schemas.microsoft.com/ApplicationInsights/2013/Settings";
 
         private static TelemetryConfigurationFactory instance;
-        
+
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryConfigurationFactory"/> class.
         /// </summary>
@@ -46,22 +46,20 @@
             set { instance = value; }
         }
 
-        public virtual void Initialize(TelemetryConfiguration configuration, TelemetryModules modules)
+        public virtual void Initialize(TelemetryConfiguration configuration, TelemetryModules modules, string serializedConfiguration)
         {
             configuration.TelemetryInitializers.Add(new SdkVersionPropertyTelemetryInitializer());
 
 #if !CORE_PCL
             configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
 #endif
-
-            // Load customizations from the ApplicationsInsights.config file
-            string text = PlatformSingleton.Current.ReadConfigurationXml();
-            if (!string.IsNullOrEmpty(text))
+            // Load configuration from the specified configuration
+            if (!string.IsNullOrEmpty(serializedConfiguration))
             {
-                XDocument xml = XDocument.Parse(text);
+                XDocument xml = XDocument.Parse(serializedConfiguration);
                 LoadFromXml(configuration, modules, xml);
             }
-            
+
             // Creating the default channel if no channel configuration supplied
             configuration.TelemetryChannel = configuration.TelemetryChannel ?? new InMemoryChannel();
 
@@ -69,9 +67,15 @@
             if (configuration.TelemetryProcessors == null)
             {
                 configuration.GetTelemetryProcessorChainBuilder().Build();
-            }                
+            }
 
             InitializeComponents(configuration, modules);
+        }
+
+        public virtual void Initialize(TelemetryConfiguration configuration, TelemetryModules modules)
+        {
+            // Load customizations from the ApplicationsInsights.config file
+            Initialize(configuration, modules, PlatformSingleton.Current.ReadConfigurationXml());
         }
 
         protected static object CreateInstance(Type interfaceType, string typeName, object[] constructorArgs = null)
@@ -82,7 +86,7 @@
                 throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Type '{0}' could not be loaded.", typeName));
             }
 
-            object instance = constructorArgs != null ? Activator.CreateInstance(type, constructorArgs) : Activator.CreateInstance(type);            
+            object instance = constructorArgs != null ? Activator.CreateInstance(type, constructorArgs) : Activator.CreateInstance(type);
 
             if (!interfaceType.IsAssignableFrom(instance.GetType()))
             {
@@ -152,20 +156,20 @@
         }
 
         protected static void BuildTelemetryProcessorChain(XElement definition, TelemetryConfiguration telemetryConfiguration)
-        {            
+        {
             TelemetryProcessorChainBuilder builder = telemetryConfiguration.GetTelemetryProcessorChainBuilder();
             if (definition != null)
             {
-                IEnumerable<XElement> elems = definition.Elements(XmlNamespace + AddElementName);                
+                IEnumerable<XElement> elems = definition.Elements(XmlNamespace + AddElementName);
                 foreach (XElement addElement in elems)
                 {
-                    builder = builder.Use(current => 
+                    builder = builder.Use(current =>
                     {
                         var constructorArgs = new object[] { current };
                         var instance = LoadInstance(addElement, typeof(ITelemetryProcessor), telemetryConfiguration, constructorArgs, null);
                         return (ITelemetryProcessor)instance;
-                    });                           
-                }                
+                    });
+                }
             }
 
             builder.Build();
@@ -221,8 +225,8 @@
                             {
                                 property.SetValue(instance, propertyValue, null);
                             }
-                        }                        
-                    }                    
+                        }
+                    }
                     else if (modules != null && propertyName == "TelemetryModules")
                     {
                         LoadInstance(propertyDefinition, modules.Modules.GetType(), modules.Modules, null, modules);
@@ -242,11 +246,11 @@
                     }
                 }
             }
-        }        
+        }
 
         private static void InitializeComponents(TelemetryConfiguration configuration, TelemetryModules modules)
         {
-            InitializeComponent(configuration.TelemetryChannel, configuration);            
+            InitializeComponent(configuration.TelemetryChannel, configuration);
             InitializeComponents(configuration.TelemetryInitializers, configuration);
             InitializeComponents(configuration.TelemetryProcessors.TelemetryProcessors, configuration);
             if (modules != null)
@@ -315,7 +319,7 @@
             Type type = GetManagedType(typeName);
             return type;
         }
-        
+
         private static Type GetManagedType(string typeName)
         {
             try

--- a/src/Core/Managed/Shared/Extensibility/TelemetryConfiguration.cs
+++ b/src/Core/Managed/Shared/Extensibility/TelemetryConfiguration.cs
@@ -32,8 +32,8 @@
         /// </summary>
         public static TelemetryConfiguration Active
         {
-            get 
-            { 
+            get
+            {
                 if (active == null)
                 {
                     lock (syncRoot)
@@ -49,7 +49,7 @@
                 return active;
             }
 
-            internal set 
+            internal set
             {
                 lock (syncRoot)
                 {
@@ -136,9 +136,9 @@
         public TelemetryProcessorChain TelemetryProcessors
         {
             get
-            {                
+            {
                 if (this.telemetryProcessorChain == null)
-                {                                                 
+                {
                     // Gets the telemetryprocessorchainbuilder, builds the processor chain and sets the same in the configuration.
                     this.GetTelemetryProcessorChainBuilder().Build();
                 }
@@ -154,7 +154,7 @@
                 }
 
                 this.telemetryProcessorChain = value;
-            }              
+            }
         }
 
         /// <summary>
@@ -176,6 +176,23 @@
         }
 
         /// <summary>
+        /// Creates a new <see cref="TelemetryConfiguration"/> instance loaded from the specified configuration.
+        /// </summary>
+        /// <param name="config">an xml serialized configuration</param>
+        /// <exception cref="ArgumentNullException">throws if the config value is null or empty</exception>
+        public static TelemetryConfiguration CreateFromConfiguration(string config)
+        {
+            if (String.IsNullOrWhiteSpace(config))
+            {
+                throw new ArgumentNullException("config");
+            }
+
+            var configuration = new TelemetryConfiguration();
+            TelemetryConfigurationFactory.Instance.Initialize(configuration, null, config);
+            return configuration;
+        }
+
+        /// <summary>
         /// Releases resources used by the current instance of the <see cref="TelemetryConfiguration"/> class.
         /// </summary>
         public void Dispose()
@@ -184,7 +201,7 @@
             this.Dispose(true);
             GC.SuppressFinalize(this);
         }
-        
+
         private void Dispose(bool disposing)
         {
             if (disposing)

--- a/src/Core/Managed/Wp80/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Wp80/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -40,6 +40,11 @@
 
         public virtual void Initialize(TelemetryConfiguration configuration, TelemetryModules modules = null)
         {
+            Initialize(configuration, modules, null);
+        }
+
+        public virtual void Initialize(TelemetryConfiguration configuration, TelemetryModules modules, string serializedConfig)
+        {
             configuration.TelemetryInitializers.Add(new SdkVersionPropertyTelemetryInitializer());
 
             // Load customizations from the ApplicationsInsights.config file


### PR DESCRIPTION
A scenario was recently encountered where a customer wanted to use shared
embedded config instead of deploying it across all of their applications.
Exposing an Initialize(config,text) enables this scenario without having
to hack around and write a file to disk