### PR TITLE
Added ability to manually skip sampling for individual telemetry items

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -63,20 +63,34 @@
         }
 
         [TestMethod]
-        public void TelemetryItemIsSkippedBySampling()
+        public void TelemetryItemSamplingIsSkipped()
         {
             var sentTelemetry = new List<ITelemetry>();
-            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) });
-
-            do
+            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
             {
-                var requestTelemetry = new RequestTelemetry();
-                ((ISupportSampling) requestTelemetry).SamplingSkipped = true;
-                processor.Process(requestTelemetry);
-            }
-            while (sentTelemetry.Count == 0);
+                SamplingPercentage = 0
+            };
 
-            Assert.Equal(true, ((ISupportSampling)sentTelemetry[0]).SamplingSkipped);
+            var requestTelemetry = new RequestTelemetry();
+            ((ISupportSampling)requestTelemetry).SamplingSkipped = true;
+            processor.Process(requestTelemetry);
+
+            Assert.Equal(1, sentTelemetry.Count);
+        }
+
+        [TestMethod]
+        public void TelemetryItemSamplingIsNotSkippedByDefault()
+        {
+            var sentTelemetry = new List<ITelemetry>();
+            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
+            {
+                SamplingPercentage = 0
+            };
+
+            var requestTelemetry = new RequestTelemetry();
+            processor.Process(requestTelemetry);
+
+            Assert.Equal(0, sentTelemetry.Count);
         }
 
         [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -61,7 +61,24 @@
 
             Assert.Equal(20, ((ISupportSampling)sentTelemetry[0]).SamplingPercentage);
         }
-        
+
+        [TestMethod]
+        public void TelemetryItemIsSkippedBySampling()
+        {
+            var sentTelemetry = new List<ITelemetry>();
+            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) });
+
+            do
+            {
+                var requestTelemetry = new RequestTelemetry();
+                ((ISupportSampling) requestTelemetry).SamplingSkipped = true;
+                processor.Process(requestTelemetry);
+            }
+            while (sentTelemetry.Count == 0);
+
+            Assert.Equal(true, ((ISupportSampling)sentTelemetry[0]).SamplingSkipped);
+        }
+
         [TestMethod]
         public void DependencyTelemetryIsSubjectToSampling()
         {

--- a/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
@@ -22,6 +22,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         private readonly TelemetryContext context;
 
         private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private bool samplingSkipped;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class.
@@ -171,6 +172,15 @@ namespace Microsoft.ApplicationInsights.DataContracts
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool ISupportSampling.SamplingSkipped
+        {
+            get { return this.samplingSkipped; }
+            set { this.samplingSkipped = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
@@ -19,6 +19,7 @@
         private readonly TelemetryContext context;
 
         private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private bool samplingSkipped;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventTelemetry"/> class.
@@ -88,6 +89,15 @@
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool ISupportSampling.SamplingSkipped
+        {
+            get { return this.samplingSkipped; }
+            set { this.samplingSkipped = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
@@ -23,6 +23,7 @@
         private string message;
 
         private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private bool samplingSkipped;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionTelemetry"/> class with empty properties.
@@ -150,6 +151,15 @@
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool ISupportSampling.SamplingSkipped
+        {
+            get { return this.samplingSkipped; }
+            set { this.samplingSkipped = value; }
         }
 
         internal IList<ExceptionDetails> Exceptions

--- a/src/Core/Managed/Shared/DataContracts/ISupportSampling.cs
+++ b/src/Core/Managed/Shared/DataContracts/ISupportSampling.cs
@@ -9,5 +9,10 @@
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
         double SamplingPercentage { get; set; }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool SamplingSkipped { get; set; }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
@@ -26,6 +26,7 @@
         private readonly TelemetryContext context;
 
         private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private bool samplingSkipped;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PageViewTelemetry"/> class.
@@ -133,6 +134,15 @@
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool ISupportSampling.SamplingSkipped
+        {
+            get { return this.samplingSkipped; }
+            set { this.samplingSkipped = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -25,6 +25,7 @@
         private bool successFieldSet;
 
         private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private bool samplingSkipped;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTelemetry"/> class.
@@ -200,6 +201,15 @@
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool ISupportSampling.SamplingSkipped
+        {
+            get { return this.samplingSkipped; }
+            set { this.samplingSkipped = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
@@ -19,6 +19,7 @@
         private readonly TelemetryContext context;
 
         private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private bool samplingSkipped;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TraceTelemetry"/> class.
@@ -96,6 +97,15 @@
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets if sampling should be skipped.
+        /// </summary>
+        bool ISupportSampling.SamplingSkipped
+        {
+            get { return this.samplingSkipped; }
+            set { this.samplingSkipped = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Telemetry.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Telemetry.cs
@@ -14,6 +14,7 @@
             var samplingSupportingTelemetry = telemetry as ISupportSampling;
 
             if ((samplingSupportingTelemetry != null) 
+                && !samplingSupportingTelemetry.SamplingSkipped
                 && (samplingSupportingTelemetry.SamplingPercentage > 0.0 + 1.0E-12) 
                 && (samplingSupportingTelemetry.SamplingPercentage < 100.0 - 1.0E-12))
             {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -409,6 +409,12 @@
                 this.ApplicationName);
         }
 
+        [Event(58, Message = "Sampling skipped manually: {0}.", Level = EventLevel.Verbose)]
+        public void SamplingSkippedManually(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(58, string.Empty, this.ApplicationName);
+        }
+
         private string GetApplicationName()
         {
             string name;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -410,9 +410,9 @@
         }
 
         [Event(58, Message = "Sampling skipped manually: {0}.", Level = EventLevel.Verbose)]
-        public void SamplingSkippedManually(string appDomainName = "Incorrect")
+        public void SamplingSkippedManually(string telemetryType, string appDomainName = "Incorrect")
         {
-            this.WriteEvent(58, string.Empty, this.ApplicationName);
+            this.WriteEvent(58, telemetryType ?? string.Empty, this.ApplicationName);
         }
 
         private string GetApplicationName()

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
@@ -120,13 +120,6 @@
                             TelemetryChannelEventSource.Log.SamplingSkippedByType(item.ToString());
                         }
                     }
-                    else if (samplingSupportingTelemetry.SamplingSkipped)
-                    {
-                        if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
-                        {
-                            TelemetryChannelEventSource.Log.SamplingSkippedManually();
-                        }
-                    }
                     else
                     {
                         // set sampling percentage on telemetry item, current codebase assumes it is the only one updating SamplingPercentage.
@@ -134,13 +127,23 @@
 
                         if (!this.IsSampledIn(item))
                         {
-                            if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
+                            if (samplingSupportingTelemetry.SamplingSkipped)
                             {
-                                TelemetryChannelEventSource.Log.ItemSampledOut(item.ToString());
+                                if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
+                                {
+                                    TelemetryChannelEventSource.Log.SamplingSkippedManually(item.ToString());
+                                }
                             }
+                            else
+                            {
+                                if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
+                                {
+                                    TelemetryChannelEventSource.Log.ItemSampledOut(item.ToString());
+                                }
 
-                            TelemetryDebugWriter.WriteTelemetry(item, this.GetType().Name);
-                            return;
+                                TelemetryDebugWriter.WriteTelemetry(item, this.GetType().Name);
+                                return;
+                            }
                         }
                     }
                 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
@@ -120,6 +120,13 @@
                             TelemetryChannelEventSource.Log.SamplingSkippedByType(item.ToString());
                         }
                     }
+                    else if (samplingSupportingTelemetry.SamplingSkipped)
+                    {
+                        if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
+                        {
+                            TelemetryChannelEventSource.Log.SamplingSkippedManually();
+                        }
+                    }
                     else
                     {
                         // set sampling percentage on telemetry item, current codebase assumes it is the only one updating SamplingPercentage.


### PR DESCRIPTION
This change makes it is possible to create initializers that skip the sampling for individual telemetry items.

Main reason for this change is to make it possible to skip request sampling on items with exceptions while still maintaining a strong sampling rate globally.

ref #256 