### PR TITLE
Changed SamplingPercentag to be double? to support overriding samplers

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -63,7 +63,7 @@
         }
 
         [TestMethod]
-        public void TelemetryItemSamplingIsSkipped()
+        public void TelemetryItemSamplingIsSkippedWhenSetByUser()
         {
             var sentTelemetry = new List<ITelemetry>();
             var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
@@ -76,21 +76,6 @@
             processor.Process(requestTelemetry);
 
             Assert.Equal(1, sentTelemetry.Count);
-        }
-
-        [TestMethod]
-        public void TelemetryItemSamplingIsNotSkippedByDefault()
-        {
-            var sentTelemetry = new List<ITelemetry>();
-            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
-            {
-                SamplingPercentage = 0
-            };
-
-            var requestTelemetry = new RequestTelemetry();
-            processor.Process(requestTelemetry);
-
-            Assert.Equal(0, sentTelemetry.Count);
         }
 
         [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -61,7 +61,38 @@
 
             Assert.Equal(20, ((ISupportSampling)sentTelemetry[0]).SamplingPercentage);
         }
-        
+
+        [TestMethod]
+        public void TelemetryItemSamplingIsSkipped()
+        {
+            var sentTelemetry = new List<ITelemetry>();
+            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
+            {
+                SamplingPercentage = 0
+            };
+
+            var requestTelemetry = new RequestTelemetry();
+            ((ISupportSampling)requestTelemetry).SamplingPercentage = 100;
+            processor.Process(requestTelemetry);
+
+            Assert.Equal(1, sentTelemetry.Count);
+        }
+
+        [TestMethod]
+        public void TelemetryItemSamplingIsNotSkippedByDefault()
+        {
+            var sentTelemetry = new List<ITelemetry>();
+            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
+            {
+                SamplingPercentage = 0
+            };
+
+            var requestTelemetry = new RequestTelemetry();
+            processor.Process(requestTelemetry);
+
+            Assert.Equal(0, sentTelemetry.Count);
+        }
+
         [TestMethod]
         public void DependencyTelemetryIsSubjectToSampling()
         {

--- a/src/Core/Managed/Shared/Constants.cs
+++ b/src/Core/Managed/Shared/Constants.cs
@@ -18,7 +18,5 @@
         internal const string EventSourceGroupTraitKey = "ETW_GROUP";
 
         internal const int MaxExceptionCountToSave = 10;
-
-        internal const double DefaultSamplingPercentage = 100.0;
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
@@ -21,7 +21,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         internal readonly RemoteDependencyData Data;
         private readonly TelemetryContext context;
 
-        private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private double? samplingPercentage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class.
@@ -167,7 +167,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double ISupportSampling.SamplingPercentage
+        double? ISupportSampling.SamplingPercentage
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }

--- a/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
@@ -18,7 +18,7 @@
         internal readonly EventData Data;
         private readonly TelemetryContext context;
 
-        private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private double? samplingPercentage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="EventTelemetry"/> class.
@@ -84,7 +84,7 @@
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double ISupportSampling.SamplingPercentage
+        double? ISupportSampling.SamplingPercentage
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }

--- a/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
@@ -22,7 +22,7 @@
         private Exception exception;
         private string message;
 
-        private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private double? samplingPercentage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionTelemetry"/> class with empty properties.
@@ -146,7 +146,7 @@
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double ISupportSampling.SamplingPercentage
+        double? ISupportSampling.SamplingPercentage
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }

--- a/src/Core/Managed/Shared/DataContracts/ISupportSampling.cs
+++ b/src/Core/Managed/Shared/DataContracts/ISupportSampling.cs
@@ -8,6 +8,6 @@
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double SamplingPercentage { get; set; }
+        double? SamplingPercentage { get; set; }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
@@ -25,7 +25,7 @@
         internal readonly PageViewData Data;
         private readonly TelemetryContext context;
 
-        private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private double? samplingPercentage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="PageViewTelemetry"/> class.
@@ -129,7 +129,7 @@
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double ISupportSampling.SamplingPercentage
+        double? ISupportSampling.SamplingPercentage
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -24,7 +24,7 @@
         private readonly TelemetryContext context;
         private bool successFieldSet;
 
-        private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private double? samplingPercentage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTelemetry"/> class.
@@ -196,7 +196,7 @@
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double ISupportSampling.SamplingPercentage
+        double? ISupportSampling.SamplingPercentage
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }

--- a/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
@@ -18,7 +18,7 @@
         internal readonly MessageData Data;
         private readonly TelemetryContext context;
 
-        private double samplingPercentage = Constants.DefaultSamplingPercentage;
+        private double? samplingPercentage;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TraceTelemetry"/> class.
@@ -92,7 +92,7 @@
         /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100).
         /// </summary>
-        double ISupportSampling.SamplingPercentage
+        double? ISupportSampling.SamplingPercentage
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Telemetry.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Telemetry.cs
@@ -13,11 +13,12 @@
 
             var samplingSupportingTelemetry = telemetry as ISupportSampling;
 
-            if ((samplingSupportingTelemetry != null) 
-                && (samplingSupportingTelemetry.SamplingPercentage > 0.0 + 1.0E-12) 
-                && (samplingSupportingTelemetry.SamplingPercentage < 100.0 - 1.0E-12))
+            if (samplingSupportingTelemetry != null
+                && samplingSupportingTelemetry.SamplingPercentage.HasValue
+                && (samplingSupportingTelemetry.SamplingPercentage.Value > 0.0 + 1.0E-12) 
+                && (samplingSupportingTelemetry.SamplingPercentage.Value < 100.0 - 1.0E-12))
             {
-                json.WriteProperty("sampleRate", samplingSupportingTelemetry.SamplingPercentage);
+                json.WriteProperty("sampleRate", samplingSupportingTelemetry.SamplingPercentage.Value);
             }
 
             json.WriteProperty("seq", telemetry.Sequence);

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
@@ -120,9 +120,8 @@
                             TelemetryChannelEventSource.Log.SamplingSkippedByType(item.ToString());
                         }
                     }
-                    else
+                    else if (!samplingSupportingTelemetry.SamplingPercentage.HasValue)
                     {
-                        // set sampling percentage on telemetry item, current codebase assumes it is the only one updating SamplingPercentage.
                         samplingSupportingTelemetry.SamplingPercentage = this.SamplingPercentage;
 
                         if (!this.IsSampledIn(item))


### PR DESCRIPTION
With this change the sampler won't sample items that has it's SamplePercentage already set.

This fixes two issues:
- Allows for multiple samplers as a already touched item would be igored by the next.
- Allows for setting the sample percentage of a telemetry manually for scenarios where you'd want to override an item's sampling.

Ref #257 @SergeyKanzhelev 