### PR TITLE
Added IncludedTypes to SamplingProcessor

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryProcessorChainBuilderExtensionsTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryProcessorChainBuilderExtensionsTest.cs
@@ -119,7 +119,7 @@
         [TestMethod]
         public void UseAdaptiveSamplingWithSettingsParameterThrowsArgumentNullExceptionBuilderIsNull()
         {
-            Assert.Throws<ArgumentNullException>(() => TelemetryProcessorChainBuilderExtensions.UseAdaptiveSampling(null, null, null));
+            Assert.Throws<ArgumentNullException>(() => TelemetryProcessorChainBuilderExtensions.UseAdaptiveSampling(null));
         }
 
         [TestMethod]
@@ -128,7 +128,7 @@
             var tc = new TelemetryConfiguration { TelemetryChannel = new StubTelemetryChannel() };
             var channelBuilder = new TelemetryProcessorChainBuilder(tc);
 
-            Assert.Throws<ArgumentNullException>(() => channelBuilder.UseAdaptiveSampling(null, null));
+            Assert.Throws<ArgumentNullException>(() => channelBuilder.UseAdaptiveSampling(default(SamplingPercentageEstimatorSettings), null));
         }
 
         [TestMethod]
@@ -179,6 +179,24 @@
 
             Assert.Equal(13, ((AdaptiveSamplingTelemetryProcessor)tc.TelemetryProcessorChain.FirstTelemetryProcessor).MaxSamplingPercentage);
             Assert.Equal("request", ((AdaptiveSamplingTelemetryProcessor)tc.TelemetryProcessorChain.FirstTelemetryProcessor).ExcludedTypes);
+        }
+
+        [TestMethod]
+        public void UseAdaptiveSamplingAddsAdaptiveSamplingProcessorToTheChainWithCorrectSettingsAndIncludedTypes()
+        {
+            SamplingPercentageEstimatorSettings settings = new SamplingPercentageEstimatorSettings
+            {
+                MaxSamplingPercentage = 13
+            };
+            AdaptiveSamplingPercentageEvaluatedCallback callback = (second, percentage, samplingPercentage, changed, estimatorSettings) => { };
+
+            var tc = new TelemetryConfiguration { TelemetryChannel = new StubTelemetryChannel() };
+            var channelBuilder = new TelemetryProcessorChainBuilder(tc);
+            channelBuilder.UseAdaptiveSampling(settings, callback, null, "request");
+            channelBuilder.Build();
+
+            Assert.Equal(13, ((AdaptiveSamplingTelemetryProcessor)tc.TelemetryProcessorChain.FirstTelemetryProcessor).MaxSamplingPercentage);
+            Assert.Equal("request", ((AdaptiveSamplingTelemetryProcessor)tc.TelemetryProcessorChain.FirstTelemetryProcessor).IncludedTypes);
         }
     }
 }

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -303,6 +303,20 @@
         }
 
         [TestMethod]
+        public void IncludedDoNotOverrideExcludedFromSampling()
+        {
+            TelemetryTypeDoesNotSupportSampling(
+                telemetryProcessors =>
+                {
+                    telemetryProcessors.Process(new PageViewTelemetry());
+                    telemetryProcessors.Process(new RequestTelemetry());
+                    return 2;
+                },
+                "pageview;request",
+                "exception;request");
+        }
+
+        [TestMethod]
         public void UnknownExcludedTypesAreIgnored()
         {
             TelemetryTypeSupportsSampling(telemetryProcessors => telemetryProcessors.Process(new TraceTelemetry("my trace")), "lala1;lala2,lala3");

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/AdaptiveSamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/AdaptiveSamplingTelemetryProcessor.cs
@@ -61,7 +61,8 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. Types listed are excluded even if they are set in IncludedTypes
+        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. 
+        /// Types listed are excluded even if they are set in IncludedTypes
         /// </summary>
         public string ExcludedTypes
         {
@@ -71,7 +72,9 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. Types listed are not included if they are set in ExcludedTypes
+        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. 
+        /// If left empty all types are included implicitly. 
+        /// Types are not included if they are set in ExcludedTypes
         /// </summary>
         public string IncludedTypes
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/AdaptiveSamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/AdaptiveSamplingTelemetryProcessor.cs
@@ -71,6 +71,16 @@
         }
 
         /// <summary>
+        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. All types are sampled when left empty.
+        /// </summary>
+        public string IncludedTypes
+        {
+            get { return this.samplingProcessor.IncludedTypes; }
+
+            set { this.samplingProcessor.IncludedTypes = value; }
+        }
+
+        /// <summary>
         /// Gets or sets initial sampling percentage applied at the start
         /// of the process to dynamically vary the percentage.
         /// </summary>

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/AdaptiveSamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/AdaptiveSamplingTelemetryProcessor.cs
@@ -61,7 +61,7 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. 
+        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. Types listed are excluded even if they are set in IncludedTypes
         /// </summary>
         public string ExcludedTypes
         {
@@ -71,7 +71,7 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. All types are sampled when left empty.
+        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. Types listed are not included if they are set in ExcludedTypes
         /// </summary>
         public string IncludedTypes
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
@@ -58,7 +58,8 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. Types listed are excluded even if they are set in IncludedTypes
+        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. 
+        /// Types listed are excluded even if they are set in IncludedTypes
         /// </summary>
         public string ExcludedTypes
         {
@@ -89,7 +90,9 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. Types listed are not included if they are set in ExcludedTypes
+        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. 
+        /// If left empty all types are included implicitly. 
+        /// Types are not included if they are set in ExcludedTypes
         /// </summary>
         public string IncludedTypes
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
@@ -26,9 +26,11 @@
         private readonly IDictionary<string, Type> allowedTypes;
 
         private HashSet<Type> excludedTypesHashSet;
-
         private string excludedTypesString;
-        
+
+        private HashSet<Type> includedTypesHashSet;
+        private string includedTypesString;
+
         /// <summary>
         /// Initializes a new instance of the <see cref="SamplingTelemetryProcessor"/> class.
         /// <param name="next">Next TelemetryProcessor in call chain.</param>
@@ -43,6 +45,7 @@
             this.SamplingPercentage = 100.0;
             this.Next = next;
             this.excludedTypesHashSet = new HashSet<Type>();
+            this.includedTypesHashSet = new HashSet<Type>();
             this.allowedTypes = new Dictionary<string, Type>(6, StringComparer.OrdinalIgnoreCase)
             {
                 { DependencyTelemetryName, typeof(DependencyTelemetry) },
@@ -86,6 +89,37 @@
         }
 
         /// <summary>
+        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. All types are sampled when left empty.
+        /// </summary>
+        public string IncludedTypes
+        {
+            get
+            {
+                return this.includedTypesString;
+            }
+
+            set
+            {
+                this.includedTypesString = value;
+
+                HashSet<Type> newIncludedTypesHashSet = new HashSet<Type>();
+                if (!string.IsNullOrEmpty(value))
+                {
+                    string[] splitList = value.Split(this.listSeparators, StringSplitOptions.RemoveEmptyEntries);
+                    foreach (string item in splitList)
+                    {
+                        if (this.allowedTypes.ContainsKey(item))
+                        {
+                            newIncludedTypesHashSet.Add(this.allowedTypes[item]);
+                        }
+                    }
+                }
+
+                Interlocked.Exchange(ref this.includedTypesHashSet, newIncludedTypesHashSet);
+            }
+        }
+
+        /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100) for all <see cref="ITelemetry"/>
         /// objects logged in this <see cref="TelemetryClient"/>.
         /// </summary>
@@ -113,7 +147,16 @@
                 if (samplingSupportingTelemetry != null)
                 {
                     var excludedTypesHashSetRef = this.excludedTypesHashSet;
+                    var includedTypesHashSetRef = this.includedTypesHashSet;
+
                     if (excludedTypesHashSetRef.Count > 0 && excludedTypesHashSetRef.Contains(item.GetType()))
+                    {
+                        if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
+                        {
+                            TelemetryChannelEventSource.Log.SamplingSkippedByType(item.ToString());
+                        }
+                    }
+                    else if (includedTypesHashSetRef.Count > 0 && !includedTypesHashSetRef.Contains(item.GetType()))
                     {
                         if (TelemetryChannelEventSource.Log.IsVerboseEnabled)
                         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/SamplingTelemetryProcessor.cs
@@ -58,7 +58,7 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled.
+        /// Gets or sets a semicolon separated list of telemetry types that should not be sampled. Types listed are excluded even if they are set in IncludedTypes
         /// </summary>
         public string ExcludedTypes
         {
@@ -89,7 +89,7 @@
         }
 
         /// <summary>
-        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. All types are sampled when left empty.
+        /// Gets or sets a semicolon separated list of telemetry types that should be sampled. Types listed are not included if they are set in ExcludedTypes
         /// </summary>
         public string IncludedTypes
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/TelemetryChannelBuilderExtensions.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/TelemetryChannelBuilderExtensions.cs
@@ -18,26 +18,11 @@
         /// Adds <see cref="SamplingTelemetryProcessor"/> to the given<see cref="TelemetryProcessorChainBuilder" />
         /// </summary>
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
-        /// <param name="samplingPercentage">Sampling Percentage to configure.</param>        
-        /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseSampling(this TelemetryProcessorChainBuilder builder, double samplingPercentage)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException("builder");    
-            }
-
-            return builder.Use(next => new SamplingTelemetryProcessor(next) { SamplingPercentage = samplingPercentage });
-        }
-
-        /// <summary>
-        /// Adds <see cref="SamplingTelemetryProcessor"/> to the given<see cref="TelemetryProcessorChainBuilder" />
-        /// </summary>
-        /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
         /// <param name="samplingPercentage">Sampling Percentage to configure.</param>     
         /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>   
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
         /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseSampling(this TelemetryProcessorChainBuilder builder, double samplingPercentage, string excludedTypes)
+        public static TelemetryProcessorChainBuilder UseSampling(this TelemetryProcessorChainBuilder builder, double samplingPercentage, string excludedTypes = null, string includedTypes = null)
         {
             if (builder == null)
             {
@@ -48,6 +33,7 @@
             {
                 SamplingPercentage = samplingPercentage,
                 ExcludedTypes = excludedTypes,
+                IncludedTypes = includedTypes
             });
         }
 
@@ -55,47 +41,21 @@
         /// Adds <see cref="AdaptiveSamplingTelemetryProcessor"/> to the <see cref="TelemetryProcessorChainBuilder" />
         /// </summary>
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
-        /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException("builder");
-            }
-
-            return builder.Use(next => new AdaptiveSamplingTelemetryProcessor(next));
-        }
-
-        /// <summary>
-        /// Adds <see cref="AdaptiveSamplingTelemetryProcessor"/> to the <see cref="TelemetryProcessorChainBuilder" />
-        /// </summary>
-        /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
         /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
         /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, string excludedTypes)
+        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, string excludedTypes = null, string includedTypes = null)
         {
             if (builder == null)
             {
                 throw new ArgumentNullException("builder");
             }
 
-            return builder.Use(next => new AdaptiveSamplingTelemetryProcessor(next) { ExcludedTypes = excludedTypes });
-        }
-
-        /// <summary>
-        /// Adds <see cref="AdaptiveSamplingTelemetryProcessor"/> to the <see cref="TelemetryProcessorChainBuilder" />
-        /// </summary>
-        /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
-        /// <param name="maxTelemetryItemsPerSecond">Maximum number of telemetry items to be generated on this application instance.</param>
-        /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, double maxTelemetryItemsPerSecond)
-        {
-            if (builder == null)
+            return builder.Use(next => new AdaptiveSamplingTelemetryProcessor(next)
             {
-                throw new ArgumentNullException("builder");
-            }
-
-            return builder.Use(next => new AdaptiveSamplingTelemetryProcessor(next) { MaxTelemetryItemsPerSecond = maxTelemetryItemsPerSecond });
+                ExcludedTypes = excludedTypes,
+                IncludedTypes = includedTypes
+            });
         }
 
         /// <summary>
@@ -104,8 +64,9 @@
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
         /// <param name="maxTelemetryItemsPerSecond">Maximum number of telemetry items to be generated on this application instance.</param>
         /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
         /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, double maxTelemetryItemsPerSecond, string excludedTypes)
+        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, double maxTelemetryItemsPerSecond, string excludedTypes = null, string includedTypes = null)
         {
             if (builder == null)
             {
@@ -116,6 +77,7 @@
             {
                 MaxTelemetryItemsPerSecond = maxTelemetryItemsPerSecond,
                 ExcludedTypes = excludedTypes,
+                IncludedTypes = includedTypes
             });
         }
 
@@ -125,38 +87,15 @@
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
         /// <param name="settings">Set of settings applicable to dynamic sampling percentage algorithm.</param>
         /// <param name="callback">Callback invoked every time sampling percentage evaluation occurs.</param>
-        /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
-        public static TelemetryProcessorChainBuilder UseAdaptiveSampling(
-            this TelemetryProcessorChainBuilder builder, 
-            SamplingPercentageEstimatorSettings settings,
-            AdaptiveSamplingPercentageEvaluatedCallback callback)
-        {
-            if (builder == null)
-            {
-                throw new ArgumentNullException("builder");
-            }
-
-            if (settings == null)
-            {
-                throw new ArgumentNullException("settings");
-            }
-
-            return builder.Use(next => new AdaptiveSamplingTelemetryProcessor(settings, callback, next) { InitialSamplingPercentage = 100.0 / settings.EffectiveInitialSamplingRate });
-        }
-
-        /// <summary>
-        /// Adds <see cref="AdaptiveSamplingTelemetryProcessor"/> to the <see cref="TelemetryProcessorChainBuilder" />
-        /// </summary>
-        /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/></param>
-        /// <param name="settings">Set of settings applicable to dynamic sampling percentage algorithm.</param>
-        /// <param name="callback">Callback invoked every time sampling percentage evaluation occurs.</param>
         /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
         /// <return>Instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
         public static TelemetryProcessorChainBuilder UseAdaptiveSampling(
             this TelemetryProcessorChainBuilder builder,
             SamplingPercentageEstimatorSettings settings,
             AdaptiveSamplingPercentageEvaluatedCallback callback, 
-            string excludedTypes)
+            string excludedTypes = null,
+            string includedTypes = null)
         {
             if (builder == null)
             {
@@ -172,6 +111,7 @@
             {
                 InitialSamplingPercentage = 100.0 / settings.EffectiveInitialSamplingRate,
                 ExcludedTypes = excludedTypes,
+                IncludedTypes = includedTypes
             });
         }
     }


### PR DESCRIPTION
With #258 it makes sense to offer more flexibility by having both ExcludeTypes and IncludeTypes.

With this change the following scenarios will be possible and quite easy to configure:

### Exceptions: 100%, requests: 50%, everything else: 20%
```
<Add Type="...AdaptiveSamplingTelemetryProcessor">
    <IncludeTypes>Exception</IncludeTypes>
</Add>
<Add Type="...AdaptiveSamplingTelemetryProcessor">
    <SamplingPercentage>50</SamplingPercentage>
    <IncludeTypes>Request</IncludeTypes>
</Add>
<Add Type="...AdaptiveSamplingTelemetryProcessor">
    <SamplingPercentage>20</SamplingPercentage>
</Add>
```

### Dependencies: 20%, everything else: 100%
```
<Add Type="...AdaptiveSamplingTelemetryProcessor">
    <SamplingPercentage>20</SamplingPercentage>
    <IncludeTypes>Dependency</IncludeTypes>
</Add>
<Add Type="...AdaptiveSamplingTelemetryProcessor">
</Add>
```