### PR TITLE
Added helper method to insert TelemetryProcessors at the start of the chain

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
@@ -40,6 +40,18 @@
         }
 
         /// <summary>
+        /// Uses given factory to add TelemetryProcessor at the start of the chain of processors. The processors
+        /// in the chain will be invoked in the same order in which they are chained.
+        /// </summary>
+        /// <param name="telemetryProcessorFactory">A delegate that returns a <see cref="ITelemetryProcessor"/>
+        /// , given the next <see cref="ITelemetryProcessor"/> in the call chain.</param>
+        public TelemetryProcessorChainBuilder UseFirst(Func<ITelemetryProcessor, ITelemetryProcessor> telemetryProcessorFactory)
+        {
+            this.factories.Insert(0, telemetryProcessorFactory);
+            return this;
+        }
+
+        /// <summary>
         /// Builds the chain of linked <see cref="ITelemetryProcessor" /> instances and sets the same in configuration object passed.
         /// A special telemetry processor for handling Transmission is always appended as the last
         /// processor in the chain.


### PR DESCRIPTION
With this we can add TelemetryProcessors at the start of the chain. This is useful if you inject processors by code and want your processor to run first.