### PR TITLE
Empty required fields are replaced with "n/a", properties with required

### DIFF
--- a/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
@@ -116,9 +116,8 @@
             var telemetry = new EventTelemetry { Name = null };
 
             ((ITelemetry)telemetry).Sanitize();
-            
-            Assert.Contains("name", telemetry.Name, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("required", telemetry.Name, StringComparison.OrdinalIgnoreCase);            
+
+            Assert.Equal("n/a", telemetry.Name);           
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/DataContracts/MetricTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/MetricTelemetryTest.cs
@@ -147,8 +147,7 @@
 
             ((ITelemetry)telemetry).Sanitize();
 
-            Assert.Contains("name", telemetry.Name, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("required", telemetry.Name, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("n/a", telemetry.Name);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/DataContracts/PageViewTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/PageViewTelemetryTest.cs
@@ -112,8 +112,7 @@
 
             ((ITelemetry)telemetry).Sanitize();
 
-            Assert.Contains("name", telemetry.Name, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("required", telemetry.Name, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("n/a", telemetry.Name);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/DataContracts/TraceTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/TraceTelemetryTest.cs
@@ -121,8 +121,7 @@
 
             ((ITelemetry)telemetry).Sanitize();
 
-            Assert.Contains("message", telemetry.Message, StringComparison.OrdinalIgnoreCase);
-            Assert.Contains("required", telemetry.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("n/a", telemetry.Message);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
@@ -150,7 +150,7 @@
         {
             var dictionary = new Dictionary<string, string> { { string.Empty, string.Empty } };
             dictionary.SanitizeProperties();
-            Assert.Equal("(required property name is empty)", dictionary.Single().Key);
+            Assert.Equal("required", dictionary.Single().Key);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/TelemetryClientTest.cs
+++ b/Test/CoreSDK.Test/Shared/TelemetryClientTest.cs
@@ -32,8 +32,6 @@
     [TestClass]
     public class TelemetryClientTest
     {
-        private const string RequiredFieldText = "is a required field";
-
         [TestMethod]
         public void IsEnabledReturnsTrueIfTelemetryTrackingIsEnabledInConfiguration()
         {
@@ -228,7 +226,7 @@
 
             var exceptionTelemetry = (ExceptionTelemetry)sentTelemetry.Single();
             Assert.NotNull(exceptionTelemetry.Exception);
-            Assert.Contains(RequiredFieldText, exceptionTelemetry.Exception.Message, StringComparison.OrdinalIgnoreCase);
+            Assert.Equal("n/a", exceptionTelemetry.Exception.Message);
         }
 
         [TestMethod]

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
@@ -175,7 +175,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
         private static string MakeKeyNonEmpty(string key)
         {
-            return string.IsNullOrEmpty(key) ? "(required property name is empty)" : key;
+            return string.IsNullOrEmpty(key) ? "required" : key;
         }
 
         private static string MakeKeyUnique<TValue>(string key, IDictionary<string, TValue> dictionary)

--- a/src/Core/Managed/Shared/Utils.cs
+++ b/src/Core/Managed/Shared/Utils.cs
@@ -49,7 +49,7 @@
             if (string.IsNullOrEmpty(value))
             {
                 CoreEventSource.Log.PopulateRequiredStringWithValue(parameterName, telemetryType);
-                return parameterName + " is a required field for " + telemetryType;
+                return "n/a";
             }
 
             return value;


### PR DESCRIPTION
#263 
Required empty property value is replaced with "n/a"
Required empty property name is replaced with "required" (since we may have multiple such properties, so that we add numbers in the end and "n/a1" "n/a2" would look strange) 