### PR TITLE
Issue 175, no BCL references for .Net40

### DIFF
--- a/Test/CoreSDK.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/Test/CoreSDK.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -45,7 +45,6 @@
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/CoreSDK.Test/Net40/Core.Net40.Tests.csproj
+++ b/Test/CoreSDK.Test/Net40/Core.Net40.Tests.csproj
@@ -29,18 +29,6 @@
       <HintPath>..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -51,14 +39,6 @@
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="System.Net.Http.Extensions">
-      <HintPath>..\..\..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Extensions.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Net.Http.Primitives">
-      <HintPath>..\..\..\..\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.XML" />
@@ -102,12 +82,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets')" />

--- a/Test/CoreSDK.Test/Net40/Core.Net40.Tests.csproj
+++ b/Test/CoreSDK.Test/Net40/Core.Net40.Tests.csproj
@@ -73,6 +73,7 @@
     </Compile>
     <Compile Include="FailOnAssertSetup.cs" />
     <Compile Include="Extensibility\Implementation\Platform\PlatformReferencesTests.cs" />
+    <Compile Include="TaskExTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Core\Managed\Net40\Core.Net40.csproj">

--- a/Test/CoreSDK.Test/Net40/TaskExTests.cs
+++ b/Test/CoreSDK.Test/Net40/TaskExTests.cs
@@ -1,0 +1,227 @@
+using System.Linq;
+
+namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using Assert = Xunit.Assert;
+
+    [TestClass]
+    public class TaskExTests
+    {
+        /// <summary>
+        /// Tests the scenario if RethrowIsFaulted doesn't throw exception for not faulted task.
+        /// </summary>
+        [TestMethod]
+        public void RethrowIfFaultedDoesntThrowIfNoExceptionOccured()
+        {
+            Task task = Task.Factory.StartNew(() => { });
+
+            task.Wait();
+
+            Assert.DoesNotThrow(() => task.RethrowIfFaulted());
+        }
+
+        /// <summary>
+        /// Tests the scenario if RethrowIsFaulted throws exception for not completed task.
+        /// </summary>
+        [TestMethod]
+        public void RethrowIfFaultedThrowsIfTaskIsNotCompleted()
+        {
+            Task task = TaskEx.Delay(TimeSpan.FromMilliseconds(100));
+
+            Assert.Throws<ArgumentException>(() => task.RethrowIfFaulted());
+        }
+
+        /// <summary>
+        /// Tests the scenario if RethrowIsFaulted throws exception for faulted task.
+        /// </summary>
+        [TestMethod]
+        public void RethrowIfFaultedThrowsIfExceptionOccured()
+        {
+            Task task = Task.Factory.StartNew(() => { throw new Exception(); });
+
+            try
+            {
+                task.Wait();
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
+
+            Assert.Throws<AggregateException>(() => task.RethrowIfFaulted());
+        }
+
+        /// <summary>
+        /// Tests the scenario if Delay with zero timeout completes the task.
+        /// </summary>
+        [TestMethod]
+        public void DelayWithZeroTimeoutCompletesTask()
+        {
+            Task task = TaskEx.Delay(TimeSpan.Zero);
+            task.Wait();
+
+            Assert.Equal(task.Status, TaskStatus.RanToCompletion);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Delay with timeout completes task after timeout has elapsed.
+        /// </summary>
+        [TestMethod]
+        public void DelayWaitsAtLeastTimeout()
+        {
+            TimeSpan timeout = TimeSpan.FromMilliseconds(50);
+            DateTime time = DateTime.UtcNow;
+            Task task = TaskEx.Delay(timeout);
+            
+            task.Wait();
+            TimeSpan spent = DateTime.UtcNow - time;
+
+            Assert.True(spent >= timeout);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Delay turns the task in Canceled state after CancellationTokenSource is signaled.
+        /// </summary>
+        [TestMethod]
+        public void DelayWhithCancelationCancelsTask()
+        {
+            TimeSpan timeout = TimeSpan.FromSeconds(1);
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            Task task = TaskEx.Delay(timeout, cancellationTokenSource.Token);
+
+            cancellationTokenSource.Cancel();
+
+            Assert.True(task.IsCanceled);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Delay task throws on wait after cancelation.
+        /// </summary>
+        [TestMethod]
+        public void DelayWhichIsCanceledThrows()
+        {
+            TimeSpan timeout = TimeSpan.FromSeconds(1);
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            Task task = TaskEx.Delay(timeout, cancellationTokenSource.Token);
+
+            cancellationTokenSource.Cancel();
+
+            AggregateException aggregateException = Assert.Throws<AggregateException>(() => task.Wait());
+            Assert.True(aggregateException.InnerExceptions.Single() is TaskCanceledException);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Delay task completes after cancelation without waiting for timeout.
+        /// </summary>
+        [TestMethod]
+        public void DelayWith1SecondAndCanceledDoesntWaitForASecond()
+        {
+            TimeSpan timeout = TimeSpan.FromSeconds(1);
+            CancellationTokenSource cancellationTokenSource = new CancellationTokenSource();
+            Task task = TaskEx.Delay(timeout, cancellationTokenSource.Token);
+
+            DateTime time = DateTime.UtcNow;
+            TimeSpan cancelTimeout = TimeSpan.FromMilliseconds(50);
+            TaskEx.Delay(cancelTimeout).ContinueWith(task1 => cancellationTokenSource.Cancel());
+            try
+            {
+                task.Wait();
+            }
+            catch (Exception)
+            {
+                // ignore
+            }
+
+            TimeSpan spent = DateTime.UtcNow - time;
+
+            Assert.True(spent >= cancelTimeout && spent < timeout);
+        }
+
+        /// <summary>
+        /// Tests the scenario if FromResult sets provided object as task result.
+        /// </summary>
+        [TestMethod]
+        public void FromResultReturnsInputAsResult()
+        {
+            object result = new object();
+            Task<object> task = TaskEx.FromResult<object>(result);
+
+            task.Wait();
+
+            Assert.True(result == task.Result);
+        }
+
+        /// <summary>
+        /// Tests the scenario if WhenAny throws exception for empty tasks array.
+        /// </summary>
+        [TestMethod]
+        public void WhenAnyThrowsForNoTasks()
+        {
+            Assert.Throws<ArgumentException>(() => { TaskEx.WhenAny(); });
+        }
+
+        /// <summary>
+        /// Tests the scenario if WhenAny returns first task if it has completed faster.
+        /// </summary>
+        [TestMethod]
+        public void WhenAnyReturnsFirstCompletedTask()
+        {
+            Task task1 = TaskEx.Delay(TimeSpan.FromMilliseconds(50));
+            Task task2 = TaskEx.Delay(TimeSpan.FromMilliseconds(100));
+
+            Task<Task> completedTask = TaskEx.WhenAny(task1, task2);
+            completedTask.Wait();
+
+            Assert.True(task1 == completedTask.Result);
+        }
+
+        /// <summary>
+        /// Tests the scenario if WhenAny returns second task if it has completed faster.
+        /// </summary>
+        [TestMethod]
+        public void WhenAnyReturnsFirstCompletedTask2()
+        {
+            Task task1 = TaskEx.Delay(TimeSpan.FromMilliseconds(100));
+            Task task2 = TaskEx.Delay(TimeSpan.FromMilliseconds(50));
+
+            Task<Task> completedTask = TaskEx.WhenAny(task1, task2);
+            completedTask.Wait();
+
+            Assert.True(task2 == completedTask.Result);
+        }
+
+        /// <summary>
+        /// Tests the scenario if WhenAny returns first completed task even if it has been faulted.
+        /// </summary>
+        [TestMethod]
+        public void WhenAnyReturnsFirstCompletedTaskEvenOnException()
+        {
+            Task task1 = TaskEx.Delay(TimeSpan.FromMilliseconds(100));
+            Task task2 = TaskEx.Delay(TimeSpan.FromMilliseconds(50)).ContinueWith(task => { throw new Exception(); });
+
+            Task<Task> completedTask = TaskEx.WhenAny(task1, task2);
+            completedTask.Wait();
+
+            Assert.True(task2 == completedTask.Result);
+        }
+
+        /// <summary>
+        /// Tests the scenario if WhenAny returns first completed task even if it has been canceled.
+        /// </summary>
+        [TestMethod]
+        public void WhenAnyReturnsFirstCompletedTaskEvenOnCanceled()
+        {
+            Task task1 = TaskEx.Delay(TimeSpan.FromMilliseconds(100));
+            Task task2 = TaskEx.Delay(TimeSpan.FromMilliseconds(50), new CancellationTokenSource(TimeSpan.FromMilliseconds(10)).Token);
+
+            Task<Task> completedTask = TaskEx.WhenAny(task1, task2);
+            completedTask.Wait();
+
+            Assert.True(task2 == completedTask.Result);
+        }
+    }
+}

--- a/Test/CoreSDK.Test/Net40/packages.config
+++ b/Test/CoreSDK.Test/Net40/packages.config
@@ -1,11 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="gitlink" version="2.2.0" targetFramework="net45" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
-  <package id="Microsoft.Net.Http" version="2.2.29" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net45" developmentDependency="true" />
   <package id="xunit.assert" version="2.0.0-beta-build2650" targetFramework="net45" />

--- a/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
+++ b/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
@@ -23,18 +23,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Test/CoreSDK.Test/Net46/Core.Net46.Tests.csproj
+++ b/Test/CoreSDK.Test/Net46/Core.Net46.Tests.csproj
@@ -23,18 +23,6 @@
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\..\..\..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Test/CoreSDK.Test/Shared/Channel/TransmissionTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TransmissionTest.cs
@@ -176,7 +176,7 @@
                     request.OnBeginGetRequestStream = (callback, state) =>
                     {
                         beginGetRequestStreamCount++;
-                        return TaskEx.FromResult<object>(null).AsAsyncResult(callback, request);
+                        return Task.FromResult<object>(null).AsAsyncResult(callback, request);
                     };
         
                     var transmission = new TestableTransmission { OnCreateRequest = uri => request };
@@ -251,7 +251,7 @@
                 var finishBeginGetRequestStream = new ManualResetEventSlim();
                 var request = new StubWebRequest();
                 request.OnAbort = () => requestAborted.Set();
-                request.OnBeginGetRequestStream = (callback, state) => TaskEx.Run(() => finishBeginGetRequestStream.Wait()).AsAsyncResult(callback, request);
+                request.OnBeginGetRequestStream = (callback, state) => Task.Run(() => finishBeginGetRequestStream.Wait()).AsAsyncResult(callback, request);
                 var transmission = new TestableTransmission(timeout: TimeSpan.FromTicks(1));
                 transmission.OnCreateRequest = uri => request;
 
@@ -274,7 +274,7 @@
         
                     await transmission.SendAsync();
         
-                    await TaskEx.Delay(50); // Let timout detector finish
+                    await Task.Delay(50); // Let timout detector finish
         
                     Assert.False(requestAborted);
                 });

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/SnapshottingCollectionTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/SnapshottingCollectionTest.cs
@@ -71,7 +71,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 var target = new TestableSnapshottingCollection<object>(collection);
                 lock (collection)
                 {
-                    anotherThread = TaskEx.Run(() => target.Add(new object()));
+                    anotherThread = Task.Run(() => target.Add(new object()));
                     Assert.False(anotherThread.Wait(20));
                 }
 
@@ -112,7 +112,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 var target = new TestableSnapshottingCollection<object>(collection);
                 lock (collection)
                 {
-                    anotherThread = TaskEx.Run(() => target.Clear());
+                    anotherThread = Task.Run(() => target.Clear());
                     Assert.False(anotherThread.Wait(20));
                 }
 
@@ -263,7 +263,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 var target = new TestableSnapshottingCollection<object>(collection);
                 lock (collection)
                 {
-                    anotherThread = TaskEx.Run(() => target.Remove(null));
+                    anotherThread = Task.Run(() => target.Remove(null));
                     Assert.False(anotherThread.Wait(20));
                 }
 

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/SnapshottingListTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/SnapshottingListTest.cs
@@ -107,7 +107,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 var target = new TestableSnapshottingList<object>();
                 lock (target.Collection)
                 {
-                    anotherThread = TaskEx.Run(() => target.Insert(0, new object()));
+                    anotherThread = Task.Run(() => target.Insert(0, new object()));
                     Assert.False(anotherThread.Wait(20));
                 }
 
@@ -146,7 +146,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 var target = new TestableSnapshottingList<object> { null };
                 lock (target.Collection)
                 {
-                    anotherThread = TaskEx.Run(() => target.RemoveAt(0));
+                    anotherThread = Task.Run(() => target.RemoveAt(0));
                     Assert.False(anotherThread.Wait(20));
                 }
 
@@ -196,7 +196,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 var target = new TestableSnapshottingList<object> { null };
                 lock (target.Collection)
                 {
-                    anotherThread = TaskEx.Run(() => target[0] = new object());
+                    anotherThread = Task.Run(() => target[0] = new object());
                     Assert.False(anotherThread.Wait(20));
                 }
 

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerTest.cs
@@ -198,7 +198,7 @@
                     timer.Start(() => Task.Factory.StartNew(() => actionInvoked = true));
                     timer.Cancel();
         
-                    await TaskEx.Delay(20);
+                    await Task.Delay(20);
         
                     Assert.False(actionInvoked);
                 });

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModuleTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModuleTest.cs
@@ -84,7 +84,7 @@
                 using (var cancellationTokenSource = new CancellationTokenSource())
                 {
                     var taskStarted = new AutoResetEvent(false);
-                    TaskEx.Run(() =>
+                    Task.Run(() =>
                     {
                         taskStarted.Set();
                         while (!cancellationTokenSource.IsCancellationRequested)

--- a/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
@@ -101,7 +101,7 @@
                 var tasks = new Task[8];
                 for (int i = 0; i < tasks.Length; i++)
                 {
-                    tasks[i] = TaskEx.Run(() => TelemetryConfiguration.Active);
+                    tasks[i] = Task.Run(() => TelemetryConfiguration.Active);
                 }
 
                 Task.WaitAll(tasks);

--- a/Test/CoreSDK.Test/TestFramework/Net40/TestFramework.Net40.csproj
+++ b/Test/CoreSDK.Test/TestFramework/Net40/TestFramework.Net40.csproj
@@ -42,17 +42,6 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop">
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="xunit.assert">
       <HintPath>..\..\..\..\..\packages\xunit.assert.2.0.0-beta-build2650\lib\portable-net45+win+wpa81+wp80\xunit.assert.dll</HintPath>
     </Reference>
@@ -63,12 +52,10 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="..\..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.50.0\build\StyleCop.MSBuild.Targets')" />

--- a/Test/CoreSDK.Test/TestFramework/Net40/packages.config
+++ b/Test/CoreSDK.Test/TestFramework/Net40/packages.config
@@ -1,8 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net45" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net45" />
   <package id="StyleCop.MSBuild" version="4.7.50.0" targetFramework="net45" developmentDependency="true" />
 </packages>

--- a/src/Core/Managed/Net40/Core.Net40.csproj
+++ b/src/Core/Managed/Net40/Core.Net40.csproj
@@ -117,6 +117,7 @@
     </Compile>
     <Compile Include="Extensibility\Implementation\Platform\PlatformImplementation.cs" />
     <Compile Include="Extensibility\Implementation\TelemetryConfigurationFactory.cs" />
+    <Compile Include="TaskEx.cs" />
     <Compile Include="TimeSpanEx.cs" />
     <Compile Include="Utils.cs" />
   </ItemGroup>

--- a/src/Core/Managed/Net40/Core.Net40.csproj
+++ b/src/Core/Managed/Net40/Core.Net40.csproj
@@ -28,35 +28,11 @@
       <HintPath>..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventSource.Redist.1.1.28\lib\net40\Microsoft.Diagnostics.Tracing.EventSource.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.Threading.Tasks, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions, Version=1.0.12.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.dll</HintPath>
-    </Reference>
-    <Reference Include="Microsoft.Threading.Tasks.Extensions.Desktop, Version=1.0.168.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.Async.1.0.168\lib\net40\Microsoft.Threading.Tasks.Extensions.Desktop.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
-    <Reference Include="System.IO">
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.IO.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Management" />
     <Reference Include="System.Net" />
-    <Reference Include="System.Runtime">
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Runtime.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Runtime.Serialization" />
-    <Reference Include="System.Threading.Tasks">
-      <HintPath>..\..\..\..\..\packages\Microsoft.Bcl.1.1.10\lib\net40\System.Threading.Tasks.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.XML" />
     <Reference Include="System.Xml.Linq" />
@@ -134,13 +110,11 @@
     </PropertyGroup>
     <Error Condition="!Exists('..\..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.props'))" />
     <Error Condition="!Exists('..\..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets'))" />
-    <Error Condition="!Exists('..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets'))" />
     <Error Condition="!Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\..\..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets'))" />
   </Target>
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Common.targets'))\Common.targets" />
   <Import Project="..\..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets" Condition="Exists('..\..\..\..\..\packages\MicroBuild.Core.0.2.0\build\MicroBuild.Core.targets')" />
-  <Import Project="..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <Import Project="..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets" Condition="Exists('..\..\..\..\..\packages\Microsoft.Diagnostics.Tracing.EventRegister.1.1.28\build\Microsoft.Diagnostics.Tracing.EventRegister.targets')" />
   <Import Project="..\..\..\..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.54.0\build\StyleCop.MSBuild.Targets')" />
 </Project>

--- a/src/Core/Managed/Net40/TaskEx.cs
+++ b/src/Core/Managed/Net40/TaskEx.cs
@@ -1,0 +1,105 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal static class TaskEx
+    {
+        /// <summary>
+        /// Check and rethrow exception for failed task.
+        /// </summary>
+        /// <param name="task">Task to check.</param>
+        public static void RethrowIfFaulted(this Task task)
+        {
+            if (!task.IsCompleted)
+            {
+                throw new ArgumentException("Task is not yet completed");
+            }
+
+            if (task.IsFaulted)
+            {
+                throw new AggregateException(task.Exception).Flatten();
+            }
+        }
+
+        /// <summary>
+        /// Creates a task that completes after a specified time interval.
+        /// </summary>
+        /// <param name="timeout">The time span to wait before completing the returned task.</param>
+        /// <returns>A Task that represents the time delay.</returns>
+        public static Task Delay(TimeSpan timeout)
+        {
+            return Delay(timeout, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a task that completes after a specified time interval.
+        /// </summary>
+        /// <param name="timeout">The time span to wait before completing the returned task.</param>
+        /// <param name="token">The cancellation token that will interrupt delay.</param>
+        /// <returns>A Task that represents the time delay.</returns>
+        public static Task Delay(TimeSpan timeout, CancellationToken token)
+        {
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+
+            if (timeout.Ticks <= 0)
+            {
+                tcs.SetResult(null);
+                return tcs.Task;
+            }
+
+            Timer timer = null;
+            timer = new Timer(
+                state =>
+                    {
+                        timer.Dispose();
+                        tcs.TrySetResult(null);
+                    }, 
+                null, 
+                timeout, 
+                TimeSpan.FromMilliseconds(Timeout.Infinite));
+
+            token.Register(
+                () =>
+                    {
+                        timer.Dispose();
+                        tcs.TrySetCanceled();
+                    });
+
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Creates a Task that's completed successfully with the specified result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
+        /// <param name="result">The result to store into the completed task.</param>
+        /// <returns>The successfully completed task.</returns>
+        public static Task<TResult> FromResult<TResult>(TResult result)
+        {
+            TaskCompletionSource<TResult> tcs = new TaskCompletionSource<TResult>();
+            tcs.SetResult(result);
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when any of the supplied tasks have completed.
+        /// </summary>
+        /// <param name="tasks">The tasks to wait on for completion.</param>
+        /// <returns>A task that represents the completion of one of the supplied tasks. The return Task's Result is the task that completed.</returns>
+        public static Task<Task> WhenAny(params Task[] tasks)
+        {
+            if (tasks.Length == 0)
+            {
+                throw new ArgumentException("The tasks argument contains no tasks");
+            }
+
+            TaskCompletionSource<Task> taskCompletionSource = new TaskCompletionSource<Task>();
+
+            Task.Factory.ContinueWhenAny(tasks, completedTask => taskCompletionSource.SetResult(completedTask), TaskContinuationOptions.ExecuteSynchronously);
+
+            return taskCompletionSource.Task;
+        }
+    }
+}

--- a/src/Core/Managed/Net40/packages.config
+++ b/src/Core/Managed/Net40/packages.config
@@ -2,9 +2,6 @@
 <packages>
   <package id="Desktop.Analyzers" version="1.1.0" targetFramework="net40" />
   <package id="MicroBuild.Core" version="0.2.0" targetFramework="net40" developmentDependency="true" />
-  <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Async" version="1.0.168" targetFramework="net40" />
-  <package id="Microsoft.Bcl.Build" version="1.0.21" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventRegister" version="1.1.28" targetFramework="net40" />
   <package id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28" targetFramework="net40" />
   <package id="StyleCop.MSBuild" version="4.7.54.0" targetFramework="net40" developmentDependency="true" />

--- a/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
@@ -121,7 +121,7 @@ namespace Microsoft.ApplicationInsights.Channel
                 try
                 {
                     // send request
-                    this.Send(telemetryItems, timeout).ConfigureAwait(false).GetAwaiter().GetResult();
+                    this.Send(telemetryItems, timeout).Wait();
                 }
                 catch (Exception e)
                 {
@@ -133,18 +133,22 @@ namespace Microsoft.ApplicationInsights.Channel
         /// <summary>
         /// Serializes a list of telemetry items and sends them.
         /// </summary>
-        private async Task Send(IEnumerable<ITelemetry> telemetryItems, TimeSpan timeout)
+        private Task Send(IEnumerable<ITelemetry> telemetryItems, TimeSpan timeout)
         {
             if (telemetryItems == null || !telemetryItems.Any())
             {
                 CoreEventSource.Log.LogVerbose("No Telemetry Items passed to Enqueue");
-                return;
+#if NET40
+                return TaskEx.FromResult<object>(null);
+#else
+                return Task.FromResult<object>(null);
+#endif
             }
 
             byte[] data = JsonSerializer.Serialize(telemetryItems);
             var transmission = new Transmission(this.endpointAddress, data, "application/x-json-stream", JsonSerializer.CompressionType, timeout);
 
-            await transmission.SendAsync().ConfigureAwait(false);
+            return transmission.SendAsync();
         }
 
         private void Dispose(bool disposing)

--- a/src/Core/NuGet/Core/Package.nuspec
+++ b/src/Core/NuGet/Core/Package.nuspec
@@ -19,8 +19,6 @@
     <tags>Analytics ApplicationInsights Telemetry AppInsights</tags>
     <dependencies>
       <group targetFramework="net40">
-        <dependency id="Microsoft.Bcl" version="1.1.10" />
-        <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
         <dependency id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28"/>
       </group>
       <group targetFramework="net45">


### PR DESCRIPTION
BCL dependencies has been removed from base API project.
TelemetryChannel still uses BCL.

[Issue 175](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/175)