### PR TITLE
Sergkanz/context tags cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
+- Context properties `NetworkType`, `ScreenResolution` and `Language` marked as obsolete. Please use custom properties to report network type, screen resolution and language. Values stored in these properties will be send as custom properties. 
+
+
 ## Version 2.2.0-beta2
 
 - InMemoryChannel has a new override for Flush method that accepts timeout.

--- a/Schema/PublicSchema/ContextTagKeys.bond
+++ b/Schema/PublicSchema/ContextTagKeys.bond
@@ -13,8 +13,6 @@ struct ContextTagKeys
     [MaxStringLength("1024")]
     100: string 	 DeviceId = "ai.device.id";
     
-    110: string 	 DeviceLanguage = "ai.device.language";
-    
     [Description("Device locale using <language>-<REGION> pattern, following RFC 5646. Example 'en-US'.")]
     [MaxStringLength("64")]
     115: string 	 DeviceLocale = "ai.device.locale";
@@ -23,8 +21,6 @@ struct ContextTagKeys
     [MaxStringLength("256")]
     120: string 	 DeviceModel = "ai.device.model";
     
-    125: string 	 DeviceNetwork = "ai.device.network";
-    
     [Description("Client device OEM name taken from the browser.")]
     [MaxStringLength("256")]
     130: string 	 DeviceOEMName = "ai.device.oemName";
@@ -32,16 +28,6 @@ struct ContextTagKeys
     [Description("Operating system name and version of the device the end user of the application is using. If this field is empty then it is derived from the user agent. Example 'Windows 10 Pro 10.0.10586.0'")]
     [MaxStringLength("256")]
     140: string 	 DeviceOSVersion = "ai.device.osVersion";
-    
-    [Description("Name of the instance where application is running. Computer name for on-premisis, instance name for Azure.")]
-    [MaxStringLength("256")]
-    145: string 	 DeviceRoleInstance = "ai.device.roleInstance";
-    
-    [Description("Name of the role application is part of. Maps directly to the role name in azure.")]
-    [MaxStringLength("256")]
-    150: string 	 DeviceRoleName = "ai.device.roleName";
-    
-    155: string 	 DeviceScreenResolution = "ai.device.screenResolution";
     
     [Description("The type of the device the end user of the application is using. Used primarily to distinguish JavaScript telemetry from server side telemetry. Examples: 'PC', 'Phone', 'Browser'. 'PC' is the default value.")]
     [MaxStringLength("64")]

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/DeviceContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/DeviceContextTest.cs
@@ -17,14 +17,14 @@
         [TestMethod]
         public void TypeIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             Assert.Null(context.Type);
         }
 
         [TestMethod]
         public void TypeCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             context.Type = "test value";
             Assert.Equal("test value", context.Type);
         }
@@ -32,14 +32,14 @@
         [TestMethod]
         public void IdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             Assert.Null(context.Id);
         }
 
         [TestMethod]
         public void IdCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             context.Id = "test value";
             Assert.Equal("test value", context.Id);
         }
@@ -47,14 +47,14 @@
         [TestMethod]
         public void OperatingSystemIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             Assert.Null(context.OperatingSystem);
         }
 
         [TestMethod]
         public void OperatingSystemCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             context.OperatingSystem = "test value";
             Assert.Equal("test value", context.OperatingSystem);
         }
@@ -62,14 +62,14 @@
         [TestMethod]
         public void OemNameIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             Assert.Null(context.OemName);
         }
 
         [TestMethod]
         public void OemNameCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             context.OemName = "test value";
             Assert.Equal("test value", context.OemName);
         }
@@ -77,14 +77,14 @@
         [TestMethod]
         public void DeviceModelIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             Assert.Null(context.Model);
         }
 
         [TestMethod]
         public void DeviceModelCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
             context.Model = "test value";
             Assert.Equal("test value", context.Model);
         }
@@ -92,46 +92,58 @@
         [TestMethod]
         public void NetworkTypeIsNullByDefaultToPreventUnnecessaryTransmissionOfDefaultValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+#pragma warning disable 618
             Assert.Null(context.NetworkType);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void NetworkTypeCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+#pragma warning disable 618
             context.NetworkType = "42";
             Assert.Equal("42", context.NetworkType);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void ScreenResolutionIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+#pragma warning disable 618
             Assert.Null(context.ScreenResolution);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void ScreenResolutionCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+#pragma warning disable 618
             context.ScreenResolution = "test value";
             Assert.Equal("test value", context.ScreenResolution);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void LanguageIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+#pragma warning disable 618
             Assert.Null(context.Language);
+#pragma warning restore 618
         }
 
         [TestMethod]
         public void LanguageCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+#pragma warning disable 618
             context.Language = "test value";
             Assert.Equal("test value", context.Language);
+#pragma warning restore 618
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
+++ b/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
@@ -70,7 +70,7 @@
         /// </summary>
         public DeviceContext Device
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.device, () => new DeviceContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.device, () => new DeviceContext(this.Tags, this.Properties)); }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
@@ -21,8 +21,8 @@
         /// </summary>
         public string RoleName
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceRoleName); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceRoleName, value); }
+            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.CloudRole); }
+            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.CloudRole, value); }
         }
 
         /// <summary>
@@ -30,8 +30,8 @@
         /// </summary>
         public string RoleInstance
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceRoleInstance); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceRoleInstance, value); }
+            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.CloudRoleInstance); }
+            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.CloudRoleInstance, value); }
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
@@ -9,10 +10,12 @@
     public sealed class DeviceContext
     {
         private readonly IDictionary<string, string> tags;
+        private readonly IDictionary<string, string> properties;
 
-        internal DeviceContext(IDictionary<string, string> tags)
+        internal DeviceContext(IDictionary<string, string> tags, IDictionary<string, string> properties)
         {
             this.tags = tags;
+            this.properties = properties;
         }
         
         /// <summary>
@@ -64,28 +67,31 @@
         /// Gets or sets the <a href="http://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib">IANA interface type</a> 
         /// for the internet connected network adapter.
         /// </summary>
+        [Obsolete("Use custom properties.")]
         public string NetworkType
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceNetwork); }
-            set { this.tags.SetTagValueOrRemove(ContextTagKeys.Keys.DeviceNetwork, value); }
+            get { return this.properties.GetTagValueOrNull("ai.device.network"); }
+            set { this.properties.SetTagValueOrRemove("ai.device.network", value); }
         }
 
         /// <summary>
         /// Gets or sets the current application screen resolution.
         /// </summary>
+        [Obsolete("Use custom properties.")]
         public string ScreenResolution
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceScreenResolution); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceScreenResolution, value); }
+            get { return this.properties.GetTagValueOrNull("ai.device.screenResolution"); }
+            set { this.properties.SetStringValueOrRemove("ai.device.screenResolution", value); }
         }
 
         /// <summary>
         /// Gets or sets the current display language of the operating system.
         /// </summary>
+        [Obsolete("Use custom properties.")]
         public string Language
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceLanguage); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceLanguage, value); }
+            get { return this.properties.GetTagValueOrNull("ai.device.language"); }
+            set { this.properties.SetStringValueOrRemove("ai.device.language", value); }
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ContextTagKeys_types.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ContextTagKeys_types.cs
@@ -45,9 +45,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         public string DeviceId { get; set; }
 
         
-        public string DeviceLanguage { get; set; }
-
-        
         
         
         public string DeviceLocale { get; set; }
@@ -58,9 +55,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         public string DeviceModel { get; set; }
 
         
-        public string DeviceNetwork { get; set; }
-
-        
         
         
         public string DeviceOEMName { get; set; }
@@ -69,19 +63,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         
         public string DeviceOSVersion { get; set; }
-
-        
-        
-        
-        public string DeviceRoleInstance { get; set; }
-
-        
-        
-        
-        public string DeviceRoleName { get; set; }
-
-        
-        public string DeviceScreenResolution { get; set; }
 
         
         
@@ -177,15 +158,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         {
             ApplicationVersion = "ai.application.ver";
             DeviceId = "ai.device.id";
-            DeviceLanguage = "ai.device.language";
             DeviceLocale = "ai.device.locale";
             DeviceModel = "ai.device.model";
-            DeviceNetwork = "ai.device.network";
             DeviceOEMName = "ai.device.oemName";
             DeviceOSVersion = "ai.device.osVersion";
-            DeviceRoleInstance = "ai.device.roleInstance";
-            DeviceRoleName = "ai.device.roleName";
-            DeviceScreenResolution = "ai.device.screenResolution";
             DeviceType = "ai.device.type";
             LocationIp = "ai.location.ip";
             OperationId = "ai.operation.id";


### PR DESCRIPTION
The idea of the schema cleanup is to only expose fields available in Application Analytics and making sense for Application Insights for services.

Thus marking those fields obolete