### PR TITLE
Enable RichPayloadEventSource in Net45 package.

### DIFF
--- a/Microsoft.ApplicationInsights.sln
+++ b/Microsoft.ApplicationInsights.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{D954291E-2A0B-460D-934E-DC6B0785DB48}") = "Core.Shared", "src\Core\Managed\Shared\Core.Shared.shproj", "{C1AAA703-5E32-45C0-A69D-F46D1C659AE4}"
 EndProject
@@ -79,29 +79,29 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ApplicationInsightsTypes", 
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{412659ca-49b0-4834-bfbf-8183055083c8}*SharedItemsImports = 4
-		src\Core\Managed\Shared\Shared.projitems*{412659ca-49b0-4834-bfbf-8183055083c8}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{0927e682-4a56-46b6-8125-94fa066b2f57}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Operation.AL.Shared.Tests\Operation.AL.Tests.Shared.projitems*{0927e682-4a56-46b6-8125-94fa066b2f57}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{0927e682-4a56-45b6-8125-94fa066b2f57}*SharedItemsImports = 4
 		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{0927e682-4a56-45b6-8125-94fa066b2f57}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{4dc2927f-bb78-4363-8428-0f02955064bc}*SharedItemsImports = 13
-		src\Core\Managed\Shared\Shared.projitems*{862b97af-f620-43fd-9b65-7e5423f3b7e3}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{394a78e5-2f8f-4d2d-ae08-027380c9f6b2}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{394a78e5-2f8f-4d2d-ae08-027380c9f6b2}*SharedItemsImports = 4
-		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{f76c6cbd-29b0-4564-bdcb-c969f8fec136}*SharedItemsImports = 13
-		src\Core\Managed\Shared\Shared.projitems*{958cfe53-53b7-4e26-846d-da3f214013e6}*SharedItemsImports = 4
-		src\Core\Managed\Operation.AL.Shared\Operation.AL.Shared.projitems*{958cfe53-53b7-4e26-846d-da3f214013e6}*SharedItemsImports = 4
-		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{cd752cd2-6711-4ad7-b5c8-f8c23cf076b1}*SharedItemsImports = 4
-		src\Core\Managed\Shared\Shared.projitems*{cd752cd2-6711-4ad7-b5c8-f8c23cf076b1}*SharedItemsImports = 4
-		src\Core\Managed\Shared\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
-		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{d7d4e3f5-ec0d-47c9-90cc-56f612976122}*SharedItemsImports = 4
-		Test\CoreSDK.Test\Operation.AL.Shared.Tests\Operation.AL.Tests.Shared.projitems*{4e54ed64-28b4-484f-ad5e-089fd2ec9b8b}*SharedItemsImports = 13
-		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{c4a0db5b-0988-4e04-b9b8-bcf3b0842000}*SharedItemsImports = 13
+		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{0927e682-4a56-45b6-8125-94fa066b2f57}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Operation.AL.Shared.Tests\Operation.AL.Tests.Shared.projitems*{0927e682-4a56-46b6-8125-94fa066b2f57}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{0927e682-4a56-46b6-8125-94fa066b2f57}*SharedItemsImports = 4
 		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{1ad07f5f-80e4-4020-b944-ee20756e3b24}*SharedItemsImports = 4
-		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{804af8fd-87f5-48ae-90c8-70433018b76e}*SharedItemsImports = 4
 		src\Core\Managed\Operation.AL.Shared\Operation.AL.Shared.projitems*{21350114-0bf7-4f90-9732-5395840e8cbb}*SharedItemsImports = 13
 		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{21350114-0bf7-4f90-9732-5395840e8ce0}*SharedItemsImports = 13
+		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{394a78e5-2f8f-4d2d-ae08-027380c9f6b2}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{394a78e5-2f8f-4d2d-ae08-027380c9f6b2}*SharedItemsImports = 4
+		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{412659ca-49b0-4834-bfbf-8183055083c8}*SharedItemsImports = 4
+		src\Core\Managed\Shared\Shared.projitems*{412659ca-49b0-4834-bfbf-8183055083c8}*SharedItemsImports = 4
+		Test\CoreSDK.Test\Operation.CC.Shared.Tests\Operation.CC.Tests.Shared.projitems*{4dc2927f-bb78-4363-8428-0f02955064bc}*SharedItemsImports = 13
+		Test\CoreSDK.Test\Operation.AL.Shared.Tests\Operation.AL.Tests.Shared.projitems*{4e54ed64-28b4-484f-ad5e-089fd2ec9b8b}*SharedItemsImports = 13
+		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{804af8fd-87f5-48ae-90c8-70433018b76e}*SharedItemsImports = 4
+		src\Core\Managed\Shared\Shared.projitems*{862b97af-f620-43fd-9b65-7e5423f3b7e3}*SharedItemsImports = 4
+		src\Core\Managed\Operation.AL.Shared\Operation.AL.Shared.projitems*{958cfe53-53b7-4e26-846d-da3f214013e6}*SharedItemsImports = 4
+		src\Core\Managed\Shared\Shared.projitems*{958cfe53-53b7-4e26-846d-da3f214013e6}*SharedItemsImports = 4
+		src\Core\Managed\Shared\Shared.projitems*{c1aaa703-5e32-45c0-a69d-f46d1c659ae4}*SharedItemsImports = 13
+		Test\CoreSDK.Test\Shared\Core.Shared.Tests.projitems*{c4a0db5b-0988-4e04-b9b8-bcf3b0842000}*SharedItemsImports = 13
+		src\Core\Managed\Operation.CC.Shared\Operation.CC.Shared.projitems*{cd752cd2-6711-4ad7-b5c8-f8c23cf076b1}*SharedItemsImports = 4
+		src\Core\Managed\Shared\Shared.projitems*{cd752cd2-6711-4ad7-b5c8-f8c23cf076b1}*SharedItemsImports = 4
+		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{d7d4e3f5-ec0d-47c9-90cc-56f612976122}*SharedItemsImports = 4
+		Test\CoreSDK.Test\TestFramework\Shared\TestFramework.Shared.projitems*{f76c6cbd-29b0-4564-bdcb-c969f8fec136}*SharedItemsImports = 13
 	EndGlobalSection
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
+++ b/Test/CoreSDK.Test/Net45/Core.Net45.Tests.csproj
@@ -56,6 +56,9 @@
     <Compile Include="..\Net40\Extensibility\Implementation\Platform\PlatformReferencesTests.cs">
       <Link>Extensibility\Implementation\Platform\PlatformReferencesTests.cs</Link>
     </Compile>
+    <Compile Include="..\Net46\Extensibility\Implementation\RichPayloadEventSourceTest.cs">
+      <Link>Extensibility\Implementation\RichPayloadEventSourceTest.cs</Link>
+    </Compile>
     <Compile Include="FailOnAssertSetup.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Test/CoreSDK.Test/Net46/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/CoreSDK.Test/Net46/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -207,25 +207,25 @@
             var actualProperties = actualEventPayload.Keys.Select(k => new { Key = k, Value = actualEventPayload[k] });
 
             Assert.IsTrue(expectedProperties.Count() == actualProperties.Count());
-            var e1 = expectedProperties.GetEnumerator();
-            var e2 = actualProperties.GetEnumerator();
-            while (e1.MoveNext() && e2.MoveNext())
+            var expectedPropertiesEnumerator = expectedProperties.GetEnumerator();
+            var actualPropertiesEnumerator = actualProperties.GetEnumerator();
+            while (expectedPropertiesEnumerator.MoveNext() && actualPropertiesEnumerator.MoveNext())
             {
-                var expctedProperty = e1.Current;
-                var actualProperty = e2.Current;
-                Assert.AreEqual(e1.Current.Name, e2.Current.Key);
+                var expectedProperty = expectedPropertiesEnumerator.Current;
+                var actualProperty = actualPropertiesEnumerator.Current;
+                Assert.AreEqual(expectedPropertiesEnumerator.Current.Name, actualPropertiesEnumerator.Current.Key);
 
-                if (!expctedProperty.PropertyType.IsValueType
-                    && !expctedProperty.PropertyType.IsPrimitive
-                    && expctedProperty.PropertyType != typeof(string))
+                if (!expectedProperty.PropertyType.IsValueType
+                    && !expectedProperty.PropertyType.IsPrimitive
+                    && expectedProperty.PropertyType != typeof(string))
                 {
-                    if (expctedProperty.PropertyType.IsClass)
+                    if (expectedProperty.PropertyType.IsClass)
                     {
-                        VerifyEventPayload(expctedProperty.PropertyType.GetProperties().AsEnumerable(), (IDictionary<string, object>)actualProperty.Value);
+                        VerifyEventPayload(expectedProperty.PropertyType.GetProperties().AsEnumerable(), (IDictionary<string, object>)actualProperty.Value);
                     }
                     else
                     {
-                        var enumerableType = GetEnumerableType(expctedProperty.PropertyType);
+                        var enumerableType = GetEnumerableType(expectedProperty.PropertyType);
                         Assert.IsNotNull(enumerableType);
                         Assert.IsTrue(actualProperty.Value.GetType().IsArray);
 

--- a/Test/CoreSDK.Test/Net46/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/CoreSDK.Test/Net46/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -6,7 +6,9 @@
     using System.Linq;
     using Channel;
     using Microsoft.ApplicationInsights.DataContracts;
+
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Reflection;
 
     /// <summary>
     /// Tests the rich payload event source tracking.
@@ -23,6 +25,7 @@
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Requests,
                 new RequestTelemetry("TestRequest", DateTimeOffset.Now, TimeSpan.FromMilliseconds(10), "200", true),
+                typeof(External.RequestData),
                 (client, item) => { client.TrackRequest((RequestTelemetry)item); });
         }
 
@@ -35,6 +38,7 @@
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Traces,
                 new TraceTelemetry("TestTrace", SeverityLevel.Information),
+                typeof(External.MessageData),
                 (client, item) => { client.TrackTrace((TraceTelemetry)item); });
         }
 
@@ -47,6 +51,7 @@
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Events,
                 new EventTelemetry("TestEvent"),
+                typeof(External.EventData),
                 (client, item) => { client.TrackEvent((EventTelemetry)item); });
         }
 
@@ -56,9 +61,13 @@
         [TestMethod]
         public void RichPayloadEventSourceExceptionSentTest()
         {
+            var exceptionTelemetry = new ExceptionTelemetry(new SystemException("Test"));
+            exceptionTelemetry.Data.exceptions[0].parsedStack = new External.StackFrame[] { new External.StackFrame() };
+
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Exceptions,
-                new ExceptionTelemetry(new SystemException("Test")),
+                exceptionTelemetry,
+                typeof(External.ExceptionData),
                 (client, item) => { client.TrackException((ExceptionTelemetry)item); });
         }
 
@@ -71,6 +80,7 @@
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Metrics,
                 new MetricTelemetry("TestMetric", 1),
+                typeof(External.MetricData),
                 (client, item) => { client.TrackMetric((MetricTelemetry)item); });
         }
 
@@ -83,6 +93,7 @@
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Dependencies,
                 new DependencyTelemetry("TestDependency", "TestCommand", DateTimeOffset.Now, TimeSpan.Zero, true),
+                typeof(External.RemoteDependencyData),
                 (client, item) => { client.TrackDependency((DependencyTelemetry)item); });
         }
 
@@ -95,7 +106,34 @@
             this.DoTracking(
                 RichPayloadEventSource.Keywords.PageViews,
                 new PageViewTelemetry("TestPage"),
+                typeof(External.PageViewData),
                 (client, item) => { client.TrackPageView((PageViewTelemetry)item); });
+        }
+
+        /// <summary>
+        /// Tests tracking session state telemetry.
+        /// </summary>
+        [TestMethod]
+        public void RichPayloadEventSourceSessionStateSentTest()
+        {
+            this.DoTracking(
+                RichPayloadEventSource.Keywords.SessionState,
+                new SessionStateTelemetry(new SessionState()),
+                typeof(External.SessionStateData),
+                (client, item) => { client.Track((SessionStateTelemetry)item); });
+        }
+
+        /// <summary>
+        /// Tests tracking session state telemetry.
+        /// </summary>
+        [TestMethod]
+        public void RichPayloadEventSourceSessionPerformanceCounterTest()
+        {
+            this.DoTracking(
+                RichPayloadEventSource.Keywords.PerformanceCounters,
+                new PerformanceCounterTelemetry("TestCategory", "TestCounter", "TestInstance", 1.0),
+                typeof(External.PerformanceCounterData),
+                (client, item) => { client.Track((PerformanceCounterTelemetry)item); });
         }
 
         /// <summary>
@@ -104,52 +142,127 @@
         /// <param name="keywords">The event keywords to enable.</param>
         /// <param name="item">The telemetry item to track.</param>
         /// <param name="track">The tracking callback to execute.</param>
-        private void DoTracking(EventKeywords keywords, ITelemetry item, Action<TelemetryClient, ITelemetry> track)
+        private void DoTracking(EventKeywords keywords, ITelemetry item, Type dataType, Action<TelemetryClient, ITelemetry> track)
         {
-            var client = new TelemetryClient();
-            client.InstrumentationKey = Guid.NewGuid().ToString();
-
-            using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
+            if (IsRunningOnVersion46AndAbove())
             {
-                listener.EnableEvents(RichPayloadEventSource.Log.EventSourceInternal, EventLevel.Verbose, keywords);
+                var client = new TelemetryClient();
+                client.InstrumentationKey = Guid.NewGuid().ToString();
 
-                item.Context.Properties.Add("property1", "value1");
-                item.Context.User.Id = "testUserId";
-                item.Context.Operation.Id = Guid.NewGuid().ToString();
-
-                track(client, item);
-
-                var actualEvent = listener.Messages.FirstOrDefault();
-
-                Assert.IsNotNull(actualEvent);
-                Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
-
-                int keysFound = 0;
-                object[] tags = actualEvent.Payload[1] as object[];
-                foreach (object tagObject in tags)
+                using (var listener = new Microsoft.ApplicationInsights.TestFramework.TestEventListener())
                 {
-                    Dictionary<string, object> tag = (Dictionary<string, object>)tagObject;
-                    Assert.IsNotNull(tag);
-                    string key = (string)tag["Key"];
-                    object value = tag["Value"];
-                    if (!string.IsNullOrWhiteSpace(key))
+                    listener.EnableEvents(RichPayloadEventSource.Log.EventSourceInternal, EventLevel.Verbose, keywords);
+
+                    item.Context.Properties.Add("property1", "value1");
+                    item.Context.User.Id = "testUserId";
+                    item.Context.Operation.Id = Guid.NewGuid().ToString();
+
+                    track(client, item);
+
+                    var actualEvent = listener.Messages.FirstOrDefault();
+
+                    Assert.IsNotNull(actualEvent);
+                    Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
+
+                    int keysFound = 0;
+                    object[] tags = actualEvent.Payload[1] as object[];
+                    foreach (object tagObject in tags)
                     {
-                        if (key == "ai.user.id")
+                        Dictionary<string, object> tag = (Dictionary<string, object>)tagObject;
+                        Assert.IsNotNull(tag);
+                        string key = (string)tag["Key"];
+                        object value = tag["Value"];
+                        if (!string.IsNullOrWhiteSpace(key))
                         {
-                            Assert.AreEqual("testUserId", value);
-                            ++keysFound;
+                            if (key == "ai.user.id")
+                            {
+                                Assert.AreEqual("testUserId", value);
+                                ++keysFound;
+                            }
+                            else if (key == "ai.operation.id")
+                            {
+                                Assert.AreEqual(item.Context.Operation.Id, value);
+                                ++keysFound;
+                            }
                         }
-                        else if (key == "ai.operation.id")
+                    }
+
+                    Assert.AreEqual(2, keysFound);
+                    Assert.IsNotNull(actualEvent.Payload[2]);
+
+                    var expectedProperties = dataType.GetProperties().AsEnumerable();
+                    var actualPropertiesPayload = (IDictionary<string, object>)actualEvent.Payload[2];
+                    VerifyEventPayload(expectedProperties, actualPropertiesPayload);
+                }
+            }
+            else
+            {
+                // 4.5 doesn't have RichPayload events
+                Assert.IsNull(RichPayloadEventSource.Log.EventSourceInternal);
+            }
+        }
+
+        private static void VerifyEventPayload(IEnumerable<PropertyInfo> expectedProperties, IDictionary<string, object> actualEventPayload)
+        {
+            var actualProperties = actualEventPayload.Keys.Select(k => new { Key = k, Value = actualEventPayload[k] });
+
+            Assert.IsTrue(expectedProperties.Count() == actualProperties.Count());
+            var e1 = expectedProperties.GetEnumerator();
+            var e2 = actualProperties.GetEnumerator();
+            while (e1.MoveNext() && e2.MoveNext())
+            {
+                var expctedProperty = e1.Current;
+                var actualProperty = e2.Current;
+                Assert.AreEqual(e1.Current.Name, e2.Current.Key);
+
+                if (!expctedProperty.PropertyType.IsValueType
+                    && !expctedProperty.PropertyType.IsPrimitive
+                    && expctedProperty.PropertyType != typeof(string))
+                {
+                    if (expctedProperty.PropertyType.IsClass)
+                    {
+                        VerifyEventPayload(expctedProperty.PropertyType.GetProperties().AsEnumerable(), (IDictionary<string, object>)actualProperty.Value);
+                    }
+                    else
+                    {
+                        var enumerableType = GetEnumerableType(expctedProperty.PropertyType);
+                        Assert.IsNotNull(enumerableType);
+                        Assert.IsTrue(actualProperty.Value.GetType().IsArray);
+
+                        if (enumerableType.IsClass)
                         {
-                            Assert.AreEqual(item.Context.Operation.Id, value);
-                            ++keysFound;
+                            VerifyEventPayload(enumerableType.GetProperties().AsEnumerable(), (IDictionary<string, object>)((object[])actualProperty.Value)[0]);
                         }
                     }
                 }
 
-                Assert.AreEqual(2, keysFound);
-                Assert.IsNotNull(actualEvent.Payload[2]);
             }
+        }
+
+        private static Type GetEnumerableType(Type type)
+        {
+            foreach (Type intType in type.GetInterfaces())
+            {
+                if (intType.IsGenericType && intType.GetGenericTypeDefinition() == typeof(IEnumerable<>))
+                {
+                    return intType.GetGenericArguments()[0];
+                }
+            }
+            return null;
+        }
+
+        private static bool IsRunningOnVersion46AndAbove()
+        {
+            string productVersionString = System.Diagnostics.FileVersionInfo.GetVersionInfo(typeof(object).Assembly.Location).ProductVersion;
+
+            Version ver;
+            if (!Version.TryParse(productVersionString, out ver))
+            {
+                Assert.Fail("Unable to determine .net framework version");
+            }
+
+            var ver46 = new Version(4, 6, 0, 0);
+            return ver >= ver46;
         }
     }
 }

--- a/src/Core/Managed/Net45/Core.Net45.csproj
+++ b/src/Core/Managed/Net45/Core.Net45.csproj
@@ -42,6 +42,8 @@
     <Compile Include="..\Net40\Extensibility\Implementation\TelemetryConfigurationFactory.cs">
       <Link>Extensibility\Implementation\TelemetryConfigurationFactory.cs</Link>
     </Compile>
+    <Compile Include="Extensibility\Implementation\RichPayloadEventSource.TelemetryHandler.cs" />
+    <Compile Include="Extensibility\Implementation\RichPayloadEventSource.cs" />
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\..\..\..\packages\Desktop.Analyzers.1.1.0\analyzers\dotnet\cs\Desktop.Analyzers.dll" />

--- a/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -1,0 +1,604 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Linq;
+    using System.Reflection;
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    /// <summary>
+    /// Define the telemetry handlers.
+    /// Create anonymous type for each telemetry data type.
+    /// </summary>
+    internal sealed partial class RichPayloadEventSource
+    {
+        private readonly string dummyPartAiKeyValue = string.Empty;
+        private readonly IDictionary<string, string> dummyPartATagsValue = new Dictionary<string, string>();
+
+        private void InitTelemetryHandlers(Type eventSourceType)
+        {
+            // EventSource.Write<T> (String, EventSourceOptions, T)
+            var writeGenericMethod = eventSourceType.GetMethods(BindingFlags.Instance | BindingFlags.Public)
+                .Where(m => m.Name == "Write" && m.IsGenericMethod == true)
+                .Select(m => new { Method = m, Parameters = m.GetParameters() })
+                .Where(m => m.Parameters.Length == 3
+                            && m.Parameters[0].ParameterType.FullName == "System.String"
+                            && m.Parameters[1].ParameterType.FullName == "System.Diagnostics.Tracing.EventSourceOptions"
+                            && m.Parameters[2].ParameterType.FullName == null && m.Parameters[2].ParameterType.IsByRef == false)
+                .Select(m => m.Method)
+                .SingleOrDefault();
+
+            if (writeGenericMethod != null)
+            {
+                var eventSourceOptionsType = eventSourceType.Assembly.GetType("System.Diagnostics.Tracing.EventSourceOptions");
+                var eventSourceOptionsKeywordsProperty = eventSourceOptionsType.GetProperty("Keywords", BindingFlags.Public | BindingFlags.Instance);
+
+                // Request
+                this.telemetryHandlers.Add(typeof(RequestTelemetry), this.CreateHandlerForRequestTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // Trace
+                this.telemetryHandlers.Add(typeof(TraceTelemetry), this.CreateHandlerForTraceTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // Event
+                this.telemetryHandlers.Add(typeof(EventTelemetry), this.CreateHandlerForEventTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // Dependency
+                this.telemetryHandlers.Add(typeof(DependencyTelemetry), this.CreateHandlerForDependencyTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // Metric
+                this.telemetryHandlers.Add(typeof(MetricTelemetry), this.CreateHandlerForMetricTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // Exception
+                this.telemetryHandlers.Add(typeof(ExceptionTelemetry), this.CreateHandlerForExceptionTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // PerformanceCounter
+                this.telemetryHandlers.Add(typeof(PerformanceCounterTelemetry), this.CreateHandlerForPerformanceCounterTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // PageView
+                this.telemetryHandlers.Add(typeof(PageViewTelemetry), this.CreateHandlerForPageViewTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+
+                // SessionState
+                this.telemetryHandlers.Add(typeof(SessionStateTelemetry), this.CreateHandlerForSessionStateTelemetry(writeGenericMethod, eventSourceOptionsType, eventSourceOptionsKeywordsProperty));
+            }
+            else
+            {
+                CoreEventSource.Log.LogVerbose("Unable to get method: EventSource.Write<T>(String, EventSourceOptions, T)");
+            }
+        }
+
+        private Action<ITelemetry> CreateHandlerForRequestTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.Requests;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyRequestData = new RequestData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_RequestData = new
+                {
+                    // The properties and layout should be the same as RequestData_types.cs
+                    dummyRequestData.ver,
+                    dummyRequestData.id,
+                    dummyRequestData.source,
+                    dummyRequestData.name,
+                    dummyRequestData.startTime,
+                    dummyRequestData.duration,
+                    dummyRequestData.responseCode,
+                    dummyRequestData.success,
+                    dummyRequestData.httpMethod,
+                    dummyRequestData.url,
+                    dummyRequestData.properties,
+                    dummyRequestData.measurements
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as RequestTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_RequestData = new
+                        {
+                            data.ver,
+                            data.id,
+                            data.source,
+                            data.name,
+                            data.startTime,
+                            data.duration,
+                            data.responseCode,
+                            data.success,
+                            data.httpMethod,
+                            data.url,
+                            data.properties,
+                            data.measurements
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { RequestTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForTraceTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.Traces;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyMessageData = new MessageData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_MessageData = new
+                {
+                    // The properties and layout should be the same as MessageData_types.cs
+                    dummyMessageData.ver,
+                    dummyMessageData.message,
+                    dummyMessageData.severityLevel,
+                    dummyMessageData.properties
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as TraceTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_MessageData = new
+                        {
+                            data.ver,
+                            data.message,
+                            data.severityLevel,
+                            data.properties
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { TraceTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForEventTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.Events;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyEventData = new EventData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_EventData = new
+                {
+                    // The properties and layout should be the same as EventData_types.cs
+                    dummyEventData.ver,
+                    dummyEventData.name,
+                    dummyEventData.properties,
+                    dummyEventData.measurements
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as EventTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_EventData = new
+                        {
+                            data.ver,
+                            data.name,
+                            data.properties,
+                            data.measurements
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { EventTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForDependencyTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.Dependencies;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyDependencyData = new RemoteDependencyData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_RemoteDependencyData = new
+                {
+                    // The properties and layout should be the same as RemoteDependencyData_types.cs
+                    dummyDependencyData.ver,
+                    dummyDependencyData.name,
+                    dummyDependencyData.id,
+                    dummyDependencyData.resultCode,
+                    dummyDependencyData.kind,
+                    dummyDependencyData.value,
+                    dummyDependencyData.duration,
+                    dummyDependencyData.dependencyKind,
+                    dummyDependencyData.success,
+                    dummyDependencyData.async,
+                    dummyDependencyData.dependencySource,
+                    dummyDependencyData.commandName,
+                    dummyDependencyData.data,
+                    dummyDependencyData.dependencyTypeName,
+                    dummyDependencyData.target,
+                    dummyDependencyData.properties,
+                    dummyDependencyData.measurements
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as DependencyTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_RemoteDependencyData = new
+                        {
+                            data.ver,
+                            data.name,
+                            data.id,
+                            data.resultCode,
+                            data.kind,
+                            data.value,
+                            data.duration,
+                            data.dependencyKind,
+                            data.success,
+                            data.async,
+                            data.dependencySource,
+                            data.commandName,
+                            data.data,
+                            data.dependencyTypeName,
+                            data.target,
+                            data.properties,
+                            data.measurements
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { DependencyTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForMetricTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.Metrics;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyMetricData = new MetricData();
+            var dummyDataPoint = new DataPoint();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_MetricData = new
+                {
+                    // The properties and layout should be the same as MetricData_types.cs
+                    dummyMetricData.ver,
+                    metrics = new[]
+                    {
+                        new
+                        {
+                            // The properties and layout should be the same as DataPoint_types.cs
+                            dummyDataPoint.name,
+                            dummyDataPoint.kind,
+                            dummyDataPoint.value,
+                            dummyDataPoint.count,
+                            dummyDataPoint.min,
+                            dummyDataPoint.max,
+                            dummyDataPoint.stdDev
+                        }
+                    }.AsEnumerable(),
+                    dummyMetricData.properties
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as MetricTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_MetricData = new
+                        {
+                            data.ver,
+                            metrics = data.metrics.Select(i => new
+                            {
+                                i.name,
+                                i.kind,
+                                i.value,
+                                i.count,
+                                i.min,
+                                i.max,
+                                i.stdDev
+                            }),
+                            data.properties
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { MetricTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForExceptionTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.Exceptions;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyExceptionData = new ExceptionData();
+            var dummyExceptionDetails = new ExceptionDetails();
+            var dummyStackFrame = new StackFrame();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_ExceptionData = new
+                {
+                    // The properties and layout should be the same as ExceptionData_types.cs
+                    dummyExceptionData.ver,
+                    dummyExceptionData.handledAt,
+                    exceptions = new[]
+                    {
+                        new
+                        {
+                            // The properties and layout should be the same as ExceptionDetails_types.cs
+                            dummyExceptionDetails.id,
+                            dummyExceptionDetails.outerId,
+                            dummyExceptionDetails.typeName,
+                            dummyExceptionDetails.message,
+                            dummyExceptionDetails.hasFullStack,
+                            dummyExceptionDetails.stack,
+                            parsedStack = new[]
+                            {
+                                new
+                                {
+                                    // The properties and layout should be the same as StackFrame_types.cs
+                                    dummyStackFrame.level,
+                                    dummyStackFrame.method,
+                                    dummyStackFrame.assembly,
+                                    dummyStackFrame.fileName,
+                                    dummyStackFrame.line
+                                }
+                            }.AsEnumerable()
+                        }
+                    }.AsEnumerable(),
+                    dummyExceptionData.severityLevel,
+                    dummyExceptionData.problemId,
+                    dummyExceptionData.properties,
+                    dummyExceptionData.measurements,
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as ExceptionTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_ExceptionData = new
+                        {
+                            data.ver,
+                            data.handledAt,
+                            exceptions = data.exceptions.Select(i => new
+                            {
+                                i.id,
+                                i.outerId,
+                                i.typeName,
+                                i.message,
+                                i.hasFullStack,
+                                i.stack,
+                                parsedStack = i.parsedStack.Select(j => new
+                                {
+                                    j.level,
+                                    j.method,
+                                    j.assembly,
+                                    j.fileName,
+                                    j.line
+                                }),
+                            }),
+                            data.severityLevel,
+                            data.problemId,
+                            data.properties,
+                            data.measurements
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { ExceptionTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForPerformanceCounterTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.PerformanceCounters;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyPerfData = new PerformanceCounterData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_PerformanceCounterData = new
+                {
+                    // The properties and layout should be the same as PerformanceCounterData_types.cs
+                    dummyPerfData.ver,
+                    dummyPerfData.categoryName,
+                    dummyPerfData.counterName,
+                    dummyPerfData.instanceName,
+                    dummyPerfData.kind,
+                    dummyPerfData.count,
+                    dummyPerfData.min,
+                    dummyPerfData.max,
+                    dummyPerfData.stdDev,
+                    dummyPerfData.value,
+                    dummyPerfData.properties
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as PerformanceCounterTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_PerformanceCounterData = new
+                        {
+                            data.ver,
+                            data.categoryName,
+                            data.counterName,
+                            data.instanceName,
+                            data.kind,
+                            data.count,
+                            data.min,
+                            data.max,
+                            data.stdDev,
+                            data.value,
+                            data.properties
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { PerformanceCounterTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForPageViewTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.PageViews;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummyPageViewData = new PageViewData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_PageViewPerfData = new
+                {
+                    // The properties and layout should be the same as PageViewData_types.cs (EventData_types.cs)
+                    dummyPageViewData.url,
+                    dummyPageViewData.duration,
+                    dummyPageViewData.ver,
+                    dummyPageViewData.name,
+                    dummyPageViewData.properties,
+                    dummyPageViewData.measurements,
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as PageViewTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_PageViewPerfData = new
+                        {
+                            data.url,
+                            data.duration,
+                            data.ver,
+                            data.name,
+                            data.properties,
+                            data.measurements,
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { PageViewTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+
+        private Action<ITelemetry> CreateHandlerForSessionStateTelemetry(MethodInfo writeGenericMethod, Type eventSourceOptionsType, PropertyInfo eventSourceOptionsKeywordsProperty)
+        {
+            var eventSourceOptions = Activator.CreateInstance(eventSourceOptionsType);
+            var keywords = Keywords.SessionState;
+            eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
+            var dummySessionStateData = new SessionStateData();
+            var writeMethod = writeGenericMethod.MakeGenericMethod(new
+            {
+                PartA_iKey = this.dummyPartAiKeyValue,
+                PartA_Tags = this.dummyPartATagsValue,
+                PartB_SessionStateData = new
+                {
+                    // The properties and layout should be the same as SessionStateData_types.cs
+                    dummySessionStateData.ver,
+                    dummySessionStateData.state
+                }
+            }.GetType());
+
+            return (item) =>
+            {
+                if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
+                {
+                    var telemetryItem = item as SessionStateTelemetry;
+                    var data = telemetryItem.Data;
+                    var extendedData = new
+                    {
+                        // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
+                        PartA_iKey = telemetryItem.Context.InstrumentationKey,
+                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartB_SessionStateData = new
+                        {
+                            data.ver,
+                            data.state
+                        }
+                    };
+
+                    writeMethod.Invoke(this.EventSourceInternal, new object[] { SessionStateTelemetry.TelemetryName, eventSourceOptions, extendedData });
+                }
+            };
+        }
+    }
+}

--- a/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -30,7 +30,7 @@
         private const string EventProviderName = "Microsoft-ApplicationInsights-Data";
 
         /// <summary>A dictionary mapping each telemetry item type to its handler.</summary>
-        private readonly Dictionary<Type, Action<ITelemetry>> telemetryHandlers = new Dictionary<Type, Action<ITelemetry>>();
+        private readonly Dictionary<Type, Action<ITelemetry>> telemetryHandlers;
 
         /// <summary>
         /// Initializes a new instance of the RichPayloadEventSource class.
@@ -47,7 +47,8 @@
                     var etwSelfDescribingEventFormat = Enum.ToObject(eventSourceSettingsType, 8);
                     this.EventSourceInternal = (EventSource)Activator.CreateInstance(eventSourceType, EventProviderName, etwSelfDescribingEventFormat);
 
-                    this.InitTelemetryHandlers(eventSourceType);
+                    // CreateTelemetryHandlers is defined in RichPayloadEventSource.TelemetryHandler.cs
+                    this.telemetryHandlers = this.CreateTelemetryHandlers(this.EventSourceInternal);
                 }
             }
         }

--- a/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -1,0 +1,154 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    /// <summary>
+    /// RichPayload Event Source (.Net 4.5 version)
+    /// It dynamically checks the runtime version and only emits the event if the runtime is .Net Framework 4.6 and above.
+    /// As .Net 4.5 project doesn't support EventDataAttribute, the class uses the anonymous type (RichPayloadEventSource.TelemetryHandler.cs) for the corresponding telemetry data type.
+    /// The anonymous type keeps the same properties and layout as the telemetry data type schema. 
+    /// Once you update the data type, you should also update the anonymous type.
+    /// </summary>
+    internal sealed partial class RichPayloadEventSource : IDisposable
+    {
+        /// <summary>RichPayloadEventSource instance.</summary>
+        public static readonly RichPayloadEventSource Log = new RichPayloadEventSource();
+
+        /// <summary>Event source.</summary>
+        internal readonly EventSource EventSourceInternal;
+
+        /// <summary>Event provider name.</summary>
+        private const string EventProviderName = "Microsoft-ApplicationInsights-Data";
+
+        /// <summary>A dictionary mapping each telemetry item type to its handler.</summary>
+        private readonly Dictionary<Type, Action<ITelemetry>> telemetryHandlers = new Dictionary<Type, Action<ITelemetry>>();
+
+        /// <summary>
+        /// Initializes a new instance of the RichPayloadEventSource class.
+        /// </summary>
+        public RichPayloadEventSource()
+        {
+            if (AppDomain.CurrentDomain.IsHomogenous && AppDomain.CurrentDomain.IsFullyTrusted)
+            {
+                var eventSourceType = typeof(EventSource);
+                var eventSourceSettingsType = eventSourceType.Assembly.GetType("System.Diagnostics.Tracing.EventSourceSettings");
+
+                if (eventSourceSettingsType != null)
+                {
+                    var etwSelfDescribingEventFormat = Enum.ToObject(eventSourceSettingsType, 8);
+                    this.EventSourceInternal = (EventSource)Activator.CreateInstance(eventSourceType, EventProviderName, etwSelfDescribingEventFormat);
+
+                    this.InitTelemetryHandlers(eventSourceType);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Process a collected telemetry item.
+        /// </summary>
+        /// <param name="item">A collected Telemetry item.</param>
+        public void Process(ITelemetry item)
+        {
+            if (this.EventSourceInternal == null)
+            {
+                return;
+            }
+
+            Action<ITelemetry> handler = null;
+            var itemType = item.GetType();
+            if (!this.telemetryHandlers.TryGetValue(itemType, out handler))
+            {
+                string msg = string.Format(CultureInfo.InvariantCulture, "Unknown telemetry type: {0}", itemType.FullName);
+                CoreEventSource.Log.LogVerbose(msg);
+
+                return;
+            }
+
+            handler(item);
+        }
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Disposes the object.
+        /// </summary>
+        /// <param name="disposing">True if disposing.</param>
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (this.EventSourceInternal != null)
+                {
+                    this.EventSourceInternal.Dispose();
+                }
+            }
+        }
+
+        /// <summary>
+        /// Keywords for the RichPayloadEventSource.
+        /// </summary>
+        public sealed class Keywords
+        {
+            /// <summary>
+            /// Keyword for requests.
+            /// </summary>
+            public const EventKeywords Requests = (EventKeywords)0x1;
+
+            /// <summary>
+            /// Keyword for traces.
+            /// </summary>
+            public const EventKeywords Traces = (EventKeywords)0x2;
+
+            /// <summary>
+            /// Keyword for events.
+            /// </summary>
+            public const EventKeywords Events = (EventKeywords)0x4;
+
+            /// <summary>
+            /// Keyword for exceptions.
+            /// </summary>
+            public const EventKeywords Exceptions = (EventKeywords)0x8;
+
+            /// <summary>
+            /// Keyword for dependencies.
+            /// </summary>
+            public const EventKeywords Dependencies = (EventKeywords)0x10;
+
+            /// <summary>
+            /// Keyword for metrics.
+            /// </summary>
+            public const EventKeywords Metrics = (EventKeywords)0x20;
+
+            /// <summary>
+            /// Keyword for page views.
+            /// </summary>
+            public const EventKeywords PageViews = (EventKeywords)0x40;
+
+            /// <summary>
+            /// Keyword for performance counters.
+            /// </summary>
+            public const EventKeywords PerformanceCounters = (EventKeywords)0x80;
+
+            /// <summary>
+            /// Keyword for session state.
+            /// </summary>
+            public const EventKeywords SessionState = (EventKeywords)0x100;
+        }
+    }
+}

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -309,7 +309,7 @@
                 // invokes the Process in the first processor in the chain
                 this.configuration.TelemetryProcessorChain.Process(telemetry);
 
-#if NET46
+#if NET46 || NET45
                 // logs rich payload ETW event for any partners to process it
                 RichPayloadEventSource.Log.Process(telemetry);
 #endif


### PR DESCRIPTION
#293 The change is to dynamically enable RichPayloadEventSource in Net45 package. As EventDataAttribute is only available in 4.6, the code uses anonymous type for all telemetry data.

"[Write<T>](https://msdn.microsoft.com/en-us/library/dn823293(v=vs.110).aspx) requires T to be an anonymous type or marked with the EventDataAttribute attribute. In addition, the properties of T must be a supported property type; either a simple framework type such as Int16, Int32, Int64, String, Guid, DateTime or DateTimeOffset, or an array of primitive types."

@SergeyKanzhelev @abaranch 