### PR TITLE
Allow all characters in property names. Change sanitization to optimi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 - InMemoryChannel has a new override for Flush method that accepts timeout.
 - Local storage folder name was changed. That means that when the application stopped, and the application was updated to the new SDK, then the telemetry from the old local folder will not be send.
-- Allow all characters in property names.
+- Allow all characters in property names and measurements names.
 
 ## Version 2.2.0-beta1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 - InMemoryChannel has a new override for Flush method that accepts timeout.
 - Local storage folder name was changed. That means that when the application stopped, and the application was updated to the new SDK, then the telemetry from the old local folder will not be send.
+- Allow all characters in property names.
 
 ## Version 2.2.0-beta1
 

--- a/Test/CoreSDK.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
@@ -55,7 +55,7 @@
             Assert.Equal(3, telemetry.Properties.Count); //AvailabilityTelemetry sanitize already sets one property which is why this is 3 instead of 2
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), telemetry.Properties.Keys.ToArray()[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[0]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", telemetry.Properties.Keys.ToArray()[1]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", telemetry.Properties.Keys.ToArray()[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[1]);
 
             Assert.Same(telemetry.Properties, telemetry.Properties);

--- a/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -145,7 +145,7 @@
             Assert.Equal(2, telemetry.Properties.Count);
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), telemetry.Properties.Keys.ToArray()[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[0]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", telemetry.Properties.Keys.ToArray()[1]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", telemetry.Properties.Keys.ToArray()[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[1]);
 
             Assert.Same(telemetry.Properties, telemetry.Properties);

--- a/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/EventTelemetryTest.cs
@@ -101,13 +101,13 @@
             string[] values = telemetry.Properties.Values.OrderBy(s => s).ToArray();
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), keys[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), values[1]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), values[0]);
 
             Assert.Equal(2, telemetry.Metrics.Count);
             keys = telemetry.Metrics.Keys.OrderBy(s => s).ToArray();
             Assert.Equal(new string('Y', Property.MaxDictionaryNameLength), keys[1]);
-            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -439,7 +439,7 @@
             Assert.Equal(2, telemetry.Properties.Count);
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), telemetry.Properties.Keys.ToArray()[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[0]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", telemetry.Properties.Keys.ToArray()[1]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", telemetry.Properties.Keys.ToArray()[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[1]);
         }
 
@@ -455,7 +455,7 @@
             Assert.Equal(2, telemetry.Metrics.Count);
             string[] keys = telemetry.Metrics.Keys.OrderBy(s => s).ToArray();
             Assert.Equal(new string('Y', Property.MaxDictionaryNameLength), keys[1]);
-            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/DataContracts/MetricTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/MetricTelemetryTest.cs
@@ -136,7 +136,7 @@
             Assert.Equal(2, telemetry.Properties.Count);
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), telemetry.Properties.Keys.ToArray()[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[0]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", telemetry.Properties.Keys.ToArray()[1]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", telemetry.Properties.Keys.ToArray()[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[1]);
         }
 

--- a/Test/CoreSDK.Test/Shared/DataContracts/PageViewTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/PageViewTelemetryTest.cs
@@ -94,13 +94,13 @@
             string[] values = telemetry.Properties.Values.OrderBy(s => s).ToArray();
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), keys[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), values[1]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), values[0]);
 
             Assert.Equal(2, telemetry.Metrics.Count);
             keys = telemetry.Metrics.Keys.OrderBy(s => s).ToArray();
             Assert.Equal(new string('Y', Property.MaxDictionaryNameLength), keys[1]);
-            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
 
             Assert.Equal(new Uri("http://foo.com/" + new string('Y', Property.MaxUrlLength - 15)), telemetry.Url);
         }

--- a/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -156,13 +156,13 @@
             string[] values = telemetry.Properties.Values.OrderBy(s => s).ToArray();
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), keys[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), values[1]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), values[0]);
 
             Assert.Equal(2, telemetry.Metrics.Count);
             keys = telemetry.Metrics.Keys.OrderBy(s => s).ToArray();
             Assert.Equal(new string('Y', Property.MaxDictionaryNameLength), keys[1]);
-            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "001", keys[0]);
+            Assert.Equal(new string('Y', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
 
             Assert.Equal(new Uri("http://foo.com/" + new string('Y', Property.MaxUrlLength - 15)), telemetry.Url);
 

--- a/Test/CoreSDK.Test/Shared/DataContracts/TraceTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/TraceTelemetryTest.cs
@@ -110,7 +110,7 @@
             Assert.Equal(2, telemetry.Properties.Count);
             Assert.Equal(new string('X', Property.MaxDictionaryNameLength), telemetry.Properties.Keys.ToArray()[0]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[0]);
-            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "001", telemetry.Properties.Keys.ToArray()[1]);
+            Assert.Equal(new string('X', Property.MaxDictionaryNameLength - 3) + "1", telemetry.Properties.Keys.ToArray()[1]);
             Assert.Equal(new string('X', Property.MaxValueLength), telemetry.Properties.Values.ToArray()[1]);
         }
 

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
@@ -154,37 +154,6 @@
         }
 
         [TestMethod]
-        public void SanitizePropertiesReplacesSpecialCharactersWithUnderscores()
-        {
-            foreach (char invalidCharacter in GetInvalidNameCharacters())
-            {
-                string originalKey = "test" + invalidCharacter + "key";
-                const string OriginalValue = "Test Value";
-                var original = new Dictionary<string, string> { { originalKey, OriginalValue } };
-
-                original.SanitizeProperties();
-
-                string sanitizedKey = originalKey.Replace(invalidCharacter, '_');
-                Assert.Equal(new[] { new KeyValuePair<string, string>(sanitizedKey, OriginalValue) }, original);
-            }
-        }
-
-        [TestMethod]
-        public void SanitizePropertiesMakesKeyUniqueAfterReplacingSpecialCharactersWithUnderscores()
-        {
-            string originalKey = "test#key";
-            var dictionary = new Dictionary<string, string> 
-            {
-                { originalKey, string.Empty },
-                { originalKey.Replace("#", "_"), string.Empty },
-            };
-
-            dictionary.SanitizeProperties();
-
-            Assert.Contains("test_key001", dictionary.Keys);
-        }
-
-        [TestMethod]
         public void SanitizePropertiesTruncatesKeysLongerThan150Characters()
         {
             string originalKey = new string('A', Property.MaxNameLength + 1);
@@ -251,22 +220,6 @@
 
             string sanitizedKey = OriginalKey.Trim();
             Assert.Equal(new[] { new KeyValuePair<string, double>(sanitizedKey, OriginalValue) }, original);
-        }
-
-        [TestMethod]
-        public void SanitizeMeasurementsReplacesSpecialCharactersWithUnderscores()
-        {
-            foreach (char invalidCharacter in GetInvalidNameCharacters())
-            {
-                string originalKey = "test" + invalidCharacter + "key";
-                const double OriginalValue = 42.0;
-                var original = new Dictionary<string, double> { { originalKey, OriginalValue } };
-
-                original.SanitizeMeasurements();
-
-                string sanitizedKey = originalKey.Replace(invalidCharacter, '_');
-                Assert.Equal(new[] { new KeyValuePair<string, double>(sanitizedKey, OriginalValue) }, original);
-            }
         }
 
         [TestMethod]

--- a/src/Core/Managed/Shared/Utils.cs
+++ b/src/Core/Managed/Shared/Utils.cs
@@ -90,10 +90,19 @@
 
         public static double SanitizeNanAndInfinity(double value)
         {
+            bool valueChanged;
+            return SanitizeNanAndInfinity(value, out valueChanged);
+        }
+
+        public static double SanitizeNanAndInfinity(double value, out bool valueChanged)
+        {
+            valueChanged = false;
+
             // Disallow Nan and Infinity since Breeze does not accept it
             if (double.IsInfinity(value) || double.IsNaN(value))
             {
                 value = 0;
+                valueChanged = true;
             }
 
             return value;


### PR DESCRIPTION
- removed regex that was used to check that we have only approved characters in property names
- changed sanitation on optimistic approach where we re-add properties only when we actually did sanitation. In 99% cases that should work faster.. 