### PR TITLE
Add try/catches to config reading

### DIFF
--- a/Test/CoreSDK.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -201,36 +201,6 @@
         }
 
         [TestMethod]
-        public void GetExceptionDetailsInvokesPlatformToGetExceptionDetails()
-        {
-            Exception exception = null;
-
-            Extensibility.Implementation.Platform.PlatformSingleton.Current = new StubPlatform
-            {
-                OnGetExceptionDetails = (e, p) =>
-                {
-                    exception = e;
-
-                    return new Extensibility.Implementation.External.ExceptionDetails();
-                }
-            };
-            try
-            {
-                var expectedException = new Exception();
-                var expectedParentDetails = new Extensibility.Implementation.External.ExceptionDetails();
-
-                ExceptionTelemetry original = CreateExceptionTelemetry(expectedException);
-
-                Assert.Same(expectedException, exception);
-                Assert.Same(expectedException, original.Exception);
-            }
-            finally
-            {
-                Microsoft.ApplicationInsights.Extensibility.Implementation.Platform.PlatformSingleton.Current = null;
-            }
-        }
-
-        [TestMethod]
         public void SerializeWritesDataBaseTypeAsExpectedByEndpoint()
         {
             ExceptionTelemetry original = CreateExceptionTelemetry();

--- a/Test/CoreSDK.Test/TestFramework/Shared/StubPlatform.cs
+++ b/Test/CoreSDK.Test/TestFramework/Shared/StubPlatform.cs
@@ -14,19 +14,9 @@
         public Func<string> OnReadConfigurationXml = () => null;
         public Func<Exception, ExceptionDetails, ExceptionDetails> OnGetExceptionDetails = (e, p) => new ExceptionDetails();
 
-        public IDictionary<string, object> GetApplicationSettings()
-        {
-            return this.OnGetApplicationSettings();
-        }
-
         public string ReadConfigurationXml()
         {
             return this.OnReadConfigurationXml();
-        }
-
-        public ExceptionDetails GetExceptionDetails(Exception exception, ExceptionDetails parentExceptionDetails)
-        {
-            return this.OnGetExceptionDetails(exception, parentExceptionDetails);
         }
 
         public IDebugOutput GetDebugOutput()

--- a/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
@@ -174,7 +174,7 @@
                 exception = new Exception(Utils.PopulateRequiredStringValue(null, "message", typeof(ExceptionTelemetry).FullName));
             }
 
-            ExceptionDetails exceptionDetails = PlatformSingleton.Current.GetExceptionDetails(exception, parentExceptionDetails);
+            ExceptionDetails exceptionDetails = ExceptionConverter.ConvertToExceptionDetails(exception, parentExceptionDetails);
 
             // For upper level exception see if Message was provided and do not use exceptiom.message in that case
             if (parentExceptionDetails == null && !string.IsNullOrWhiteSpace(this.Message))
@@ -220,7 +220,7 @@
                 exceptions.RemoveRange(Constants.MaxExceptionCountToSave, exceptions.Count - Constants.MaxExceptionCountToSave);
                 
                 // we'll add our new exception and parent it to the root exception (first one in the list)
-                exceptions.Add(PlatformSingleton.Current.GetExceptionDetails(countExceededException, exceptions[0]));
+                exceptions.Add(ExceptionConverter.ConvertToExceptionDetails(countExceededException, exceptions[0]));
             }
             
             this.Data.exceptions = exceptions;

--- a/src/Core/Managed/Shared/Extensibility/Implementation/IPlatform.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/IPlatform.cs
@@ -15,19 +15,9 @@
     internal interface IPlatform
     {
         /// <summary>
-        /// Returns a dictionary that can be used to access per-user/per-application settings shared by all application instances.
-        /// </summary>
-        IDictionary<string, object> GetApplicationSettings();
-
-        /// <summary>
         /// Returns contents of the ApplicationInsights.config file in the application directory.
         /// </summary>
         string ReadConfigurationXml();
-
-        /// <summary>
-        /// Returns the platform specific <see cref="ExceptionDetails"/> object for the given Exception.
-        /// </summary>
-        ExceptionDetails GetExceptionDetails(Exception exception, ExceptionDetails parentExceptionDetails);
 
         /// <summary>
         /// Returns the platform specific Debugger writer to the VS output console.


### PR DESCRIPTION
- Add try/catches to config reading so TelemetryConfiguration.Active does not throw
- Remove couple methods from Platform interface (which needs to be removed all together since now we have only one implementation) 