### PR TITLE
Sergkanz/level up versions

### DIFF
--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -8,7 +8,7 @@
     <SemanticVersionMajor>2</SemanticVersionMajor>
     <SemanticVersionMinor>2</SemanticVersionMinor>
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone>beta2</PreReleaseMilestone>
+    <PreReleaseMilestone>beta3</PreReleaseMilestone>
     <!-- 
       Date when Semantic Version was changed. 
       Update for every public release.

--- a/src/TelemetryChannels/ServerTelemetryChannel/NuGet/TelemetryChannel.NuGet.csproj
+++ b/src/TelemetryChannels/ServerTelemetryChannel/NuGet/TelemetryChannel.NuGet.csproj
@@ -16,7 +16,7 @@
     <NoWarn>2008</NoWarn>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <PackageSpecFile>$(MSBuildProjectDirectory)\Package.nuspec</PackageSpecFile>
-    <PackageVersionFile>$(BinRoot)\$(Configuration)\Core\Managed\Net45\Microsoft.ApplicationInsights.dll</PackageVersionFile>
+    <PackageVersionFile>$(BinRoot)\$(Configuration)\Core\Managed\Net40\Microsoft.ApplicationInsights.dll</PackageVersionFile>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
@@ -38,7 +38,7 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Core\Managed\Net45\Core.Net45.csproj">
+    <ProjectReference Include="..\..\..\Core\Managed\Net40\Core.Net40.csproj">
       <Project>{412659ca-49b0-4834-bfbf-8183055083c8}</Project>
       <Name>Core.Net45</Name>
     </ProjectReference>

--- a/src/TelemetryChannels/ServerTelemetryChannel/NuGet/TelemetryChannel.NuGet.csproj
+++ b/src/TelemetryChannels/ServerTelemetryChannel/NuGet/TelemetryChannel.NuGet.csproj
@@ -38,10 +38,6 @@
     </None>
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\Core\Managed\Net40\Core.Net40.csproj">
-      <Project>{412659ca-49b0-4834-bfbf-8183055083c8}</Project>
-      <Name>Core.Net45</Name>
-    </ProjectReference>
     <ProjectReference Include="..\Net45\TelemetryChannel.Net45.csproj">
       <Project>{18ce7397-7566-46d6-a52d-3b441363b326}</Project>
       <Name>TelemetryChannel.Net45</Name>


### PR DESCRIPTION
I use the same version of `Microsoft.ApplicationInsights.dll` in both nuspec. this solves the problem of uneven versions for nugget packages