### PR TITLE
Removed null check as it can break the JsonWriter flow.

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/JsonWriter.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/JsonWriter.cs
@@ -128,11 +128,6 @@
                 this.WriteStartObject();
                 foreach (KeyValuePair<string, string> item in values)
                 {
-                    if (item.Value == null)
-                    {
-                        continue;
-                    }
-
                     this.WriteProperty(item.Key, item.Value);
                 }
 


### PR DESCRIPTION
We should't remove properties that are null as it might brake the flow of the JsonWriter.

PS: Why was this done in the first place? What could break on the back end with this change?

Ref #319 