### PR TITLE
Missing period at the end of a comment in the function header caused …

### DIFF
--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -191,7 +191,7 @@
         }
 
         /// <summary>
-        /// Gets or sets the source for the request telemetry object. This often is a hashed instrumentation key identifying the caller 
+        /// Gets or sets the source for the request telemetry object. This often is a hashed instrumentation key identifying the caller.
         /// </summary>
         public string Source
         {


### PR DESCRIPTION
…a build break. Fixing that.