### PR TITLE
Enable local throttling of telemetry items sent to the backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ This changelog will be used to generate documentation on [release notes page](ht
 - Type `PerformanceCounterTelemetry` was marked obsolete. Use `MetricTelemetry` instead.
 - Marked `RequestTelemetry.HttpMethod` as obsolete. Put http verb as part of the name for the better grouping by name and use custom properties to report http verb as a dimension.
 - Marked `RequestTelemetry.StartTime` as obsolete. Use `TimeStamp` instead.
+- [Removed BCL dependency](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/175)
+- [Added IPv6 support](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/316)
+- [Fixed issue #278](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/278)
+- [Fixed issue #271](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/271)
+- [Fixed issue #319](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/319)
+- [Fixed issue #318](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/318)
 
 ## Version 2.2.0-beta2
 

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTelemetrySerializer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTelemetrySerializer.cs
@@ -9,7 +9,7 @@
     {
         public Action<IEnumerable<ITelemetry>> OnSerialize = _ => { };
 
-        public override void Serialize(IEnumerable<ITelemetry> items)
+        public override void Serialize(ICollection<ITelemetry> items)
         {
             this.OnSerialize(items);
         }

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetrySerializerTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetrySerializerTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.IO.Compression;
     using System.Linq;
@@ -69,7 +70,7 @@
             public void ThrowsArgumentExceptionWhenTelemetryIsEmptyToPreventUsageErrors()
             {
                 var serializer = new TelemetrySerializer(new StubTransmitter());
-                Assert.Throws<ArgumentException>(() => serializer.Serialize(Enumerable.Empty<ITelemetry>()));
+                Assert.Throws<ArgumentException>(() => serializer.Serialize(new List<ITelemetry>()));
             }
 
             [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionSenderTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionSenderTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -232,6 +233,43 @@
                 Assert.Same(sender, eventSender);
                 Assert.Same(transmission, eventArgs.Transmission);
                 Assert.Same(wrapper, eventArgs.Response);
+            }
+
+            [TestMethod]
+            public void IsRaisedWhenTransmissionIsThrottledLocally()
+            {
+                var sender = new TransmissionSender();
+
+                var eventIsRaised = new ManualResetEventSlim();
+                var firedCount = 0;
+                var eventArgs = new List<Implementation.TransmissionProcessedEventArgs>();
+                sender.TransmissionSent += (s, a) =>
+                {
+                    firedCount++;
+                    eventArgs.Add(a);
+                    if (firedCount == 2)
+                    {
+                        eventIsRaised.Set();
+                    }
+                };
+
+                var telemetryItems = new List<ITelemetry>();
+                for (var i=0; i<sender.ThrottleLimit + 10; i++)
+                {
+                    telemetryItems.Add(new DataContracts.MetricTelemetry());
+                }
+
+                var wrapper = new HttpWebResponseWrapper();
+                Transmission transmission = new StubTransmission(telemetryItems) { OnSend = () => wrapper };
+                sender.Enqueue(() => transmission);
+
+                Assert.True(eventIsRaised.Wait(50));
+                Assert.Equal(2, firedCount);
+                Assert.Equal(429, eventArgs[0].Response.StatusCode);
+                Assert.Equal("Internally Throttled", eventArgs[0].Response.StatusDescription);
+                Assert.Same(wrapper, eventArgs[1].Response);
+                Assert.Equal(sender.ThrottleLimit, ((StubTransmission)eventArgs[0].Transmission).CountOfItems());
+                Assert.Equal(10, ((StubTransmission)eventArgs[1].Transmission).CountOfItems());
             }
         }
     }

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionSenderTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionSenderTest.cs
@@ -239,6 +239,7 @@
             public void IsRaisedWhenTransmissionIsThrottledLocallyWithItems()
             {
                 var sender = new TransmissionSender();
+                sender.ApplyThrottle = true;
 
                 var eventIsRaised = new ManualResetEventSlim();
                 var firedCount = 0;
@@ -276,6 +277,7 @@
             public void IsRaisedWhenTransmissionIsThrottledLocallyWithByteArray()
             {
                 var sender = new TransmissionSender();
+                sender.ApplyThrottle = true;
 
                 var eventIsRaised = new ManualResetEventSlim();
                 var firedCount = 0;

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionStorageTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionStorageTest.cs
@@ -654,7 +654,7 @@
                 Assert.NotNull(dequeued);
             }
 
-            [TestMethod, Timeout(150)]
+            [TestMethod, Timeout(200)]
             public void DoesNotEndlesslyTryToLoadFileTheProcessNoLongerHasAccessTo()
             {
                 StubPlatformFile inaccessibleFile = CreateFile("InaccessibleFile.trn");
@@ -664,7 +664,8 @@
                 var storage = new TransmissionStorage();
                 storage.Initialize(provider);
 
-                Assert.Throws<UnauthorizedAccessException>(() => storage.Dequeue());
+                Transmission result = storage.Dequeue();
+                Assert.Null(result);
             }
 
             [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/TestFramework/Shared/StubTransmission.cs
+++ b/Test/ServerTelemetryChannel.Test/TestFramework/Shared/StubTransmission.cs
@@ -44,7 +44,7 @@
 
         public override Tuple<Transmission, Transmission> Split(Func<int, int> calculateLength)
         {
-            var ret = base.Split(calculateLength);
+            Tuple<Transmission,Transmission> ret = base.Split(calculateLength);
 
             if (ret.Item2 == null)
             {
@@ -87,7 +87,7 @@
             }
             else
             {
-                var compress = this.ContentEncoding == JsonSerializer.CompressionType;
+                bool compress = this.ContentEncoding == JsonSerializer.CompressionType;
                 string[] payloadItems = JsonSerializer
                     .Deserialize(this.Content, compress)
                     .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);

--- a/Test/ServerTelemetryChannel.Test/TestFramework/Shared/StubTransmission.cs
+++ b/Test/ServerTelemetryChannel.Test/TestFramework/Shared/StubTransmission.cs
@@ -46,6 +46,11 @@
         {
             var ret = base.Split(calculateLength);
 
+            if (ret.Item2 == null)
+            {
+                return Tuple.Create((Transmission)this, (Transmission) null);
+            }
+
             return Tuple.Create((Transmission)this.Convert(ret.Item1), (Transmission)this.Convert(ret.Item2));
         }
 

--- a/Test/ServerTelemetryChannel.Test/TestFramework/Shared/StubTransmission.cs
+++ b/Test/ServerTelemetryChannel.Test/TestFramework/Shared/StubTransmission.cs
@@ -18,12 +18,12 @@
         public Func<HttpWebResponseWrapper> OnSend = () => null;
 
         public StubTransmission()
-            : base(new Uri("any://uri"), new byte[0], string.Empty, string.Empty)
+            : base(new Uri("any://uri"), new byte[0], JsonSerializer.ContentType, string.Empty)
         {
         }
 
         public StubTransmission(byte[] content)
-            : base(new Uri("any://uri"), content, string.Empty, string.Empty)
+            : base(new Uri("any://uri"), content, JsonSerializer.ContentType, string.Empty)
         {
         }
 

--- a/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
@@ -146,7 +146,7 @@ namespace Microsoft.ApplicationInsights.Channel
             }
 
             byte[] data = JsonSerializer.Serialize(telemetryItems);
-            var transmission = new Transmission(this.endpointAddress, data, "application/x-json-stream", JsonSerializer.CompressionType, timeout);
+            var transmission = new Transmission(this.endpointAddress, data, JsonSerializer.ContentType, JsonSerializer.CompressionType, timeout);
 
             return transmission.SendAsync();
         }

--- a/src/Core/Managed/Shared/Channel/Transmission.cs
+++ b/src/Core/Managed/Shared/Channel/Transmission.cs
@@ -67,7 +67,7 @@
         /// Initializes a new instance of the <see cref="Transmission"/> class.
         /// </summary>
         public Transmission(Uri address, ICollection<ITelemetry> telemetryItems, TimeSpan timeout = default(TimeSpan)) 
-            : this(address, JsonSerializer.Serialize(telemetryItems, true), "application-x-json-stream", JsonSerializer.CompressionType, timeout)
+            : this(address, JsonSerializer.Serialize(telemetryItems, true), "application/x-json-stream", JsonSerializer.CompressionType, timeout)
         {
             this.TelemetryItems = telemetryItems;
         }
@@ -272,12 +272,12 @@
                     transmissionA = new Transmission(
                         this.EndpointAddress,
                         JsonSerializer.ConvertToByteArray(itemsA, compress),
-                        "application-x-json-stream",
+                        "application/x-json-stream",
                         this.ContentEncoding);
                     transmissionB = new Transmission(
                         this.EndpointAddress,
                         JsonSerializer.ConvertToByteArray(itemsB, compress),
-                        "application-x-json-stream",
+                        "application/x-json-stream",
                         this.ContentEncoding);
                 }
             }

--- a/src/Core/Managed/Shared/Channel/Transmission.cs
+++ b/src/Core/Managed/Shared/Channel/Transmission.cs
@@ -140,7 +140,6 @@
             get; private set;
         }
 
-#if !NET40
         /// <summary>
         /// Gets the number of telemetry items in the transmission
         /// </summary>
@@ -149,6 +148,7 @@
             get; private set;
         }
 
+#if !NET40
         /// <summary>
         /// Executes the request that the current transmission represents.
         /// </summary>

--- a/src/Core/Managed/Shared/Extensibility/Implementation/HttpWebResponseWrapper.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/HttpWebResponseWrapper.cs
@@ -19,5 +19,10 @@
         /// Gets or sets HttpWebResponse Retry-After header value.
         /// </summary>
         public string RetryAfterHeader { get; set; }
+
+        /// <summary>
+        /// Gets or sets HttpWebResponse StatusDescription.
+        /// </summary>
+        public string StatusDescription { get; set; }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/JsonSerializer.cs
@@ -35,6 +35,17 @@
         }
 
         /// <summary>
+        /// Gets the content type used by the serializer. 
+        /// </summary>
+        public static string ContentType
+        {
+            get
+            {
+                return "application/x-json-stream";
+            }
+        }
+
+        /// <summary>
         /// Serializes and compress the telemetry items into a JSON string. Each JSON object is separated by a new line. 
         /// </summary>
         /// <param name="telemetryItems">The list of telemetry items to serialize.</param>

--- a/src/Core/Managed/Shared/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/JsonSerializer.cs
@@ -89,7 +89,7 @@
         {
             var memoryStream = new MemoryStream(telemetryItemsData);
             
-            using (Stream decompressedStream = new GZipStream(memoryStream, CompressionMode.Decompress))
+            using (Stream decompressedStream = compress ? (Stream)new GZipStream(memoryStream, CompressionMode.Decompress) : memoryStream)
             {
                 using (MemoryStream str = new MemoryStream())
                 {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/PartialSuccessTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/PartialSuccessTransmissionPolicy.cs
@@ -31,7 +31,7 @@
 
         private void HandleTransmissionSentEvent(object sender, TransmissionProcessedEventArgs args)
         {
-            if (args.Exception == null && args.Response == null)
+            if (args.Exception == null && (args.Response == null || args.Response.StatusCode == ResponseStatusCodes.Success))
             {
                 // We succesfully sent transmittion
                 this.backoffLogicManager.ResetConsecutiveErrors();

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ResponseStatusCodes.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ResponseStatusCodes.cs
@@ -2,6 +2,7 @@
 {
     internal class ResponseStatusCodes
     {
+        public const int Success = 200;
         public const int PartialSuccess = 206;
         public const int RequestTimeout = 408;
         public const int ResponseCodeTooManyRequests = 429;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -417,6 +417,17 @@
             this.WriteEvent(58, statusCode, currentDelayInSeconds, this.ApplicationName);
         }
 
+        [Event(59, Message = "Transmission locally throttled. Throttle Limit: {0}. Attempted: {1}. Accepted: {2}. ", Level = EventLevel.Warning)]
+        public void TransmissionThrottledWarning(int limit, int attempted, int accepted)
+        {
+            this.WriteEvent(
+                59,
+                limit.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                attempted.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                accepted.ToString(System.Globalization.CultureInfo.InvariantCulture) ?? string.Empty,
+                this.ApplicationName);
+        }
+
         private string GetApplicationName()
         {
             string name;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -418,7 +418,7 @@
         }
 
         [Event(59, Message = "Transmission locally throttled. Throttle Limit: {0}. Attempted: {1}. Accepted: {2}. ", Level = EventLevel.Warning)]
-        public void TransmissionThrottledWarning(int limit, int attempted, int accepted)
+        public void TransmissionThrottledWarning(int limit, int attempted, int accepted, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 59,

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetrySerializer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetrySerializer.cs
@@ -51,7 +51,7 @@
             }
         }
 
-        public virtual void Serialize(IEnumerable<ITelemetry> items)
+        public virtual void Serialize(ICollection<ITelemetry> items)
         {
             if (items == null)
             {
@@ -63,9 +63,8 @@
                 throw new ArgumentException("One or more telemetry item is expected", "items");
             }
 
-            byte[] content = JsonSerializer.Serialize(items);
             string encoding = JsonSerializer.CompressionType;
-            var transmission = new Transmission(this.endpointAddress, content, "application/x-json-stream", encoding);
+            var transmission = new Transmission(this.endpointAddress, items, "application/x-json-stream", encoding);
             this.transmitter.Enqueue(transmission);
         }
     }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetrySerializer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetrySerializer.cs
@@ -63,8 +63,7 @@
                 throw new ArgumentException("One or more telemetry item is expected", "items");
             }
 
-            string encoding = JsonSerializer.CompressionType;
-            var transmission = new Transmission(this.endpointAddress, items, "application/x-json-stream", encoding);
+            var transmission = new Transmission(this.endpointAddress, items);
             this.transmitter.Enqueue(transmission);
         }
     }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
@@ -5,6 +5,7 @@
     using System.Threading.Tasks;
 
     using Microsoft.ApplicationInsights.Channel.Implementation;
+    using Extensibility.Implementation;
 
 #if NET45
     using TaskEx = System.Threading.Tasks.Task;
@@ -29,42 +30,38 @@
 
         private void HandleTransmissionSentEvent(object sender, TransmissionProcessedEventArgs e)
         {
-            var webException = e.Exception as WebException;
-            if (webException != null)
+            HttpWebResponseWrapper httpWebResponse = e.Response;
+            if (httpWebResponse != null)
             {
-                HttpWebResponse httpWebResponse = webException.Response as HttpWebResponse;
-                if (httpWebResponse != null)
+                if (httpWebResponse.StatusCode == ResponseStatusCodes.ResponseCodeTooManyRequests ||
+                    httpWebResponse.StatusCode == ResponseStatusCodes.ResponseCodeTooManyRequestsOverExtendedTime)
                 {
-                    if (httpWebResponse.StatusCode == (HttpStatusCode)ResponseStatusCodes.ResponseCodeTooManyRequests ||
-                        httpWebResponse.StatusCode == (HttpStatusCode)ResponseStatusCodes.ResponseCodeTooManyRequestsOverExtendedTime)
+                    this.MaxSenderCapacity = 0;
+                    if (httpWebResponse.StatusCode == ResponseStatusCodes.ResponseCodeTooManyRequestsOverExtendedTime)
                     {
-                        this.MaxSenderCapacity = 0;
-                        if (httpWebResponse.StatusCode == (HttpStatusCode)ResponseStatusCodes.ResponseCodeTooManyRequestsOverExtendedTime)
-                        {
-                            // We start loosing data!
-                            this.MaxBufferCapacity = 0;
-                            this.MaxStorageCapacity = 0;
-                        }
-                        else
-                        {
-                            this.MaxBufferCapacity = null;
-                            this.MaxStorageCapacity = null;
-                        }
-
-                        this.LogCapacityChanged();
-                        this.Apply();
-
-                        this.backoffLogicManager.ReportBackoffEnabled((int)httpWebResponse.StatusCode);
-                        this.Transmitter.Enqueue(e.Transmission);
-
-                        this.backoffLogicManager.ScheduleRestore(
-                            httpWebResponse.Headers, 
-                            () =>
-                                {
-                                    this.ResetPolicy();
-                                    return TaskEx.FromResult<object>(null);
-                                });
+                        // We start losing data!
+                        this.MaxBufferCapacity = 0;
+                        this.MaxStorageCapacity = 0;
                     }
+                    else
+                    {
+                        this.MaxBufferCapacity = null;
+                        this.MaxStorageCapacity = null;
+                    }
+
+                    this.LogCapacityChanged();
+                    this.Apply();
+
+                    this.backoffLogicManager.ReportBackoffEnabled((int)httpWebResponse.StatusCode);
+                    this.Transmitter.Enqueue(e.Transmission);
+
+                    this.backoffLogicManager.ScheduleRestore(
+                        httpWebResponse.RetryAfterHeader, 
+                        () =>
+                            {
+                                this.ResetPolicy();
+                                return TaskEx.FromResult<object>(null);
+                            });
                 }
             }
         }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionProcessedEventArgs.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionProcessedEventArgs.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
+    using System.Net;
 
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -9,6 +10,19 @@
     {
         public TransmissionProcessedEventArgs(Transmission transmission, Exception exception = null, HttpWebResponseWrapper response = null)
         {
+            // Fix missing arguments if not passed in
+            if (exception != null && response == null && exception is WebException &&
+                ((WebException)exception).Response is HttpWebResponse)
+            {
+                var excResponse = (HttpWebResponse)((WebException)exception).Response;
+                response = new HttpWebResponseWrapper()
+                {
+                    StatusCode = (int)excResponse.StatusCode,
+                    StatusDescription = excResponse.StatusDescription,
+                    RetryAfterHeader = excResponse.Headers?.Get("Retry-After")
+                };
+            }
+
             this.Transmission = transmission;
             this.Exception = exception;
             this.Response = response;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionProcessedEventArgs.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionProcessedEventArgs.cs
@@ -14,12 +14,12 @@
             if (exception != null && response == null && exception is WebException &&
                 ((WebException)exception).Response is HttpWebResponse)
             {
-                var excResponse = (HttpWebResponse)((WebException)exception).Response;
+                HttpWebResponse exceptionResponse = (HttpWebResponse)((WebException)exception).Response;
                 response = new HttpWebResponseWrapper()
                 {
-                    StatusCode = (int)excResponse.StatusCode,
-                    StatusDescription = excResponse.StatusDescription,
-                    RetryAfterHeader = excResponse.Headers?.Get("Retry-After")
+                    StatusCode = (int)exceptionResponse.StatusCode,
+                    StatusDescription = exceptionResponse.StatusDescription,
+                    RetryAfterHeader = exceptionResponse.Headers?.Get("Retry-After")
                 };
             }
 

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionSender.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionSender.cs
@@ -15,7 +15,7 @@
         private int transmissionCount = 0;
         private int capacity = 3;
 
-        private bool applyThrottle = true;
+        private bool applyThrottle = false;
         private int throttleWindowInMilliseconds = 1000;
         private long currentThrottleWindowId = 0;
         private int currentItemsCount = 0;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionSender.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionSender.cs
@@ -1,6 +1,10 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Net;
+    using System.Runtime.Serialization;
     using System.Threading;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
@@ -10,6 +14,12 @@
     {
         private int transmissionCount = 0;
         private int capacity = 3;
+
+        private bool applyThrottle = true;
+        private int throttleWindowInMilliseconds = 1000;
+        private long currentThrottleWindowId = 0;
+        private int currentItemsCount = 0;
+        private int throttleLimit = 10;
 
         public event EventHandler<TransmissionProcessedEventArgs> TransmissionSent;
 
@@ -38,6 +48,56 @@
                 this.capacity = value;
             }
         }
+
+        /// <summary>
+        /// Enables a limiter on the maximum number of <see cref="ITelemetry"/> objects that can be sent in a given throttle window.
+        /// Items attempted to be sent in excession of the local throttle amount will be treated the same as a backend throttle
+        /// </summary>
+        public virtual bool ApplyThrottle
+        {
+            get
+            {
+                return this.applyThrottle;
+            }
+
+            set
+            {
+                this.applyThrottle = value;
+            }
+        }
+
+        /// <summary>
+        /// Set the maximum number of items that will be allowed to send in a given throttle window.
+        /// </summary>
+        public virtual int ThrottleLimit
+        {
+            get
+            {
+                return this.throttleLimit;
+            }
+
+            set
+            {
+                this.throttleLimit = value;
+            }
+        }
+
+        /// <summary>
+        /// Set the size of the self-limiting throttle window in milliseconds
+        /// </summary>
+        public virtual int ThrottleWindow
+        {
+            get
+            {
+                return this.throttleWindowInMilliseconds;
+            }
+
+            set
+            {
+                this.throttleWindowInMilliseconds = value;
+            }
+        }
+
 
         public virtual bool Enqueue(Func<Transmission> transmissionGetter)
         {
@@ -86,10 +146,14 @@
             Exception exception = null;
             HttpWebResponseWrapper responseContent = null;
 
+            // Locally self-throttle this payload before we send it
+            Transmission acceptedTransmission = Throttle(transmission);
+
+            // Now that we've self-imposed a throttle, we can try to send the remaining data
             try
             {
-                TelemetryChannelEventSource.Log.TransmissionSendStarted(transmission.Id);
-                responseContent = await transmission.SendAsync().ConfigureAwait(false);          
+                TelemetryChannelEventSource.Log.TransmissionSendStarted(acceptedTransmission.Id);
+                responseContent = await acceptedTransmission.SendAsync().ConfigureAwait(false);          
             }
             catch (Exception e)
             {
@@ -100,15 +164,184 @@
                 int currentCapacity = Interlocked.Decrement(ref this.transmissionCount);
                 if (exception == null)
                 {
-                    TelemetryChannelEventSource.Log.TransmissionSentSuccessfully(transmission.Id, currentCapacity);
+                    TelemetryChannelEventSource.Log.TransmissionSentSuccessfully(acceptedTransmission.Id, currentCapacity);
+
+                    if (responseContent == null && exception is WebException)
+                    {
+                        var response = (HttpWebResponse)((WebException)exception).Response;
+                        responseContent = new HttpWebResponseWrapper()
+                        {
+                            StatusCode = (int)response.StatusCode,
+                            StatusDescription = response.StatusDescription,
+                            RetryAfterHeader = response.Headers.Get("Retry-After")
+                        };
+                    }
                 }
                 else
                 {
-                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(transmission.Id, exception.ToString());
+                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(acceptedTransmission.Id, exception.ToString());
                 }
 
-                this.OnTransmissionSent(new TransmissionProcessedEventArgs(transmission, exception, responseContent));
+                this.OnTransmissionSent(new TransmissionProcessedEventArgs(acceptedTransmission, exception, responseContent));
             }
+        }
+
+        /// <summary>
+        /// Checks if the transmission throttling policy allows for sending another request.
+        /// If so, this method will add a request to the current throttle count (unless peeking)
+        /// </summary>
+        /// <returns>The number of events that are sendable</returns>
+        private int IsTransmissionSendable(int numEvents = 1, bool peek = false)
+        {
+            if (!this.applyThrottle)
+            {
+                return numEvents;
+            }
+
+            var throttleWindowId = (long)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1)).TotalMilliseconds / this.ThrottleWindow);
+            var isInThrottleWindow = throttleWindowId == currentThrottleWindowId;
+            if (isInThrottleWindow && currentItemsCount < this.ThrottleLimit)
+            {
+                var numAccepted = Math.Min(numEvents, this.ThrottleLimit - this.currentItemsCount);
+                if (!peek)
+                {
+                    this.currentItemsCount += numAccepted;
+                }
+
+                return numAccepted;
+            }
+            else if (!isInThrottleWindow)
+            {
+                var numAccepted = Math.Min(numEvents, this.ThrottleLimit);
+                this.currentThrottleWindowId = throttleWindowId;
+                this.currentItemsCount = numAccepted;
+                return numAccepted;
+            }
+
+            return 0;
+        }
+
+        private Transmission Throttle(Transmission transmission)
+        {
+            if (!this.ApplyThrottle)
+            {
+                return transmission;
+            }
+
+            Transmission acceptedTransmission = transmission;
+            Transmission rejectedTransmission = null;
+            int attemptedItemsCount = -1;
+            int acceptedItemsCount = -1;
+
+            // We can be more efficient if we have a copy of the telemetry items still
+            if (transmission.TelemetryItems != null)
+            {
+                // We don't need to deserialize, we have a copy of each telemetry item
+                attemptedItemsCount = transmission.TelemetryItems.Count;
+                acceptedItemsCount = this.IsTransmissionSendable(transmission.TelemetryItems.Count);
+                if (acceptedItemsCount != transmission.TelemetryItems.Count)
+                {
+                    List<ITelemetry> acceptedItems = new List<ITelemetry>();
+                    List<ITelemetry> rejectedItems = new List<ITelemetry>();
+                    var i = 0;
+                    foreach (var item in transmission.TelemetryItems)
+                    {
+                        if (i < acceptedItemsCount)
+                        {
+                            acceptedItems.Add(item);
+                        }
+                        else
+                        {
+                            rejectedItems.Add(item);
+                        }
+                        i++;
+                    }
+
+                    acceptedTransmission = new Transmission(
+                        transmission.EndpointAddress,
+                        JsonSerializer.Serialize(acceptedItems),
+                        "application-x-json-stream",
+                        JsonSerializer.CompressionType);
+                    rejectedTransmission = new Transmission(
+                        transmission.EndpointAddress,
+                        JsonSerializer.Serialize(rejectedItems),
+                        "application-x-json-stream",
+                        JsonSerializer.CompressionType);
+                }
+            }
+            else
+            {
+                // We have to decode the payload in order to throttle
+                var compress = transmission.ContentEncoding == JsonSerializer.CompressionType;
+                string[] payloadItems = JsonSerializer
+                    .Deserialize(transmission.Content, compress)
+                    .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+
+                attemptedItemsCount = payloadItems.Length;
+                acceptedItemsCount = this.IsTransmissionSendable(payloadItems.Length);
+
+                if (acceptedItemsCount != payloadItems.Length)
+                {
+                    string acceptedItems = "";
+                    string rejectedItems = "";
+
+                    for (int i = 0; i < payloadItems.Length; i++)
+                    {
+                        if (i < acceptedItemsCount)
+                        {
+                            if (!string.IsNullOrEmpty(acceptedItems))
+                            {
+                                acceptedItems += Environment.NewLine;
+                            }
+                            acceptedItems += payloadItems[i];
+                        }
+                        else
+                        {
+                            if (!string.IsNullOrEmpty(rejectedItems))
+                            {
+                                rejectedItems += Environment.NewLine;
+                            }
+                            rejectedItems += payloadItems[i];
+                        }
+                    }
+
+                    acceptedTransmission = new Transmission(
+                        transmission.EndpointAddress,
+                        JsonSerializer.ConvertToByteArray(acceptedItems, compress),
+                        "application-x-json-stream",
+                        transmission.ContentEncoding);
+                    rejectedTransmission = new Transmission(
+                        transmission.EndpointAddress,
+                        JsonSerializer.ConvertToByteArray(rejectedItems, compress),
+                        "application-x-json-stream",
+                        transmission.ContentEncoding);
+                }
+            }
+
+            // Send rejected payload back for retry
+            if (rejectedTransmission != null)
+            {
+                TelemetryChannelEventSource.Log.TransmissionThrottledWarning(this.ThrottleLimit, attemptedItemsCount, acceptedItemsCount);
+                SendTransmissionThrottleRejection(rejectedTransmission);
+            }
+            
+            return acceptedTransmission;
+        }
+
+        private void SendTransmissionThrottleRejection(Transmission rejectedTransmission)
+        {
+            var exception = new WebException(
+                "Transmission was split by local throttling policy",
+                null,
+                System.Net.WebExceptionStatus.Success,
+                null
+            );
+            this.OnTransmissionSent(new TransmissionProcessedEventArgs(rejectedTransmission, exception, new HttpWebResponseWrapper()
+            {
+                StatusCode = ResponseStatusCodes.ResponseCodeTooManyRequests,
+                StatusDescription = "Internally Throttled",
+                RetryAfterHeader = null
+            }));
         }
     }
 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionSender.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TransmissionSender.cs
@@ -51,7 +51,7 @@
 
         /// <summary>
         /// Enables a limiter on the maximum number of <see cref="ITelemetry"/> objects that can be sent in a given throttle window.
-        /// Items attempted to be sent in excession of the local throttle amount will be treated the same as a backend throttle
+        /// Items attempted to be sent in excession of the local throttle amount will be treated the same as a backend throttle.
         /// </summary>
         public virtual bool ApplyThrottle
         {
@@ -83,7 +83,7 @@
         }
 
         /// <summary>
-        /// Set the size of the self-limiting throttle window in milliseconds
+        /// Set the size of the self-limiting throttle window in milliseconds.
         /// </summary>
         public virtual int ThrottleWindow
         {
@@ -173,7 +173,7 @@
 
                 if (responseContent == null && exception is WebException)
                 {
-                    var response = (HttpWebResponse)((WebException)exception).Response;
+                    HttpWebResponse response = (HttpWebResponse)((WebException)exception).Response;
                     responseContent = new HttpWebResponseWrapper()
                     {
                         StatusCode = (int)response.StatusCode,
@@ -230,7 +230,7 @@
 
             int attemptedItemsCount = -1;
             int acceptedItemsCount = -1;
-            var transmissions = transmission.Split((transmissionLength) => {
+            Tuple<Transmission,Transmission> transmissions = transmission.Split((transmissionLength) => {
                 attemptedItemsCount = transmissionLength;
                 acceptedItemsCount = this.IsTransmissionSendable(transmissionLength);
                 return acceptedItemsCount;
@@ -251,7 +251,7 @@
 
         private void SendTransmissionThrottleRejection(Transmission rejectedTransmission)
         {
-            var exception = new WebException(
+            WebException exception = new WebException(
                 "Transmission was split by local throttling policy",
                 null,
                 System.Net.WebExceptionStatus.Success,

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
@@ -99,6 +99,24 @@
             }
         }
 
+        public bool ApplyThrottle
+        {
+            get { return this.Sender.ApplyThrottle; }
+            set { this.Sender.ApplyThrottle = value; }
+        }
+
+        public int ThrottleLimit
+        {
+            get { return this.Sender.ThrottleLimit; }
+            set { this.Sender.ThrottleLimit = value; }
+        }
+
+        public int ThrottleWindow
+        {
+            get { return this.Sender.ThrottleWindow; }
+            set { this.Sender.ThrottleWindow = value; }
+        }
+
         public BackoffLogicManager BackoffLogicManager
         {
             get { return this.backoffLogicManager; }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -172,6 +172,34 @@
         }
 
         /// <summary>
+        /// Enables a limiter on the maximum number of <see cref="ITelemetry"/> objects that can be sent in a given throttle window.
+        /// Items attempted to be sent in excession of the local throttle amount will be treated the same as a backend throttle.
+        /// </summary>
+        public bool EnableLocalThrottling
+        {
+            get { return this.Transmitter.ApplyThrottle; }
+            set { this.Transmitter.ApplyThrottle = value; }
+        }
+
+        /// <summary>
+        /// Set the maximum number of items that will be allowed to send in a given throttle window.
+        /// </summary>
+        public int LocalThrottleLimit
+        {
+            get { return this.Transmitter.ThrottleLimit; }
+            set { this.Transmitter.ThrottleLimit = value; }
+        }
+
+        /// <summary>
+        /// Set the size of the self-limiting throttle window in milliseconds.
+        /// </summary>
+        public int LocalThrottleWindow
+        {
+            get { return this.Transmitter.ThrottleWindow; }
+            set { this.Transmitter.ThrottleWindow = value; }
+        }
+
+        /// <summary>
         /// Gets or sets first TelemetryProcessor in processor call chain.
         /// </summary>
         internal ITelemetryProcessor TelemetryProcessor


### PR DESCRIPTION
These changes extend the TransmissionSender to allow it to enforce a throttle on number of telemetry items sent to the backend. Various other files are changed to allow efficient splitting of Transmission objects where possible to help support these changes.