### PR TITLE
Bindu/sanitize rich event source

### DIFF
--- a/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -102,6 +102,7 @@
                     // The properties and layout should be the same as RequestData_types.cs
                     dummyRequestData.ver,
                     dummyRequestData.id,
+                    dummyRequestData.source,
                     dummyRequestData.name,
                     dummyRequestData.duration,
                     dummyRequestData.responseCode,
@@ -127,6 +128,7 @@
                         {
                             data.ver,
                             data.id,
+                            data.source,
                             data.name,
                             data.duration,
                             data.responseCode,

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -362,6 +362,7 @@
 
 #if !CORE_PCL
                 // logs rich payload ETW event for any partners to process it
+                telemetry.Sanitize();
                 RichPayloadEventSource.Log.Process(telemetry);
 #endif
             }


### PR DESCRIPTION
1. Sanitize telemetry item before log it as rich payload event #343 
2. When I ran unit test, I found RichPayloadEventSourceRequestSentTest failed as the previous commit 06adb3b5. Fixed the issue. 