### PR TITLE
Hand coded sanitization logic to match the bond schema, unit tests.

### DIFF
--- a/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -113,7 +113,7 @@
         {
             DependencyTelemetry telemetry = new DependencyTelemetry();
             telemetry.Name = new string('Z', Property.MaxNameLength + 1);
-            telemetry.Data = new string('Y', Property.MaxCommandNameLength + 1);
+            telemetry.Data = new string('Y', Property.MaxDataLength + 1);
             telemetry.Type = new string('D', Property.MaxDependencyTypeLength + 1);
             telemetry.Properties.Add(new string('X', Property.MaxDictionaryNameLength) + 'X', new string('X', Property.MaxValueLength + 1));
             telemetry.Properties.Add(new string('X', Property.MaxDictionaryNameLength) + 'Y', new string('X', Property.MaxValueLength + 1));
@@ -121,7 +121,7 @@
             ((ITelemetry)telemetry).Sanitize();
 
             Assert.Equal(new string('Z', Property.MaxNameLength), telemetry.Name);
-            Assert.Equal(new string('Y', Property.MaxCommandNameLength), telemetry.Data);
+            Assert.Equal(new string('Y', Property.MaxDataLength), telemetry.Data);
             Assert.Equal(new string('D', Property.MaxDependencyTypeLength), telemetry.Type);
 
             Assert.Equal(2, telemetry.Properties.Count);

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
@@ -9,6 +9,7 @@
     using Microsoft.VisualStudio.TestPlatform.UnitTestFramework;
 #endif
     using Assert = Xunit.Assert;
+    using DataContracts;
 
     [TestClass]
     public class PropertyTest
@@ -289,6 +290,82 @@
             original.SanitizeMeasurements();
 
             Assert.Equal(0, original["Key"]);
+        }
+
+        [TestMethod]
+        public void SanitizeTelemetryContextTest()
+        {            
+            var telemetryContext = new TelemetryContext();
+
+            var componentContext = telemetryContext.Component;
+            componentContext.Version = new string('Z', Property.MaxApplicationVersionLength + 1);
+
+            var deviceContext = telemetryContext.Device;
+            deviceContext.Id = new string('Z', Property.MaxDeviceIdLength + 1);
+            deviceContext.Model = new string('Z', Property.MaxDeviceModelLength + 1);
+            deviceContext.OemName = new string('Z', Property.MaxDeviceOemNameLength + 1);
+            deviceContext.OperatingSystem = new string('Z', Property.MaxDeviceOperatingSystemLength + 1);
+            deviceContext.Type = new string('Z', Property.MaxDeviceTypeLength + 1);
+
+            var locationContext = telemetryContext.Location;
+            locationContext.Ip = new string('Z', Property.MaxLocationIpLength + 1);
+
+            var operationContext = telemetryContext.Operation;
+            operationContext.Id = new string('Z', Property.MaxOperationIdLength + 1);
+            operationContext.Name = new string('Z', Property.MaxOperationNameLength + 1);
+            operationContext.ParentId = new string('Z', Property.MaxOperationParentIdLength + 1);
+            operationContext.SyntheticSource = new string('Z', Property.MaxOperationSyntheticSourceLength + 1);
+            operationContext.CorrelationVector = new string('Z', Property.MaxOperationCorrelationVectorLength + 1);
+
+            var sessionContext = telemetryContext.Session;
+            sessionContext.Id = new string('Z', Property.MaxSessionIdLength + 1);
+
+            var userContext = telemetryContext.User;
+            userContext.Id = new string('Z', Property.MaxUserIdLength + 1);
+            userContext.AccountId = new string('Z', Property.MaxUserAccountIdLength + 1);
+            userContext.UserAgent = new string('Z', Property.MaxUserAgentLength + 1);
+            userContext.AuthenticatedUserId = new string('Z', Property.MaxUserAuthenticatedIdLength + 1);
+
+            var cloudContext = telemetryContext.Cloud;
+            cloudContext.RoleName = new string('Z', Property.MaxCloudRoleNameLength + 1);
+            cloudContext.RoleInstance = new string('Z', Property.MaxCloudRoleInstanceLength + 1);
+
+            var internalContext = telemetryContext.Internal;
+            internalContext.SdkVersion = new string('Z', Property.MaxInternalSdkVersionLength + 1);
+            internalContext.AgentVersion = new string('Z', Property.MaxInternalAgentVersionLength + 1);
+            internalContext.NodeName = new string('Z', Property.MaxInternalNodeNameLength + 1);            
+
+            telemetryContext.SanitizeTelemetryContext();
+
+            Assert.Equal(new string('Z', Property.MaxApplicationVersionLength), componentContext.Version);
+
+            Assert.Equal(new string('Z', Property.MaxDeviceIdLength), deviceContext.Id);
+            Assert.Equal(new string('Z', Property.MaxDeviceModelLength), deviceContext.Model);
+            Assert.Equal(new string('Z', Property.MaxDeviceOemNameLength), deviceContext.OemName);
+            Assert.Equal(new string('Z', Property.MaxDeviceOperatingSystemLength), deviceContext.OperatingSystem);
+            Assert.Equal(new string('Z', Property.MaxDeviceTypeLength), deviceContext.Type);
+
+            Assert.Equal(new string('Z', Property.MaxLocationIpLength), locationContext.Ip);
+
+            Assert.Equal(new string('Z', Property.MaxOperationIdLength), operationContext.Id);
+            Assert.Equal(new string('Z', Property.MaxOperationNameLength), operationContext.Name);
+            Assert.Equal(new string('Z', Property.MaxOperationParentIdLength), operationContext.ParentId);
+            Assert.Equal(new string('Z', Property.MaxOperationSyntheticSourceLength), operationContext.SyntheticSource);
+            Assert.Equal(new string('Z', Property.MaxOperationCorrelationVectorLength), operationContext.CorrelationVector);
+
+            Assert.Equal(new string('Z', Property.MaxSessionIdLength), sessionContext.Id);
+
+            Assert.Equal(new string('Z', Property.MaxUserIdLength), userContext.Id);
+            Assert.Equal(new string('Z', Property.MaxUserAccountIdLength), userContext.AccountId);
+            Assert.Equal(new string('Z', Property.MaxUserAgentLength), userContext.UserAgent);
+            Assert.Equal(new string('Z', Property.MaxUserAuthenticatedIdLength), userContext.AuthenticatedUserId);
+
+            Assert.Equal(new string('Z', Property.MaxCloudRoleNameLength), cloudContext.RoleName);
+            Assert.Equal(new string('Z', Property.MaxCloudRoleInstanceLength), cloudContext.RoleInstance);
+
+            Assert.Equal(new string('Z', Property.MaxInternalSdkVersionLength), internalContext.SdkVersion);
+            Assert.Equal(new string('Z', Property.MaxInternalAgentVersionLength), internalContext.AgentVersion);
+            Assert.Equal(new string('Z', Property.MaxInternalNodeNameLength), internalContext.NodeName);            
         }
 
         private static IEnumerable<char> GetInvalidNameCharacters()

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
@@ -10,6 +10,7 @@
 #endif
     using Assert = Xunit.Assert;
     using DataContracts;
+    using External;
 
     [TestClass]
     public class PropertyTest
@@ -298,74 +299,74 @@
             var telemetryContext = new TelemetryContext();
 
             var componentContext = telemetryContext.Component;
-            componentContext.Version = new string('Z', Property.MaxApplicationVersionLength + 1);
+            componentContext.Version = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.ApplicationVersion]+ 1);
 
             var deviceContext = telemetryContext.Device;
-            deviceContext.Id = new string('Z', Property.MaxDeviceIdLength + 1);
-            deviceContext.Model = new string('Z', Property.MaxDeviceModelLength + 1);
-            deviceContext.OemName = new string('Z', Property.MaxDeviceOemNameLength + 1);
-            deviceContext.OperatingSystem = new string('Z', Property.MaxDeviceOperatingSystemLength + 1);
-            deviceContext.Type = new string('Z', Property.MaxDeviceTypeLength + 1);
+            deviceContext.Id = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceId] + 1);
+            deviceContext.Model = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceModel] + 1);
+            deviceContext.OemName = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOEMName] + 1);
+            deviceContext.OperatingSystem = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOSVersion] + 1);
+            deviceContext.Type = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceType] + 1);
 
             var locationContext = telemetryContext.Location;
-            locationContext.Ip = new string('Z', Property.MaxLocationIpLength + 1);
+            locationContext.Ip = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.LocationIp] + 1);
 
             var operationContext = telemetryContext.Operation;
-            operationContext.Id = new string('Z', Property.MaxOperationIdLength + 1);
-            operationContext.Name = new string('Z', Property.MaxOperationNameLength + 1);
-            operationContext.ParentId = new string('Z', Property.MaxOperationParentIdLength + 1);
-            operationContext.SyntheticSource = new string('Z', Property.MaxOperationSyntheticSourceLength + 1);
-            operationContext.CorrelationVector = new string('Z', Property.MaxOperationCorrelationVectorLength + 1);
+            operationContext.Id = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationId] + 1);
+            operationContext.Name = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationName] + 1);
+            operationContext.ParentId = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationParentId] + 1);
+            operationContext.SyntheticSource = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationSyntheticSource] + 1);
+            operationContext.CorrelationVector = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationCorrelationVector] + 1);
 
             var sessionContext = telemetryContext.Session;
-            sessionContext.Id = new string('Z', Property.MaxSessionIdLength + 1);
+            sessionContext.Id = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.SessionId] + 1);
 
             var userContext = telemetryContext.User;
-            userContext.Id = new string('Z', Property.MaxUserIdLength + 1);
-            userContext.AccountId = new string('Z', Property.MaxUserAccountIdLength + 1);
-            userContext.UserAgent = new string('Z', Property.MaxUserAgentLength + 1);
-            userContext.AuthenticatedUserId = new string('Z', Property.MaxUserAuthenticatedIdLength + 1);
+            userContext.Id = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserId] + 1);
+            userContext.AccountId = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAccountId] + 1);
+            userContext.UserAgent = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAgent] + 1);
+            userContext.AuthenticatedUserId = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAuthUserId] + 1);
 
             var cloudContext = telemetryContext.Cloud;
-            cloudContext.RoleName = new string('Z', Property.MaxCloudRoleNameLength + 1);
-            cloudContext.RoleInstance = new string('Z', Property.MaxCloudRoleInstanceLength + 1);
+            cloudContext.RoleName = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRole] + 1);
+            cloudContext.RoleInstance = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRoleInstance] + 1);
 
             var internalContext = telemetryContext.Internal;
-            internalContext.SdkVersion = new string('Z', Property.MaxInternalSdkVersionLength + 1);
-            internalContext.AgentVersion = new string('Z', Property.MaxInternalAgentVersionLength + 1);
-            internalContext.NodeName = new string('Z', Property.MaxInternalNodeNameLength + 1);            
+            internalContext.SdkVersion = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalSdkVersion] + 1);
+            internalContext.AgentVersion = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalAgentVersion] + 1);
+            internalContext.NodeName = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalNodeName] + 1);            
 
             telemetryContext.SanitizeTelemetryContext();
 
-            Assert.Equal(new string('Z', Property.MaxApplicationVersionLength), componentContext.Version);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.ApplicationVersion]), componentContext.Version);
 
-            Assert.Equal(new string('Z', Property.MaxDeviceIdLength), deviceContext.Id);
-            Assert.Equal(new string('Z', Property.MaxDeviceModelLength), deviceContext.Model);
-            Assert.Equal(new string('Z', Property.MaxDeviceOemNameLength), deviceContext.OemName);
-            Assert.Equal(new string('Z', Property.MaxDeviceOperatingSystemLength), deviceContext.OperatingSystem);
-            Assert.Equal(new string('Z', Property.MaxDeviceTypeLength), deviceContext.Type);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceId]), deviceContext.Id);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceModel]), deviceContext.Model);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOEMName]), deviceContext.OemName);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOSVersion]), deviceContext.OperatingSystem);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceType]), deviceContext.Type);
 
-            Assert.Equal(new string('Z', Property.MaxLocationIpLength), locationContext.Ip);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.LocationIp]), locationContext.Ip);
 
-            Assert.Equal(new string('Z', Property.MaxOperationIdLength), operationContext.Id);
-            Assert.Equal(new string('Z', Property.MaxOperationNameLength), operationContext.Name);
-            Assert.Equal(new string('Z', Property.MaxOperationParentIdLength), operationContext.ParentId);
-            Assert.Equal(new string('Z', Property.MaxOperationSyntheticSourceLength), operationContext.SyntheticSource);
-            Assert.Equal(new string('Z', Property.MaxOperationCorrelationVectorLength), operationContext.CorrelationVector);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationId]), operationContext.Id);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationName]), operationContext.Name);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationParentId]), operationContext.ParentId);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationSyntheticSource]), operationContext.SyntheticSource);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationCorrelationVector]), operationContext.CorrelationVector);
 
-            Assert.Equal(new string('Z', Property.MaxSessionIdLength), sessionContext.Id);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.SessionId]), sessionContext.Id);
 
-            Assert.Equal(new string('Z', Property.MaxUserIdLength), userContext.Id);
-            Assert.Equal(new string('Z', Property.MaxUserAccountIdLength), userContext.AccountId);
-            Assert.Equal(new string('Z', Property.MaxUserAgentLength), userContext.UserAgent);
-            Assert.Equal(new string('Z', Property.MaxUserAuthenticatedIdLength), userContext.AuthenticatedUserId);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserId]), userContext.Id);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAccountId]), userContext.AccountId);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAgent]), userContext.UserAgent);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAuthUserId]), userContext.AuthenticatedUserId);
 
-            Assert.Equal(new string('Z', Property.MaxCloudRoleNameLength), cloudContext.RoleName);
-            Assert.Equal(new string('Z', Property.MaxCloudRoleInstanceLength), cloudContext.RoleInstance);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRole]), cloudContext.RoleName);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRoleInstance]), cloudContext.RoleInstance);
 
-            Assert.Equal(new string('Z', Property.MaxInternalSdkVersionLength), internalContext.SdkVersion);
-            Assert.Equal(new string('Z', Property.MaxInternalAgentVersionLength), internalContext.AgentVersion);
-            Assert.Equal(new string('Z', Property.MaxInternalNodeNameLength), internalContext.NodeName);            
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalSdkVersion]), internalContext.SdkVersion);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalAgentVersion]), internalContext.AgentVersion);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalNodeName]), internalContext.NodeName);            
         }
 
         private static IEnumerable<char> GetInvalidNameCharacters()

--- a/src/Core/Managed/Shared/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/AvailabilityTelemetry.cs
@@ -157,6 +157,8 @@
 
             this.Data.properties.SanitizeProperties();
             this.Data.measurements.SanitizeMeasurements();
+
+            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
@@ -238,10 +238,11 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.Name = this.Name.SanitizeName();
             this.Name = Utils.PopulateRequiredStringValue(this.Name, "name", typeof(DependencyTelemetry).FullName);
             this.Id.SanitizeName();
-            this.ResultCode = this.ResultCode.SanitizeValue();
+            this.ResultCode = this.ResultCode.SanitizeResultCode();
             this.Type = this.Type.SanitizeDependencyType();
-            this.Data = this.Data.SanitizeCommandName();
+            this.Data = this.Data.SanitizeData();
             this.Properties.SanitizeProperties();
+            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
@@ -99,6 +99,7 @@
             this.Name = Utils.PopulateRequiredStringValue(this.Name, "name", typeof(EventTelemetry).FullName);
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
+            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
@@ -178,6 +178,7 @@
             // Sanitize on the ExceptionDetails stack information for raw stack and parsed stack is done while creating the object in ExceptionConverter.cs
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
+            this.Context.SanitizeTelemetryContext();
         }
 
         private void ConvertExceptionTree(Exception exception, ExceptionDetails parentExceptionDetails, List<ExceptionDetails> exceptions)

--- a/src/Core/Managed/Shared/DataContracts/MetricTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/MetricTelemetry.cs
@@ -178,6 +178,8 @@
             {
                 this.StandardDeviation = Utils.SanitizeNanAndInfinity(this.StandardDeviation.Value);
             }
+
+            this.Context.SanitizeTelemetryContext();
         }
 
         private void UpdateKind() 

--- a/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
@@ -145,6 +145,7 @@
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
             this.Url = this.Url.SanitizeUri();
+            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -234,6 +234,8 @@
                     this.Success = true;
                 }
             }
+
+            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
@@ -106,6 +106,7 @@
             this.Data.message = this.Data.message.SanitizeMessage();
             this.Data.message = Utils.PopulateRequiredStringValue(this.Data.message, "message", typeof(TraceTelemetry).FullName);
             this.Data.properties.SanitizeProperties();
+            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
@@ -8,7 +8,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
     using System.Collections.Generic;
     using System.Globalization;
     using System.Linq;
-    
+    using Microsoft.ApplicationInsights.DataContracts;
+
     /// <summary>
     /// A helper class for implementing properties of telemetry and context classes.
     /// </summary>
@@ -17,14 +18,38 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         public const int MaxDictionaryNameLength = 150;
         public const int MaxDependencyTypeLength = 1024;
         public const int MaxValueLength = 8 * 1024;
+        public const int MaxResultCodeLength = 1024;
         public const int MaxEventNameLength = 512;
         public const int MaxNameLength = 1024;
         public const int MaxMessageLength = 32768;
         public const int MaxUrlLength = 2048;
-        public const int MaxCommandNameLength = 2 * 1024;
+        public const int MaxDataLength = 8 * 1024;
         public const int MaxTestNameLength = 1024;
         public const int MaxRunLocationLength = 2024;
         public const int MaxAvailabilityMessageLength = 8192;
+        public const int MaxApplicationVersionLength = 1024;
+        public const int MaxDeviceIdLength = 1024;
+        public const int MaxDeviceModelLength = 256;
+        public const int MaxDeviceOemNameLength = 256;
+        public const int MaxDeviceOperatingSystemLength = 256;
+        public const int MaxDeviceTypeLength = 64;
+        public const int MaxLocationIpLength = 45;
+        public const int MaxOperationIdLength = 128;
+        public const int MaxOperationNameLength = 1024;
+        public const int MaxOperationParentIdLength = 128;
+        public const int MaxOperationSyntheticSourceLength = 1024;
+        public const int MaxOperationCorrelationVectorLength = 64;
+        public const int MaxSessionIdLength = 64;
+        public const int MaxSessionIsFirstLength = 5;
+        public const int MaxUserIdLength = 128;
+        public const int MaxUserAccountIdLength = 1024;
+        public const int MaxUserAuthenticatedIdLength = 1024;
+        public const int MaxUserAgentLength = 2048;
+        public const int MaxCloudRoleNameLength = 256;
+        public const int MaxCloudRoleInstanceLength = 256;
+        public const int MaxInternalSdkVersionLength = 64;
+        public const int MaxInternalAgentVersionLength = 64;
+        public const int MaxInternalNodeNameLength = 256;
 
         public static void Set<T>(ref T property, T value) where T : class
         {
@@ -67,6 +92,11 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return TrimAndTruncate(value, Property.MaxDependencyTypeLength);
         }
 
+        public static string SanitizeResultCode(this string value)
+        {
+            return TrimAndTruncate(value, Property.MaxResultCodeLength);
+        }
+
         public static string SanitizeValue(this string value)
         {
             return TrimAndTruncate(value, Property.MaxValueLength);
@@ -77,9 +107,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return TrimAndTruncate(message, Property.MaxMessageLength);
         }
 
-        public static string SanitizeCommandName(this string message)
+        public static string SanitizeData(this string message)
         {
-            return TrimAndTruncate(message, Property.MaxCommandNameLength);
+            return TrimAndTruncate(message, Property.MaxDataLength);
         }
 
         public static Uri SanitizeUri(this Uri uri)
@@ -119,6 +149,18 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         {
             return TrimAndTruncate(value, Property.MaxAvailabilityMessageLength);
         }
+
+        public static void SanitizeTelemetryContext(this TelemetryContext telemetryContext)
+        {
+            SanitizeComponentContext(telemetryContext.Component);            
+            SanitizeDeviceContext(telemetryContext.Device);
+            SanitizeLocationContext(telemetryContext.Location);                                    
+            SanitizeOperationContext(telemetryContext.Operation);            
+            SanitizeSessionContext(telemetryContext.Session); 
+            SanitizeUserContext(telemetryContext.User);
+            SanitizeCloudContext(telemetryContext.Cloud);
+            SanitizeInternalContext(telemetryContext.Internal);                        
+        }        
 
         public static void SanitizeProperties(this IDictionary<string, string> dictionary)
         {
@@ -221,6 +263,60 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             }
 
             return key;
+        }
+
+        private static void SanitizeComponentContext(ComponentContext componentContext)
+        {
+            componentContext.Version = TrimAndTruncate(componentContext.Version, Property.MaxApplicationVersionLength);
+        }
+
+        private static void SanitizeDeviceContext(DeviceContext deviceContext)
+        {
+            deviceContext.Id = TrimAndTruncate(deviceContext.Id, Property.MaxDeviceIdLength);
+            deviceContext.Model = TrimAndTruncate(deviceContext.Model, Property.MaxDeviceModelLength);
+            deviceContext.OemName = TrimAndTruncate(deviceContext.OemName, Property.MaxDeviceOemNameLength);
+            deviceContext.OperatingSystem = TrimAndTruncate(deviceContext.OperatingSystem, Property.MaxDeviceOperatingSystemLength);
+            deviceContext.Type = TrimAndTruncate(deviceContext.Type, Property.MaxDeviceTypeLength);
+        }
+
+        private static void SanitizeLocationContext(LocationContext locationContext)
+        {
+            locationContext.Ip = TrimAndTruncate(locationContext.Ip, Property.MaxLocationIpLength);
+        }
+
+        private static void SanitizeOperationContext(OperationContext operationContext)
+        {
+            operationContext.Id = TrimAndTruncate(operationContext.Id, Property.MaxOperationIdLength);
+            operationContext.Name = TrimAndTruncate(operationContext.Name, Property.MaxOperationNameLength);
+            operationContext.ParentId = TrimAndTruncate(operationContext.ParentId, Property.MaxOperationParentIdLength);
+            operationContext.SyntheticSource = TrimAndTruncate(operationContext.SyntheticSource, Property.MaxOperationSyntheticSourceLength);
+            operationContext.CorrelationVector = TrimAndTruncate(operationContext.CorrelationVector, Property.MaxOperationCorrelationVectorLength);
+        }
+
+        private static void SanitizeSessionContext(SessionContext sessionContext)
+        {
+            sessionContext.Id = TrimAndTruncate(sessionContext.Id, Property.MaxSessionIdLength);
+        }
+
+        private static void SanitizeUserContext(UserContext userContext)
+        {
+            userContext.Id = TrimAndTruncate(userContext.Id, Property.MaxUserIdLength);
+            userContext.AccountId = TrimAndTruncate(userContext.AccountId, Property.MaxUserAccountIdLength);
+            userContext.UserAgent = TrimAndTruncate(userContext.UserAgent, Property.MaxUserAgentLength);
+            userContext.AuthenticatedUserId = TrimAndTruncate(userContext.AuthenticatedUserId, Property.MaxUserAuthenticatedIdLength);
+        }
+
+        private static void SanitizeCloudContext(CloudContext cloudContext)
+        {
+            cloudContext.RoleName = TrimAndTruncate(cloudContext.RoleName, Property.MaxCloudRoleNameLength);
+            cloudContext.RoleInstance = TrimAndTruncate(cloudContext.RoleInstance, Property.MaxCloudRoleInstanceLength);
+        }
+
+        private static void SanitizeInternalContext(InternalContext internalContext)
+        {
+            internalContext.SdkVersion = TrimAndTruncate(internalContext.SdkVersion, Property.MaxInternalSdkVersionLength);
+            internalContext.AgentVersion = TrimAndTruncate(internalContext.AgentVersion, Property.MaxInternalAgentVersionLength);
+            internalContext.NodeName = TrimAndTruncate(internalContext.NodeName, Property.MaxInternalNodeNameLength);
         }
     }
 }


### PR DESCRIPTION
Hand coded sanitization logic to match the bond schema, unit tests. This is Short-Term fix until we fully implement auto generation of sanitization logic from bond schema.