### PR TITLE
Refactor TaskTimer

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/Tracing/DiagnoisticsEventThrottlingSchedulerTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/Tracing/DiagnoisticsEventThrottlingSchedulerTest.cs
@@ -5,17 +5,12 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
-    public sealed class DiagnoisticsEventThrottlingSchedulerTest : IDisposable
+    public sealed class DiagnoisticsEventThrottlingSchedulerTest
     {
         private const int SchedulingRoutineRunInterval = 10;
         private const int ExecuteTimes = 3;
 
         private readonly DiagnoisticsEventThrottlingScheduler scheduler = new DiagnoisticsEventThrottlingScheduler();
-
-        public void Dispose()
-        {
-            this.scheduler.Dispose();
-        }
 
         [TestMethod]
         public void TestStateAfterInitialization()

--- a/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimer.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimer.cs
@@ -21,8 +21,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
     {
         private class DelayedWork
         {
-            public DelayedWork(Func<Task> runFunc) { this.RunFunc = runFunc; this.IsCancellationRequested = false; }
-            public Func<Task> RunFunc { get; private set; }
+            public DelayedWork(Func<Task> runWhenElapsedFunc) { this.RunWhenElapsedFunc = runWhenElapsedFunc; this.IsCancellationRequested = false; }
+            public Func<Task> RunWhenElapsedFunc { get; private set; }
             public bool IsCancellationRequested { get; set; }
         }
 
@@ -96,10 +96,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                         try
                         {
-                            // Task may (or may not) be executed syncronously
-                            Task task = (delayedWork.RunFunc == null)
-                                                ? null
-                                                : delayedWork.RunFunc();
+                            // If the delegate parameter was null, we will now throw and log.
+                            // Note, ask may (or may not) be executed syncronously.
+                            Task task = delayedWork.RunWhenElapsedFunc();
 
                             // Just in case we check for null if someone returned null
                             if (task == null)
@@ -147,6 +146,15 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             {
                 currentWork.IsCancellationRequested = true;
             }
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        [Obsolete("This class does no longer implement IDisposable. Dispose() is deprecated. Use Cancel() instead.", error: false)] 
+        public void Dispose()
+        {
+            Cancel();
         }
 
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/DiagnoisticsEventThrottlingScheduler.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/DiagnoisticsEventThrottlingScheduler.cs
@@ -14,15 +14,9 @@
 #endif
 
     internal class DiagnoisticsEventThrottlingScheduler 
-        : IDiagnoisticsEventThrottlingScheduler, IDisposable
+        : IDiagnoisticsEventThrottlingScheduler
     {
         private readonly IList<TaskTimer> timers = new List<TaskTimer>();
-        private volatile bool disposed = false;
-
-        ~DiagnoisticsEventThrottlingScheduler()
-        {
-            this.Dispose(false);
-        }
 
         public ICollection<object> Tokens
         {
@@ -69,28 +63,10 @@
 
             if (this.timers.Remove(timer))
             {
-                DisposeTimer(timer);
-
                 CoreEventSource.Log.DiagnoisticsEventThrottlingSchedulerTimerWasRemoved();
             }
         }
 
-        public void Dispose()
-        {
-            this.Dispose(true);
-        }
-
-        private static void DisposeTimer(IDisposable timer)
-        {
-            try
-            {
-                timer.Dispose();
-            }
-            catch (Exception exc)
-            {
-                CoreEventSource.Log.DiagnoisticsEventThrottlingSchedulerDisposeTimerFailure(exc.ToInvariantString());
-            }
-        }
 
         private static TaskTimer InternalCreateAndStartTimer(
             int intervalInMilliseconds,
@@ -113,28 +89,6 @@
             timer.Start(task);
 
             return timer;
-        }
-
-        private void Dispose(bool managed)
-        {
-            if (managed && !this.disposed)
-            {
-                this.DisposeAllTimers();
-
-                GC.SuppressFinalize(this);
-            }
-
-            this.disposed = true;
-        }
-
-        private void DisposeAllTimers()
-        {
-            foreach (var timer in this.timers)
-            {
-                DisposeTimer(timer);
-            }
-
-            this.timers.Clear();
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModule.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModule.cs
@@ -158,8 +158,6 @@
             if (managed && !this.disposed)
             {
                 this.EventListener.Dispose();
-                (this.throttlingScheduler as IDisposable).Dispose();
-
                 GC.SuppressFinalize(this);
             }
 

--- a/src/Core/Managed/Shared/Extensibility/MetricManager.cs
+++ b/src/Core/Managed/Shared/Extensibility/MetricManager.cs
@@ -119,12 +119,6 @@
         /// </summary>
         public void Dispose()
         {
-            if (this.snapshotTimer != null)
-            {
-                this.snapshotTimer.Dispose();
-                this.snapshotTimer = null;
-            }
-
             this.Flush();
         }
 

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
@@ -12,7 +12,7 @@
     using TaskEx = System.Threading.Tasks.Task;
 #endif
 
-    internal class BackoffLogicManager : IDisposable
+    internal class BackoffLogicManager
     {
         private const int SlotDelayInSeconds = 10;
         private const int MaxDelayInSeconds = 3600;
@@ -156,11 +156,6 @@
             }
         }
 
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
 
         // Calculates the time to wait before retrying in case of an error based on
         // http://en.wikipedia.org/wiki/Exponential_backoff
@@ -217,18 +212,6 @@
             TelemetryChannelEventSource.Log.TransmissionPolicyRetryAfterParseFailedWarning(retryAfter);
 
             return false;
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (this.pauseTimer != null)
-                {
-                    this.pauseTimer.Dispose();
-                    this.pauseTimer = null;
-                }
-            }
         }
     }
 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -14,7 +14,7 @@
     /// <summary>
     /// Accumulates <see cref="ITelemetry"/> items for efficient transmission.
     /// </summary>
-    internal class TelemetryBuffer : IEnumerable<ITelemetry>, ITelemetryProcessor, IDisposable
+    internal class TelemetryBuffer : IEnumerable<ITelemetry>, ITelemetryProcessor
     {
         private static readonly TimeSpan DefaultFlushDelay = TimeSpan.FromSeconds(30);
 
@@ -76,14 +76,6 @@
             set { this.flushTimer.Delay = value; }
         }
 
-        /// <summary>
-        /// Releases resources used by this <see cref="TelemetryBuffer"/> instance.
-        /// </summary>
-        public void Dispose()
-        {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
-        }
         
         /// <summary>
         /// Processes the specified <paramref name="item"/> item.
@@ -154,14 +146,6 @@
         private void HandleApplicationStoppingEvent(object sender, ApplicationStoppingEventArgs e)
         {
             e.Run(this.FlushAsync);
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                this.flushTimer.Dispose();
-            }
         }
     }
 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
@@ -316,11 +316,6 @@
                     policy.Dispose();
                 }
 
-                if (this.backoffLogicManager != null)
-                {
-                    this.backoffLogicManager.Dispose();
-                }
-
                 if (this.Storage != null)
                 {
                     this.Storage.Dispose();

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -227,7 +227,6 @@
         public void Dispose()
         {   
             // Tested by FxCop rule CA2213
-            this.TelemetryBuffer.Dispose();
             this.Transmitter.Dispose();
         }
 


### PR DESCRIPTION
Hi folks,

After some discussions with Vitaly and Oleg, my goal is to improve on some of the background processing code in the SDK, specifically around the TaskTimer class.
There are several issues with that class. An instance of it is a mix between something that represents one work item and something that is used to start multiple work items. As a result both, usage and code and confusing. But the first improvement I would like to make is making it non-disposable. For that, I am making cancellation less aggressive and removing the cancellation token source, which was the reason for being disposable. I also checked all usages and removed IDisposable from all classes  where TaskTimer was the only requirement for that interface.
