### PR TITLE
Removed sanitize() from TelemetryClient.Track() 

### DIFF
--- a/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Core/Managed/Net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -117,6 +117,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as RequestTelemetry;
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -171,6 +172,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as TraceTelemetry;
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -219,6 +221,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as EventTelemetry;
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -274,6 +277,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as DependencyTelemetry;
                     var data = telemetryItem.InternalData;
                     var extendedData = new
@@ -342,6 +346,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as MetricTelemetry;
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -426,6 +431,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as ExceptionTelemetry;
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -505,6 +511,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
 #pragma warning disable 618
                     var telemetryItem = (item as PerformanceCounterTelemetry).Data;
 #pragma warning restore 618
@@ -565,6 +572,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
                     var telemetryItem = item as PageViewTelemetry;
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -615,6 +623,7 @@
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {
+                    item.Sanitize();
 #pragma warning disable 618
                     var telemetryItem = (item as SessionStateTelemetry).Data;
 #pragma warning restore 618

--- a/src/Core/Managed/Net46/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Core/Managed/Net46/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -53,6 +53,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as RequestTelemetry;
                 this.WriteEvent(
                     RequestTelemetry.TelemetryName,
@@ -68,6 +69,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as TraceTelemetry;
                 this.WriteEvent(
                     TraceTelemetry.TelemetryName,
@@ -83,6 +85,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as EventTelemetry;
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
@@ -98,6 +101,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as DependencyTelemetry;
                 this.WriteEvent(
                     DependencyTelemetry.TelemetryName,
@@ -113,6 +117,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as MetricTelemetry;
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
@@ -128,6 +133,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as ExceptionTelemetry;
                 this.WriteEvent(
                     ExceptionTelemetry.TelemetryName,
@@ -144,6 +150,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = (item as PerformanceCounterTelemetry).Data;
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
@@ -160,6 +167,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as PageViewTelemetry;
                 this.WriteEvent(
                     PageViewTelemetry.TelemetryName,
@@ -176,6 +184,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = (item as SessionStateTelemetry).Data;
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
@@ -191,6 +200,7 @@
                     return;
                 }
 
+                item.Sanitize();
                 var telemetryItem = item as AvailabilityTelemetry;
                 this.WriteEvent(
                     AvailabilityTelemetry.TelemetryName,

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -359,8 +359,7 @@
                 this.configuration.TelemetryProcessorChain.Process(telemetry);
 
 #if !CORE_PCL
-                // logs rich payload ETW event for any partners to process it
-                telemetry.Sanitize();
+                // logs rich payload ETW event for any partners to process it                
                 RichPayloadEventSource.Log.Process(telemetry);
 #endif
             }


### PR DESCRIPTION
Removed sanitize() call from Track() method to avoid unnecessary perf hit if RichEventPayloadSource is not enabled. Sanitize() is invoked after checking if the event source is enabled.

Fix for this issue, 
https://github.com/Microsoft/ApplicationInsights-dotnet/issues/393

And may be this issue as well as this could be leading to the high memory (but that will be investigated anyway):
https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/227