### PR TITLE
Adding property (sdk version) to signify metric was created using metric manager

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/SdkVersionUtils.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/SdkVersionUtils.cs
@@ -1,0 +1,34 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Globalization;
+    using System.Linq;
+    using System.Reflection;
+
+    internal class SdkVersionUtils
+    {
+        /// <summary>
+        /// Builds a string representing file version of the assembly with added prefix
+        /// in format prefix:major.minor-revision.
+        /// </summary>
+        /// <param name="versionPrefix">Prefix to add to version.</param>
+        /// <returns>String representation of the version with prefix added.</returns>
+        internal static string GetSdkVersion(string versionPrefix)
+        {
+#if !CORE_PCL
+            string versionStr = typeof(TelemetryClient).Assembly.GetCustomAttributes(false)
+                    .OfType<AssemblyFileVersionAttribute>()
+                    .First()
+                    .Version;
+            
+#else
+            string versionStr = typeof(TelemetryClient).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyFileVersionAttribute>()
+                    .First()
+                    .Version;
+#endif
+
+            Version version = new Version(versionStr);
+            return versionPrefix + version.ToString(3) + "-" + version.Revision;
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/MetricManager.cs
+++ b/src/Core/Managed/Shared/Extensibility/MetricManager.cs
@@ -122,7 +122,6 @@
             if (this.snapshotTimer != null)
             {
                 this.snapshotTimer.Dispose();
-                this.snapshotTimer = null;
             }
 
             this.Flush();

--- a/src/Core/Managed/Shared/Extensibility/MetricManager.cs
+++ b/src/Core/Managed/Shared/Extensibility/MetricManager.cs
@@ -26,6 +26,11 @@
         private static string intervalDurationPropertyName = "IntervalDurationMs";
 
         /// <summary>
+        /// Value of the property indicating 'app insights version' allowing to tell metric was built using metric manager.
+        /// </summary>
+        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("m-agg:");
+
+        /// <summary>
         /// Reporting frequency.
         /// </summary>
         private static TimeSpan aggregationPeriod = TimeSpan.FromMinutes(1);
@@ -65,6 +70,7 @@
         public MetricManager(TelemetryClient client)
         {
             this.telemetryClient = client ?? new TelemetryClient();
+
             this.metricDictionary = new ConcurrentDictionary<Metric, SimpleMetricStatisticsAggregator>();
 
             this.lastSnapshotStartDateTime = DateTimeOffset.UtcNow;
@@ -175,6 +181,10 @@
                 }
             }
 
+            // add a header allowing to distinguish metrics
+            // built using metric manager from other metrics
+            telemetry.Context.GetInternalContext().SdkVersion = sdkVersionPropertyValue;
+            
             return telemetry;
         }
 

--- a/src/Core/Managed/Shared/Extensibility/MetricManager.cs
+++ b/src/Core/Managed/Shared/Extensibility/MetricManager.cs
@@ -119,11 +119,7 @@
         /// </summary>
         public void Dispose()
         {
-            if (this.snapshotTimer != null)
-            {
-                this.snapshotTimer.Dispose();
-            }
-
+            this.snapshotTimer.Dispose();
             this.Flush();
         }
 

--- a/src/Core/Managed/Shared/Shared.projitems
+++ b/src/Core/Managed/Shared/Shared.projitems
@@ -59,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\External\SeverityLevel_types.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\External\StackFrame_types.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\HttpWebResponseWrapper.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SdkVersionUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SimpleMetricStatisticsAggregator.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TelemetryDebugWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CloudContext.cs" />

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -428,7 +428,7 @@
             // Currenly backend requires SDK version to comply "name: version"
             if (string.IsNullOrEmpty(telemetry.Context.Internal.SdkVersion))
             {
-                var version = LazyInitializer.EnsureInitialized(ref this.sdkVersion, this.GetSdkVersion);
+                var version = LazyInitializer.EnsureInitialized(ref this.sdkVersion, () => SdkVersionUtils.GetSdkVersion(VersionPrefix));
                 telemetry.Context.Internal.SdkVersion = version;
             }
 
@@ -501,24 +501,6 @@
         public void Flush()
         {
             this.configuration.TelemetryChannel.Flush();
-        }
-
-        private string GetSdkVersion()
-        {
-#if !CORE_PCL
-            string versionStr = typeof(TelemetryClient).Assembly.GetCustomAttributes(false)
-                    .OfType<AssemblyFileVersionAttribute>()
-                    .First()
-                    .Version;
-            
-#else
-            string versionStr = typeof(TelemetryClient).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyFileVersionAttribute>()
-                    .First()
-                    .Version;
-#endif
-
-            Version version = new Version(versionStr);
-            return VersionPrefix + version.ToString(3) + "-" + version.Revision;
         }
     }
 }


### PR DESCRIPTION
In this PR `MetricManager` sets special value into Sdk Version property of context such that we can tell if metric telemetry was created using `MetricManager`. 
The reason is that we want to know how many people use that approach. SdkVersion 'game' we play here is a standard way to measure exactly these things used by Web Sdk already, so, we're just re-using the approach.