### PR TITLE
Add ability to load Enum-valued configuration properties

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -295,6 +295,32 @@
         }
 
         [TestMethod]
+        public void LoadInstanceHandlesEnumPropertiesWithNumericValue()
+        {
+            var definition = new XElement(
+                "Definition",
+                new XElement("EnumProperty", "3"));
+
+            var original = new StubClassWithProperties();
+            object instance = TestableTelemetryConfigurationFactory.LoadInstance(definition, typeof(StubClassWithProperties), original, null);
+
+            Assert.Equal(System.Diagnostics.Tracing.EventLevel.Warning, original.EnumProperty);
+        }
+
+        [TestMethod]
+        public void LoadInstanceHandlesEnumPropertiesWithEnumerationValueName()
+        {
+            var definition = new XElement(
+                "Definition",
+                new XElement("EnumProperty", "Informational"));
+
+            var original = new StubClassWithProperties();
+            object instance = TestableTelemetryConfigurationFactory.LoadInstance(definition, typeof(StubClassWithProperties), original, null);
+
+            Assert.Equal(System.Diagnostics.Tracing.EventLevel.Informational, original.EnumProperty);
+        }
+
+        [TestMethod]
         public void LoadInstanceConvertsValueToExpectedTypeGivenXmlDefinitionWithNoChildElements()
         {
             var definition = new XElement("Definition", "42");
@@ -923,6 +949,8 @@
             public TimeSpan TimeSpanProperty { get; set; }
 
             public StubClassWithProperties ChildProperty { get; set; }
+
+            public System.Diagnostics.Tracing.EventLevel EnumProperty { get; set; }
         }
 
         private class StubConfigurable : ITelemetryModule

--- a/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -330,6 +330,14 @@
                 {
                     instance = TimeSpan.Parse(valueString, CultureInfo.InvariantCulture);
                 }
+#if NET40 || NET45 || NET46
+                else if (expectedType.IsEnum)
+#else
+                else if (expectedType.GetTypeInfo().IsEnum)
+#endif
+                {
+                    instance = Enum.Parse(expectedType, valueString);
+                }
                 else
                 {
                     instance = Convert.ChangeType(valueString, expectedType, CultureInfo.InvariantCulture);


### PR DESCRIPTION
This is necessary in the context of EventSource telemetry module work, but is universally applicable