### PR TITLE
Channel to drop items if buffer size is growing beyond limit

### DIFF
--- a/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
@@ -65,7 +65,7 @@
         }
 
         [TestMethod]
-        public void TelemetryBufferDoNotGrowBeyondMaxBacklogSize()
+        public void TelemetryBufferDoesNotGrowBeyondMaxBacklogSize()
         {            
             TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, MaximumUnsentBacklogSize= 1002};
             buffer.OnFull = () => { //intentionaly blank to simulate situation where buffer

--- a/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
@@ -40,11 +40,11 @@
         }
 
         [TestMethod]
-        public void WhenNewValueIsLessThanOneSetToDefault()
+        public void WhenNewValueIsLessThanMinimumSetToDefault()
         {
             var buffer = new TelemetryBuffer();
             buffer.Capacity = 0;
-            buffer.MaximumUnsentBacklogSize = 0;
+            buffer.MaximumUnsentBacklogSize = 1000; //1001 is the minimum, setting to anything low should be overruled with Default
 
             Assert.Equal(buffer.Capacity, 500);
             Assert.Equal(buffer.MaximumUnsentBacklogSize, 1000000);
@@ -67,23 +67,23 @@
         [TestMethod]
         public void TelemetryBufferDoNotGrowBeyondMaxBacklogSize()
         {            
-            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, MaximumUnsentBacklogSize= 5};
+            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, MaximumUnsentBacklogSize= 1002};
             buffer.OnFull = () => { //intentionaly blank to simulate situation where buffer
                                     //is not emptied.
                                   };
 
             // Add more items to buffer than the max backlog size
-            buffer.Enqueue(new EventTelemetry("Event1"));
-            buffer.Enqueue(new EventTelemetry("Event2"));
-            buffer.Enqueue(new EventTelemetry("Event3"));
-            buffer.Enqueue(new EventTelemetry("Event4"));
-            buffer.Enqueue(new EventTelemetry("Event5"));
-            buffer.Enqueue(new EventTelemetry("Event6"));
+            for(int i = 0; i < 1005; i++)
+            {
+                buffer.Enqueue(new EventTelemetry("Event" + i));
+            }
+            
+            
 
             // validate that items are not added after maxunsentbacklogsize is reached.
             // this also validate that items can still be added after Capacity is reached as it is only a soft limit.
             int bufferItemCount = buffer.Dequeue().Count();
-            Assert.Equal(5, bufferItemCount);
+            Assert.Equal(1002, bufferItemCount);
 
         }
     }

--- a/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
@@ -26,7 +26,7 @@
         {
             var buffer = new TelemetryBuffer();
             Assert.Equal(500, buffer.Capacity);
-            Assert.Equal(1000000, buffer.MaximumBacklogSize);
+            Assert.Equal(1000000, buffer.BacklogSize);
         }
 
         [TestMethod]
@@ -34,9 +34,9 @@
         {
             var buffer = new TelemetryBuffer();
             buffer.Capacity = 42;
-            buffer.MaximumBacklogSize = 9999;
+            buffer.BacklogSize = 9999;
             Assert.Equal(42, buffer.Capacity);
-            Assert.Equal(9999, buffer.MaximumBacklogSize);
+            Assert.Equal(9999, buffer.BacklogSize);
         }
 
         [TestMethod]
@@ -44,10 +44,10 @@
         {
             var buffer = new TelemetryBuffer();
             buffer.Capacity = 0;
-            buffer.MaximumBacklogSize = 1000; //1001 is the minimum, setting to anything low should be overruled with Default
+            buffer.BacklogSize = 1000; //1001 is the minimum, setting to anything low should be overruled with minimum allowed.
 
             Assert.Equal(500,buffer.Capacity);
-            Assert.Equal(1000000, buffer.MaximumBacklogSize);
+            Assert.Equal(1001, buffer.BacklogSize);
         }
 
         [TestMethod]
@@ -57,10 +57,10 @@
             buffer.Capacity = 9999; // a value greater than the minimum allowed for MaxBacklogSize            
 
             //Attempt to set MaxBacklogSize below Capacity
-            buffer.MaximumBacklogSize = buffer.Capacity - 1;
+            buffer.BacklogSize = buffer.Capacity - 1;
 
             // Validate that MaximumBacklogSize will be set to Capacity
-            Assert.Equal(buffer.Capacity, buffer.MaximumBacklogSize);
+            Assert.Equal(buffer.Capacity, buffer.BacklogSize);
         }
 
         [TestMethod]
@@ -70,10 +70,10 @@
             var buffer = new TelemetryBuffer();            
 
             //Attempt to set Capacity above MaxBacklogSize
-            buffer.Capacity = buffer.MaximumBacklogSize + 1;
+            buffer.Capacity = buffer.BacklogSize + 1;
 
             // Validate that Capacity will be set to MaxBacklogSize
-            Assert.Equal(buffer.Capacity, buffer.MaximumBacklogSize);
+            Assert.Equal(buffer.Capacity, buffer.BacklogSize);
         }
 
         [TestMethod]
@@ -93,7 +93,7 @@
         [TestMethod]
         public void TelemetryBufferDoesNotGrowBeyondMaxBacklogSize()
         {            
-            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, MaximumBacklogSize = 1002};
+            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, BacklogSize = 1002};
             buffer.OnFull = () => { //intentionaly blank to simulate situation where buffer
                                     //is not emptied.
                                   };

--- a/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
@@ -58,5 +58,24 @@
             Assert.NotNull(items);
             Assert.Equal(2, items.Count());
         }
+
+        [TestMethod]
+        public void TelemetryBufferDropsItemWhenBufferCapacityReached()
+        {
+            IEnumerable<ITelemetry> items = null;
+            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2 };
+            buffer.OnFull = () => { //intentionaly blank to simulate situation where buffer
+                                    //is not emptied.
+                                  };
+
+            buffer.Enqueue(new EventTelemetry("Event1"));
+            buffer.Enqueue(new EventTelemetry("Event2"));
+            buffer.Enqueue(new EventTelemetry("Event3"));
+            buffer.Enqueue(new EventTelemetry("Event4"));
+
+            int bufferItemCount = buffer.Dequeue().Count();
+            Assert.Equal(2, bufferItemCount);
+
+        }
     }
 }

--- a/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
@@ -26,7 +26,7 @@
         {
             var buffer = new TelemetryBuffer();
             Assert.Equal(500, buffer.Capacity);
-            Assert.Equal(1000000, buffer.MaximumUnsentBacklogSize);
+            Assert.Equal(1000000, buffer.MaximumBacklogSize);
         }
 
         [TestMethod]
@@ -34,9 +34,9 @@
         {
             var buffer = new TelemetryBuffer();
             buffer.Capacity = 42;
-            buffer.MaximumUnsentBacklogSize = 9999;
+            buffer.MaximumBacklogSize = 9999;
             Assert.Equal(42, buffer.Capacity);
-            Assert.Equal(9999, buffer.MaximumUnsentBacklogSize);
+            Assert.Equal(9999, buffer.MaximumBacklogSize);
         }
 
         [TestMethod]
@@ -44,10 +44,36 @@
         {
             var buffer = new TelemetryBuffer();
             buffer.Capacity = 0;
-            buffer.MaximumUnsentBacklogSize = 1000; //1001 is the minimum, setting to anything low should be overruled with Default
+            buffer.MaximumBacklogSize = 1000; //1001 is the minimum, setting to anything low should be overruled with Default
 
-            Assert.Equal(buffer.Capacity, 500);
-            Assert.Equal(buffer.MaximumUnsentBacklogSize, 1000000);
+            Assert.Equal(500,buffer.Capacity);
+            Assert.Equal(1000000, buffer.MaximumBacklogSize);
+        }
+
+        [TestMethod]
+        public void MaxBacklogCannotBeBelowCapacity()
+        {     
+            var buffer = new TelemetryBuffer();
+            buffer.Capacity = 9999; // a value greater than the minimum allowed for MaxBacklogSize            
+
+            //Attempt to set MaxBacklogSize below Capacity
+            buffer.MaximumBacklogSize = buffer.Capacity - 1;
+
+            // Validate that MaximumBacklogSize will be set to Capacity
+            Assert.Equal(buffer.Capacity, buffer.MaximumBacklogSize);
+        }
+
+        [TestMethod]
+        public void CapacityCannotBeAboveBacklogSize()
+        {
+
+            var buffer = new TelemetryBuffer();            
+
+            //Attempt to set Capacity above MaxBacklogSize
+            buffer.Capacity = buffer.MaximumBacklogSize + 1;
+
+            // Validate that Capacity will be set to MaxBacklogSize
+            Assert.Equal(buffer.Capacity, buffer.MaximumBacklogSize);
         }
 
         [TestMethod]
@@ -67,7 +93,7 @@
         [TestMethod]
         public void TelemetryBufferDoesNotGrowBeyondMaxBacklogSize()
         {            
-            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, MaximumUnsentBacklogSize= 1002};
+            TelemetryBuffer buffer = new TelemetryBuffer { Capacity = 2, MaximumBacklogSize = 1002};
             buffer.OnFull = () => { //intentionaly blank to simulate situation where buffer
                                     //is not emptied.
                                   };

--- a/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/TelemetryBufferTest.cs
@@ -26,7 +26,7 @@
         {
             var buffer = new TelemetryBuffer();
             Assert.Equal(500, buffer.Capacity);
-            Assert.Equal(100000, buffer.MaximumUnsentBacklogSize);
+            Assert.Equal(1000000, buffer.MaximumUnsentBacklogSize);
         }
 
         [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTelemetryBuffer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTelemetryBuffer.cs
@@ -1,0 +1,23 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Helpers
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
+    using System.Threading.Tasks;
+
+    internal class StubTelemetryBuffer : Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TelemetryBuffer
+    {
+        public Action<IEnumerable<ITelemetry>> OnSerialize = _ => { };
+
+        public StubTelemetryBuffer(TelemetrySerializer serializer, IApplicationLifecycle applicationLifecycle) : base(serializer, applicationLifecycle)
+        {            
+
+        }
+        public override Task FlushAsync()
+        {
+            // Intentionally blank to simulate situation where buffer is not emptied.
+            return null;
+        }
+    }
+}

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/TelemetryBufferWhichDoesNothingOnFlush.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/TelemetryBufferWhichDoesNothingOnFlush.cs
@@ -6,11 +6,11 @@
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
     using System.Threading.Tasks;
 
-    internal class StubTelemetryBuffer : Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TelemetryBuffer
+    internal class TelemetryBufferWhichDoesNothingOnFlush : Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TelemetryBuffer
     {
         public Action<IEnumerable<ITelemetry>> OnSerialize = _ => { };
 
-        public StubTelemetryBuffer(TelemetrySerializer serializer, IApplicationLifecycle applicationLifecycle) : base(serializer, applicationLifecycle)
+        public TelemetryBufferWhichDoesNothingOnFlush(TelemetrySerializer serializer, IApplicationLifecycle applicationLifecycle) : base(serializer, applicationLifecycle)
         {            
 
         }

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
@@ -71,7 +71,7 @@
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 Assert.Equal(500, buffer.Capacity);
-                Assert.Equal(1000000, buffer.MaximumBacklogSize);
+                Assert.Equal(1000000, buffer.BacklogSize);
             }
 
             [TestMethod]
@@ -79,9 +79,9 @@
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 buffer.Capacity = 42;
-                buffer.MaximumBacklogSize = 3900;
+                buffer.BacklogSize = 3900;
                 Assert.Equal(42, buffer.Capacity);
-                Assert.Equal(3900, buffer.MaximumBacklogSize);
+                Assert.Equal(3900, buffer.BacklogSize);
             }
 
             [TestMethod]
@@ -89,9 +89,9 @@
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 buffer.Capacity = 1111;
-                Assert.Throws<ArgumentException>(() => buffer.MaximumBacklogSize = 1110);
+                Assert.Throws<ArgumentException>(() => buffer.BacklogSize = 1110);
 
-                buffer.MaximumBacklogSize = 8000;
+                buffer.BacklogSize = 8000;
                 Assert.Throws<ArgumentException>(() => buffer.Capacity = 8001);
 
             }
@@ -101,13 +101,13 @@
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Capacity = 0);
-                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumBacklogSize = 0);
-                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumBacklogSize = 1000); // 1001 is minimum anything low would throw.
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.BacklogSize = 0);
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.BacklogSize = 1000); // 1001 is minimum anything low would throw.
 
                 bool exceptionThrown = false;
                 try
                 {
-                    buffer.MaximumBacklogSize = 1001; // 1001 is valid and should not throw.
+                    buffer.BacklogSize = 1001; // 1001 is valid and should not throw.
                 }
                 catch(Exception)
                 {
@@ -146,7 +146,7 @@
                 //TelemetryBufferWhichDoesNothingOnFlush does not flush items on buffer full,to test ItemDrop scenario.
                 var buffer = new TelemetryBufferWhichDoesNothingOnFlush( new StubTelemetrySerializer(), new StubApplicationLifecycle() );
                 buffer.Capacity = 2;
-                buffer.MaximumBacklogSize = 1002;
+                buffer.BacklogSize = 1002;
 
                 buffer.Process(new StubTelemetry());
 

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
@@ -71,7 +71,7 @@
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 Assert.Equal(500, buffer.Capacity);
-                Assert.Equal(1000000, buffer.MaximumUnsentBacklogSize);
+                Assert.Equal(1000000, buffer.MaximumBacklogSize);
             }
 
             [TestMethod]
@@ -79,17 +79,18 @@
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 buffer.Capacity = 42;
-                buffer.MaximumUnsentBacklogSize = 3900;
+                buffer.MaximumBacklogSize = 3900;
                 Assert.Equal(42, buffer.Capacity);
-                Assert.Equal(3900, buffer.MaximumUnsentBacklogSize);
+                Assert.Equal(3900, buffer.MaximumBacklogSize);
             }
 
             [TestMethod]
-            public void ThrowsArgumentOutOfRangeExceptionWhenNewValueIsLessThanOne()
+            public void ThrowsArgumentOutOfRangeExceptionWhenNewValueIsLessThanMinimum()
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
                 Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Capacity = 0);
-                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumUnsentBacklogSize = 0);
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumBacklogSize = 0);
+                Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumBacklogSize = 1000); // 1001 is minimum anything low would throw.
             }
         }
 
@@ -118,26 +119,23 @@
             [TestMethod]
             public void TelemetryBufferDoNotGrowBeyondMaxBacklogSize()
             {
-                //StubTelemetryBuffer does not flush items on buffer full,to test ItemDrop scenario.
-                var buffer = new StubTelemetryBuffer( new StubTelemetrySerializer(), new StubApplicationLifecycle() );
+                //TelemetryBufferWhichDoesNothingOnFlush does not flush items on buffer full,to test ItemDrop scenario.
+                var buffer = new TelemetryBufferWhichDoesNothingOnFlush( new StubTelemetrySerializer(), new StubApplicationLifecycle() );
                 buffer.Capacity = 2;
-                buffer.MaximumUnsentBacklogSize = 5;
+                buffer.MaximumBacklogSize = 1002;
 
                 buffer.Process(new StubTelemetry());
 
-                // Add more items (7) to buffer than the max backlog size(5)
-                buffer.Process(new StubTelemetry());
-                buffer.Process(new StubTelemetry());
-                buffer.Process(new StubTelemetry());
-                buffer.Process(new StubTelemetry());
-                buffer.Process(new StubTelemetry());
-                buffer.Process(new StubTelemetry());
-                buffer.Process(new StubTelemetry());
-
+                // Add more items (1005) to buffer than the max backlog size(1002)
+                for (int i = 0; i < 1005; i++)
+                {
+                    buffer.Process(new StubTelemetry());
+                }
+                                
                 // validate that items are not added after maxunsentbacklogsize is reached.
                 // this also validate that items can still be added after Capacity is reached as it is only a soft limit.
                 int bufferItemCount = buffer.Count();
-                Assert.Equal(5, bufferItemCount);
+                Assert.Equal(1002, bufferItemCount);
             }
 
             [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
@@ -91,6 +91,18 @@
                 Assert.Throws<ArgumentOutOfRangeException>(() => buffer.Capacity = 0);
                 Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumBacklogSize = 0);
                 Assert.Throws<ArgumentOutOfRangeException>(() => buffer.MaximumBacklogSize = 1000); // 1001 is minimum anything low would throw.
+
+                bool exceptionThrown = false;
+                try
+                {
+                    buffer.MaximumBacklogSize = 1001; // 1001 is valid and should not throw.
+                }
+                catch(Exception)
+                {
+                    exceptionThrown = true;
+                }
+
+                Assert.True(exceptionThrown == false, "No exception should be thrown when trying to set backlogsize to 1001");                
             }
         }
 
@@ -117,7 +129,7 @@
             }
 
             [TestMethod]
-            public void TelemetryBufferDoNotGrowBeyondMaxBacklogSize()
+            public void TelemetryBufferDoesNotGrowBeyondMaxBacklogSize()
             {
                 //TelemetryBufferWhichDoesNothingOnFlush does not flush items on buffer full,to test ItemDrop scenario.
                 var buffer = new TelemetryBufferWhichDoesNothingOnFlush( new StubTelemetrySerializer(), new StubApplicationLifecycle() );

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetryBufferTest.cs
@@ -85,6 +85,18 @@
             }
 
             [TestMethod]
+            public void ThrowsArgumentExceptionWhenBacklogSizeIsLowerThanCapacity()
+            {
+                var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());
+                buffer.Capacity = 1111;
+                Assert.Throws<ArgumentException>(() => buffer.MaximumBacklogSize = 1110);
+
+                buffer.MaximumBacklogSize = 8000;
+                Assert.Throws<ArgumentException>(() => buffer.Capacity = 8001);
+
+            }
+
+            [TestMethod]
             public void ThrowsArgumentOutOfRangeExceptionWhenNewValueIsLessThanMinimum()
             {
                 var buffer = new TelemetryBuffer(new StubTelemetrySerializer(), new StubApplicationLifecycle());

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
@@ -14,7 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BackendResponseHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\DirectoryAccessDenier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\FileAccessDenier.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetryBuffer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\TelemetryBufferWhichDoesNothingOnFlush.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetryProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetrySerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTransmissionBuffer.cs" />

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BackendResponseHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\DirectoryAccessDenier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\FileAccessDenier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetryBuffer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetryProcessor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetrySerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTransmissionBuffer.cs" />

--- a/src/Core/Managed/Shared/Channel/InMemoryChannel.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryChannel.cs
@@ -106,8 +106,8 @@
         /// </summary>
         public int MaxBacklogSize
         {
-            get { return this.buffer.MaximumUnsentBacklogSize; }
-            set { this.buffer.MaximumUnsentBacklogSize = value; }
+            get { return this.buffer.MaximumBacklogSize; }
+            set { this.buffer.MaximumBacklogSize = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Channel/InMemoryChannel.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryChannel.cs
@@ -92,11 +92,22 @@
         /// <summary>
         /// Gets or sets the maximum number of telemetry items will accumulate in a memory before 
         /// the <see cref="InMemoryChannel"/> serializing them for transmission to Application Insights.
+        /// This is not a hard limit on how many unsent items can be in the buffer.
         /// </summary>
         public int MaxTelemetryBufferCapacity
         {
             get { return this.buffer.Capacity; }
             set { this.buffer.Capacity = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. This is a hard limit
+        /// and Items will be dropped by the <see cref="InMemoryChannel"/> once this limit is hit until items are drained from the buffer.
+        /// </summary>
+        public int MaxBacklogSize
+        {
+            get { return this.buffer.MaximumUnsentBacklogSize; }
+            set { this.buffer.MaximumUnsentBacklogSize = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Channel/InMemoryChannel.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryChannel.cs
@@ -104,10 +104,10 @@
         /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. This is a hard limit
         /// and Items will be dropped by the <see cref="InMemoryChannel"/> once this limit is hit until items are drained from the buffer.
         /// </summary>
-        public int MaxBacklogSize
+        public int BacklogSize
         {
-            get { return this.buffer.MaximumBacklogSize; }
-            set { this.buffer.MaximumBacklogSize = value; }
+            get { return this.buffer.BacklogSize; }
+            set { this.buffer.BacklogSize = value; }
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
@@ -108,6 +108,7 @@ namespace Microsoft.ApplicationInsights.Channel
         private void OnBufferFull()
         {
             this.startRunnerEvent.Set();
+            CoreEventSource.Log.LogVerbose("StartRunnerEvent set as Buffer is full.");
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
+++ b/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
@@ -19,6 +19,7 @@
         private readonly object lockObj = new object();
         private int capacity = DefaultCapacity;
         private int maximumBacklogSize = DefaultMaximumUnsentBacklogSize;
+        private int minimumBacklogSize = 1001;
         private List<ITelemetry> items;
         private bool itemDroppedMessageLogged = false;
 
@@ -45,6 +46,12 @@
                     return;
                 }
 
+                if (value > this.maximumBacklogSize)
+                {
+                    this.capacity = maximumBacklogSize;
+                    return;
+                }
+
                 this.capacity = value;
             }
         }
@@ -62,9 +69,15 @@
 
             set
             {
-                if (value < 1001)
+                if (value < this.minimumBacklogSize)
                 {
                     this.maximumBacklogSize = DefaultMaximumUnsentBacklogSize;
+                    return;
+                }
+
+                if (value < this.capacity)
+                {
+                    this.maximumBacklogSize = this.capacity;
                     return;
                 }
 

--- a/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
+++ b/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
@@ -23,7 +23,7 @@
         private bool itemDroppedMessageLogged = false;
 
         internal TelemetryBuffer()
-        {            
+        {
             this.items = new List<ITelemetry>(this.Capacity);
         }
 

--- a/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
+++ b/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
@@ -15,10 +15,10 @@
         public Action OnFull;
 
         private const int DefaultCapacity = 500;
-        private const int DefaultMaximumUnsentBacklogSize = 1000000;
+        private const int DefaultMaximumUnsentBacklogSize = 1000000;        
         private readonly object lockObj = new object();
         private int capacity = DefaultCapacity;
-        private int maximumUnsentBacklogSize = DefaultMaximumUnsentBacklogSize;
+        private int maximumBacklogSize = DefaultMaximumUnsentBacklogSize;
         private List<ITelemetry> items;
         private bool itemDroppedMessageLogged = false;
 
@@ -53,22 +53,22 @@
         /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. Items will be dropped
         /// once this limit is hit.
         /// </summary>        
-        public int MaximumUnsentBacklogSize
+        public int MaximumBacklogSize
         {
             get
             {
-                return this.maximumUnsentBacklogSize;
+                return this.maximumBacklogSize;
             }
 
             set
             {
-                if (value < 1)
+                if (value < 1001)
                 {
-                    this.maximumUnsentBacklogSize = DefaultMaximumUnsentBacklogSize;
+                    this.maximumBacklogSize = DefaultMaximumUnsentBacklogSize;
                     return;
                 }
 
-                this.maximumUnsentBacklogSize = value;
+                this.maximumBacklogSize = value;
             }
         }
 
@@ -82,11 +82,11 @@
 
             lock (this.lockObj)
             {
-                if (this.items.Count >= this.MaximumUnsentBacklogSize)
+                if (this.items.Count >= this.MaximumBacklogSize)
                 {
                     if (!this.itemDroppedMessageLogged)
                     {
-                        CoreEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.MaximumUnsentBacklogSize);
+                        CoreEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.MaximumBacklogSize);
                         this.itemDroppedMessageLogged = true;
                     }
 

--- a/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
+++ b/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
@@ -15,10 +15,10 @@
         public Action OnFull;
 
         private const int DefaultCapacity = 500;
-        private const int DefaultMaximumUnsentBacklogSize = 1000000;        
+        private const int DefaultBacklogSize = 1000000;        
         private readonly object lockObj = new object();
         private int capacity = DefaultCapacity;
-        private int maximumBacklogSize = DefaultMaximumUnsentBacklogSize;
+        private int backlogSize = DefaultBacklogSize;
         private int minimumBacklogSize = 1001;
         private List<ITelemetry> items;
         private bool itemDroppedMessageLogged = false;
@@ -46,9 +46,9 @@
                     return;
                 }
 
-                if (value > this.maximumBacklogSize)
+                if (value > this.backlogSize)
                 {
-                    this.capacity = maximumBacklogSize;
+                    this.capacity = this.backlogSize;
                     return;
                 }
 
@@ -60,28 +60,28 @@
         /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. Items will be dropped
         /// once this limit is hit.
         /// </summary>        
-        public int MaximumBacklogSize
+        public int BacklogSize
         {
             get
             {
-                return this.maximumBacklogSize;
+                return this.backlogSize;
             }
 
             set
             {
                 if (value < this.minimumBacklogSize)
                 {
-                    this.maximumBacklogSize = DefaultMaximumUnsentBacklogSize;
+                    this.backlogSize = this.minimumBacklogSize;
                     return;
                 }
 
                 if (value < this.capacity)
                 {
-                    this.maximumBacklogSize = this.capacity;
+                    this.backlogSize = this.capacity;
                     return;
                 }
 
-                this.maximumBacklogSize = value;
+                this.backlogSize = value;
             }
         }
 
@@ -95,11 +95,11 @@
 
             lock (this.lockObj)
             {
-                if (this.items.Count >= this.MaximumBacklogSize)
+                if (this.items.Count >= this.BacklogSize)
                 {
                     if (!this.itemDroppedMessageLogged)
                     {
-                        CoreEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.MaximumBacklogSize);
+                        CoreEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.BacklogSize);
                         this.itemDroppedMessageLogged = true;
                     }
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -361,6 +361,18 @@
                 this.nameProvider.Name);
         }
 
+        [Event(
+            29,
+            Message = "The backlog of unsent items has reached maximum size of {0}. Items will be dropped until the backlog is cleared.",
+            Level = EventLevel.Error)]
+        public void ItemDroppedAsMaximumUnsentBacklogSizeReached(int maxBacklogSize, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                29,
+                maxBacklogSize,               
+                this.nameProvider.Name);
+        }
+
         /// <summary>
         /// Keywords for the PlatformEventSource.
         /// </summary>

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -162,6 +162,7 @@
                         this.flushTimer.Cancel();
                         telemetryToFlush = this.transmissionBuffer;
                         this.transmissionBuffer = new List<ITelemetry>(this.Capacity);
+                        this.itemDroppedMessageLogged = false;
                     }
                 }
             }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -22,7 +22,7 @@
         private readonly TelemetrySerializer serializer;
 
         private int capacity = 500;
-        private int maximumBacklogSize = 1000000;
+        private int backlogSize = 1000000;
         private int minimumBacklogSize = 1001;
         private bool itemDroppedMessageLogged = false;
         private List<ITelemetry> transmissionBuffer;
@@ -70,7 +70,7 @@
                     throw new ArgumentOutOfRangeException("value");
                 }
 
-                if (value > this.maximumBacklogSize)
+                if (value > this.backlogSize)
                 {
                     throw new ArgumentException("Capacity cannot be greater than MaximumBacklogSize", "Capacity");
                 }
@@ -85,11 +85,11 @@
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">The value is zero or less.</exception>
         /// <exception cref="ArgumentException">The value is less than the Capacity.</exception>
-        public int MaximumBacklogSize
+        public int BacklogSize
         {
             get
             {
-                return this.maximumBacklogSize;
+                return this.backlogSize;
             }
 
             set
@@ -104,7 +104,7 @@
                     throw new ArgumentException("MaximumBacklogSize cannot be lower than capacity", "MaximumBacklogSize");
                 }
 
-                this.maximumBacklogSize = value;
+                this.backlogSize = value;
             }
         }
 
@@ -141,11 +141,11 @@
 
             lock (this)
             {
-                if (this.transmissionBuffer.Count >= this.MaximumBacklogSize)
+                if (this.transmissionBuffer.Count >= this.BacklogSize)
                 {
                     if (!this.itemDroppedMessageLogged)
                     {
-                        TelemetryChannelEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.MaximumBacklogSize);
+                        TelemetryChannelEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.BacklogSize);
                         this.itemDroppedMessageLogged = true;
                     }
 

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -22,7 +22,7 @@
         private readonly TelemetrySerializer serializer;
 
         private int capacity = 500;
-        private int maximumUnsentBacklogSize = 1000000;
+        private int maximumBacklogSize = 1000000;
         private bool itemDroppedMessageLogged = false;
         private List<ITelemetry> transmissionBuffer;
 
@@ -77,21 +77,21 @@
         /// once this limit is hit.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">The value is zero or less.</exception>
-        public int MaximumUnsentBacklogSize
+        public int MaximumBacklogSize
         {
             get
             {
-                return this.maximumUnsentBacklogSize;
+                return this.maximumBacklogSize;
             }
 
             set
             {
-                if (value < 1)
+                if (value < 1001)
                 {
                     throw new ArgumentOutOfRangeException("value");
                 }
 
-                this.maximumUnsentBacklogSize = value;
+                this.maximumBacklogSize = value;
             }
         }
 
@@ -128,11 +128,11 @@
 
             lock (this)
             {
-                if (this.transmissionBuffer.Count >= this.MaximumUnsentBacklogSize)
+                if (this.transmissionBuffer.Count >= this.MaximumBacklogSize)
                 {
                     if (!this.itemDroppedMessageLogged)
                     {
-                        TelemetryChannelEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.MaximumUnsentBacklogSize);
+                        TelemetryChannelEventSource.Log.ItemDroppedAsMaximumUnsentBacklogSizeReached(this.MaximumBacklogSize);
                         this.itemDroppedMessageLogged = true;
                     }
 

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -23,6 +23,7 @@
 
         private int capacity = 500;
         private int maximumBacklogSize = 1000000;
+        private int minimumBacklogSize = 1001;
         private bool itemDroppedMessageLogged = false;
         private List<ITelemetry> transmissionBuffer;
 
@@ -54,6 +55,7 @@
         /// Gets or sets the maximum number of telemetry items that can be buffered before transmission.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">The value is zero or less.</exception>
+        /// <exception cref="ArgumentException">The value is greater than the MaximumBacklogSize.</exception>
         public int Capacity
         {
             get
@@ -68,6 +70,11 @@
                     throw new ArgumentOutOfRangeException("value");
                 }
 
+                if (value > this.maximumBacklogSize)
+                {
+                    throw new ArgumentException("Capacity cannot be greater than MaximumBacklogSize", "Capacity");
+                }
+
                 this.capacity = value;
             }
         }
@@ -77,6 +84,7 @@
         /// once this limit is hit.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">The value is zero or less.</exception>
+        /// <exception cref="ArgumentException">The value is less than the Capacity.</exception>
         public int MaximumBacklogSize
         {
             get
@@ -86,9 +94,14 @@
 
             set
             {
-                if (value < 1001)
+                if (value < this.minimumBacklogSize)
                 {
                     throw new ArgumentOutOfRangeException("value");
+                }
+
+                if (value < this.capacity)
+                {
+                    throw new ArgumentException("MaximumBacklogSize cannot be lower than capacity", "MaximumBacklogSize");
                 }
 
                 this.maximumBacklogSize = value;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -462,6 +462,16 @@
                 this.ApplicationName);
         }
 
+        [Event(65, Message = "The backlog of unsent items has reached maximum size of {0}. Items will be dropped until the backlog is cleared.",
+        Level = EventLevel.Error)]
+        public void ItemDroppedAsMaximumUnsentBacklogSizeReached(int maxBacklogSize, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                65,
+                maxBacklogSize,
+                this.ApplicationName);
+        }
+
         private string GetApplicationName()
         {
             string name;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -134,7 +134,8 @@
 
         /// <summary>
         /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. This is a hard limit
-        /// and Items will be dropped by the <see cref="ServerTelemetryChannel"/> once this limit is hit until items are drained from the buffer.
+        /// and Items will be dropped by the <see cref="ServerTelemetryChannel"/> once this limit is hit until items
+        /// are drained from the buffer.
         /// </summary>
         public int MaxBacklogSize
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -139,8 +139,8 @@
         /// </summary>
         public int MaxBacklogSize
         {
-            get { return this.TelemetryBuffer.MaximumBacklogSize; }
-            set { this.TelemetryBuffer.MaximumBacklogSize = value; }
+            get { return this.TelemetryBuffer.BacklogSize; }
+            set { this.TelemetryBuffer.BacklogSize = value; }
         }
 
         /// <summary>

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -139,8 +139,8 @@
         /// </summary>
         public int MaxBacklogSize
         {
-            get { return this.TelemetryBuffer.MaximumUnsentBacklogSize; }
-            set { this.TelemetryBuffer.MaximumUnsentBacklogSize = value; }
+            get { return this.TelemetryBuffer.MaximumBacklogSize; }
+            set { this.TelemetryBuffer.MaximumBacklogSize = value; }
         }
 
         /// <summary>

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/ServerTelemetryChannel.cs
@@ -124,11 +124,22 @@
         /// <summary>
         /// Gets or sets the maximum number of telemetry items will accumulate in a memory before 
         /// the <see cref="TelemetryChannel"/> serializing them for transmission to Application Insights.
+        /// This is not a hard limit on how many unsent items can be in the buffer.
         /// </summary>
         public int MaxTelemetryBufferCapacity 
         {
             get { return this.TelemetryBuffer.Capacity; }
             set { this.TelemetryBuffer.Capacity = value; } 
+        }
+
+        /// <summary>
+        /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. This is a hard limit
+        /// and Items will be dropped by the <see cref="ServerTelemetryChannel"/> once this limit is hit until items are drained from the buffer.
+        /// </summary>
+        public int MaxBacklogSize
+        {
+            get { return this.TelemetryBuffer.MaximumUnsentBacklogSize; }
+            set { this.TelemetryBuffer.MaximumUnsentBacklogSize = value; }
         }
 
         /// <summary>


### PR DESCRIPTION
Modified both channels to drop items if the buffer is exceeding a very huge size(configurable, default is 1million items).This can occur if item flush logic never gets a chance to run due to threadpool overload.

Fix: https://github.com/Microsoft/ApplicationInsights-dotnet/issues/345
ShortTermFix for :  https://github.com/Microsoft/ApplicationInsights-dotnet/issues/413