### PR TITLE
Change .NETStandard version of Microsoft.ApplicationInsights from 1.5 to 1.3

### DIFF
--- a/src/Core/NuGet/Core/Package.nuspec
+++ b/src/Core/NuGet/Core/Package.nuspec
@@ -28,7 +28,7 @@
       <group targetFramework="wp8">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
       </group>
-      <group targetFramework="netstandard1.5">
+      <group targetFramework="netstandard1.3">
         <dependency id="System.Collections" version="4.0.11" />
         <dependency id="System.Diagnostics.Debug" version="4.0.11" />
         <dependency id="System.Diagnostics.Tools" version="4.0.1" />
@@ -53,9 +53,9 @@
   </metadata>
   <files>
     <!-- Binaries for .NET PCL -->
-    <file src="$configuration$\Core\Managed\PCL\Microsoft.ApplicationInsights.dll" target="lib\netstandard1.5" />
-    <file src="$configuration$\Core\Managed\PCL\Microsoft.ApplicationInsights.pdb" target="lib\netstandard1.5" />
-    <file src="$configuration$\Core\Managed\PCL\Microsoft.ApplicationInsights.xml" target="lib\netstandard1.5" />
+    <file src="$configuration$\Core\Managed\PCL\Microsoft.ApplicationInsights.dll" target="lib\netstandard1.3" />
+    <file src="$configuration$\Core\Managed\PCL\Microsoft.ApplicationInsights.pdb" target="lib\netstandard1.3" />
+    <file src="$configuration$\Core\Managed\PCL\Microsoft.ApplicationInsights.xml" target="lib\netstandard1.3" />
 
     <!-- Binaries for .NET 4.0 projects -->
     <file src="$configuration$\Core\Managed\Net40\Microsoft.ApplicationInsights.dll" target="lib\net40" />


### PR DESCRIPTION
1.3 means it can work with .NET Framework 4.6 (1.5 indicates 4.6.2 is a requirement)
We do not use any 4.6.2-specific features so it makes it easier to consume the library if we target lower standard.