### PR TITLE
Fix random failing unit test

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionBufferTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TransmissionBufferTest.cs
@@ -16,7 +16,7 @@
         public class Class : TransmissionBufferTest
         {
             [TestMethod]
-            [Timeout(10000)]
+            [Timeout(15000)]
             public void EnqueueAndDequeueMethodsAreThreadSafe()
             {
                 var buffer = new TransmissionBuffer();


### PR DESCRIPTION
Increase time for TransmissionBufferTest as it frequently fails under CodeCoverage tool. 
(This was previously increased once and is passing always in test run, but under code coverage tool, this fails sometimes.)