### PR TITLE
Fix another random failing UnitTest

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerTest.cs
@@ -153,7 +153,7 @@
             }
 
             [TestMethod]
-            [Timeout(1000)]
+            [Timeout(1500)]
             public void HandlesAsyncExceptionThrownByTheDelegate()
             {
                 TaskTimer timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
@@ -169,7 +169,7 @@
             }
 
             [TestMethod]
-            [Timeout(1000)]
+            [Timeout(1500)]
             public void HandlesSyncExceptionThrownByTheDelegate()
             {
                 TaskTimer timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };


### PR DESCRIPTION
Increase max time out for some tests which fail occasionally when run with CodeCoverage..
(The test always pass when ran normally, but under CodeCov tool, it just needs more time)