### PR TITLE
Add overloads of OperationTelemetry Start/Stop extension methods

### DIFF
--- a/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
+++ b/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights
 {
     using System;
+    using System.Diagnostics;
     using System.Threading;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -61,6 +62,36 @@
             telemetry.Stop();
             Assert.NotEqual(DateTimeOffset.MinValue, telemetry.Timestamp);
             Assert.Equal(telemetry.Duration, TimeSpan.Zero);
+        }
+
+        /// <summary>
+        /// Tests the scenario if Stop computes the duration of the telemetry when timestamps are supplied to Start and Stop.
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryStopWithTimestampComputesDurationAfterStartWithTimestamp()
+        {
+            var telemetry = new DependencyTelemetry();
+
+            long startTime = 123456789012345L;
+            long ticksInOneSecond = Stopwatch.Frequency;
+            long stopTime = startTime + ticksInOneSecond;
+
+            telemetry.Start(timestamp: startTime);
+            telemetry.Stop(timestamp: stopTime);
+
+            Assert.Equal(TimeSpan.FromSeconds(1), telemetry.Duration);
+        }
+
+        /// <summary>
+        /// Tests the sceanrio if Stop assigns the duration to zero when a timestamp is supplied by Start is not called.
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryStopWithTimestampAssignsDurationZeroWithoutStart()
+        {
+            var telemetry = new DependencyTelemetry();
+            telemetry.Stop(timestamp: 123456789012345L); // timestamp is ignored because Start was not called
+
+            Assert.Equal(TimeSpan.Zero, telemetry.Duration);
         }
     }
 }

--- a/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
+++ b/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
@@ -17,13 +17,24 @@
         /// </summary>
         /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
         public static void Start(this OperationTelemetry telemetry)
-        {            
+        {
+            Start(telemetry, Stopwatch.GetTimestamp());
+        }
+
+        /// <summary>
+        /// An extension to telemetry item that initializes the timer for the the respective telemetry
+        /// using a timestamp from a high-resolution <see cref="Stopwatch"/>.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
+        /// <param name="timestamp">A high-resolution timestamp from <see cref="Stopwatch"/>.</param>
+        public static void Start(this OperationTelemetry telemetry, long timestamp)
+        {
             telemetry.Timestamp = DateTimeOffset.UtcNow;
 
             // Begin time is used internally for calculating duration of operation at the end call,
             // and hence is stored using higher precision Clock.
             // Stopwatch.GetTimestamp() is used (instead of ElapsedTicks) as it is thread-safe.
-            telemetry.BeginTimeInTicks = Stopwatch.GetTimestamp();
+            telemetry.BeginTimeInTicks = timestamp;
         }
 
         /// <summary>
@@ -34,19 +45,29 @@
         {
             if (telemetry.BeginTimeInTicks != 0L)
             {
-                long stopWatchTicksDiff = Stopwatch.GetTimestamp() - telemetry.BeginTimeInTicks;
-                double durationInMillisecs = stopWatchTicksDiff * 1000 / (double)Stopwatch.Frequency;
-                telemetry.Duration = TimeSpan.FromMilliseconds(durationInMillisecs);
+                StopImpl(telemetry, timestamp: Stopwatch.GetTimestamp());
             }
             else
-            {                
-                telemetry.Duration = TimeSpan.Zero;
-            }
-
-            if (telemetry.Timestamp == DateTimeOffset.MinValue)
             {
-                telemetry.Timestamp = DateTimeOffset.UtcNow;
-            }            
+                StopImpl(telemetry, duration: TimeSpan.Zero);
+            }
+        }
+
+        /// <summary>
+        /// An extension method to telemetry item that stops the timer and computes the duration of the request or dependency.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
+        /// <param name="timestamp">A high-resolution timestamp from <see cref="Stopwatch"/>.</param>
+        public static void Stop(this OperationTelemetry telemetry, long timestamp)
+        {
+            if (telemetry.BeginTimeInTicks != 0L)
+            {
+                StopImpl(telemetry, timestamp);
+            }
+            else
+            {
+                StopImpl(telemetry, duration: TimeSpan.Zero);
+            }
         }
 
         /// <summary>
@@ -56,6 +77,33 @@
         public static void GenerateOperationId(this OperationTelemetry telemetry)
         {
             telemetry.Id = Convert.ToBase64String(BitConverter.GetBytes(WeakConcurrentRandom.Instance.Next()));
+        }
+
+        /// <summary>
+        /// Set the duration given a timestamp from a high-resolution <see cref="Stopwatch"/>.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item object to update.</param>
+        /// <param name="timestamp">The high resolution timestamp.</param>
+        private static void StopImpl(OperationTelemetry telemetry, long timestamp)
+        {
+            long stopWatchTicksDiff = timestamp - telemetry.BeginTimeInTicks;
+            double durationInMillisecs = stopWatchTicksDiff * 1000 / (double)Stopwatch.Frequency;
+            StopImpl(telemetry, TimeSpan.FromMilliseconds(durationInMillisecs));
+        }
+
+        /// <summary>
+        /// Record the duration and, optionally, set the timestamp to the current time.
+        /// </summary>
+        /// <param name="telemetry">Telemetry item object to update.</param>
+        /// <param name="duration">The duration of the operation.</param>
+        private static void StopImpl(OperationTelemetry telemetry, TimeSpan duration)
+        {
+            telemetry.Duration = duration;
+
+            if (telemetry.Timestamp == DateTimeOffset.MinValue)
+            {
+                telemetry.Timestamp = DateTimeOffset.UtcNow;
+            }
         }
     }
 }


### PR DESCRIPTION
Background:
In https://github.com/Microsoft/ApplicationInsights-aspnetcore/pull/343 I mentioned that it would be useful to have overloads of ```Start``` and ```Stop``` which take a timestamp so that we can use the timestamps already supplied by the diagnostic listeners and avoid additional calls to ```Stopwatch.GetTimestamp()```

Once this is available in ApplicationInsights-dotnet, it can be consumed in ApplicationInsights-aspnetcore.