### PR TITLE
Allow more precise durations in OperationTelemetryExtensions.Stop

### DIFF
--- a/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
+++ b/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
@@ -93,5 +93,30 @@
 
             Assert.Equal(TimeSpan.Zero, telemetry.Duration);
         }
+
+        /// <summary>
+        /// Tests the sceanrio if durations can be recorded more precisely than 1ms
+        /// </summary>
+        [TestMethod]
+        public void OperationTelemetryCanRecordPreciseDurations()
+        {
+            var telemetry = new DependencyTelemetry();
+
+            long startTime = Stopwatch.GetTimestamp();
+            telemetry.Start(timestamp: startTime);
+
+            // Note: Do not use TimeSpan.FromSeconds because it rounds to the nearest millisecond.
+            var expectedDuration = TimeSpan.Parse("00:00:00.1234560");
+
+            // Ensure we choose a time that has a fractional (non-integral) number of milliseconds
+            Assert.NotEqual(Math.Round(expectedDuration.TotalMilliseconds), expectedDuration.TotalMilliseconds);
+
+            double durationInStopwatchTicks = Stopwatch.Frequency * expectedDuration.TotalSeconds;
+
+            long stopTime = (long)(startTime + durationInStopwatchTicks);
+            telemetry.Stop(timestamp: stopTime);
+
+            Assert.Equal(expectedDuration, telemetry.Duration);
+        }
     }
 }

--- a/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
+++ b/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
@@ -13,6 +13,11 @@
     public static class OperationTelemetryExtensions
     {
         /// <summary>
+        /// Multiplier to convert Stopwatch ticks to TimeSpan ticks.
+        /// </summary>
+        private static readonly double StopwatchTicksToTimeSpanTicks = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
+
+        /// <summary>
         /// An extension to telemetry item that starts the timer for the the respective telemetry.
         /// </summary>
         /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
@@ -87,8 +92,8 @@
         private static void StopImpl(OperationTelemetry telemetry, long timestamp)
         {
             long stopWatchTicksDiff = timestamp - telemetry.BeginTimeInTicks;
-            double durationInMillisecs = stopWatchTicksDiff * 1000 / (double)Stopwatch.Frequency;
-            StopImpl(telemetry, TimeSpan.FromMilliseconds(durationInMillisecs));
+            double durationInTicks = stopWatchTicksDiff * StopwatchTicksToTimeSpanTicks;
+            StopImpl(telemetry, TimeSpan.FromTicks((long)durationInTicks));
         }
 
         /// <summary>


### PR DESCRIPTION
We were using TimeSpan.FromMilliseconds which rounds to the nearest millisecond(!)
Now we use TimeSpan.FromTicks which gives the most precision available.