### PR TITLE
Deadlock in EventSource Initialization

### DIFF
--- a/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -45,8 +45,7 @@
         public static TelemetryConfigurationFactory Instance
         {
             // Both get and set should write something to CoreEventSource so as to initialize it. This is a fix for below deadlock issue   
-            // https://github.com/Microsoft/ApplicationInsights-dotnet/issues/428            
-                 
+            // https://github.com/Microsoft/ApplicationInsights-dotnet/issues/428                             
             get
             {
                 if (instance != null)

--- a/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Net40/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -44,8 +44,28 @@
         /// </remarks>
         public static TelemetryConfigurationFactory Instance
         {
-            get { return instance ?? (instance = new TelemetryConfigurationFactory()); }
-            set { instance = value; }
+            // Both get and set should write something to CoreEventSource so as to initialize it. This is a fix for below deadlock issue   
+            // https://github.com/Microsoft/ApplicationInsights-dotnet/issues/428            
+                 
+            get
+            {
+                if (instance != null)
+                {
+                    return instance;
+                }
+                else
+                {
+                    instance = new TelemetryConfigurationFactory();                    
+                    CoreEventSource.Log.LogVerbose("TelemetryConfigurationFactory singleton instantiated.");
+                    return instance;
+                }
+            }
+
+            set
+            {
+                instance = value;                
+                CoreEventSource.Log.LogVerbose("TelemetryConfigurationFactory singleton set to given instance.");
+            }
         }
 
         public virtual void Initialize(TelemetryConfiguration configuration, TelemetryModules modules, string serializedConfiguration)


### PR DESCRIPTION
TelemetryConfigurationFactory modified to ensure it writes something to CoreEventSource so as to force initialize CoreEventSource and prevent any deadlock when other code starts writing to CoreEventSource .
Fixes the issue below by protecting SDK from causing the deadlock itself. ( User code can still cause this)
https://github.com/Microsoft/ApplicationInsights-dotnet/issues/428