### PR TITLE
Fix failing test when stopwatch frequency isn't exactly 10^7

### DIFF
--- a/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
+++ b/Test/CoreSDK.Test/Shared/OperationTelemetryExtensionsTests.cs
@@ -113,10 +113,21 @@
 
             double durationInStopwatchTicks = Stopwatch.Frequency * expectedDuration.TotalSeconds;
 
-            long stopTime = (long)(startTime + durationInStopwatchTicks);
+            long stopTime = (long)Math.Round(startTime + durationInStopwatchTicks);
             telemetry.Stop(timestamp: stopTime);
 
-            Assert.Equal(expectedDuration, telemetry.Duration);
+            if (Stopwatch.Frequency == TimeSpan.TicksPerSecond)
+            {
+                // In this case, the times should match exactly.
+                Assert.Equal(expectedDuration, telemetry.Duration);
+            }
+            else
+            {
+                // There will be a difference, but it should be less than
+                // 1 microsecond (10 ticks)
+                var difference = (telemetry.Duration - expectedDuration).Duration();
+                Assert.True(difference.Ticks < 10);
+            }
         }
     }
 }

--- a/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
+++ b/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
@@ -93,7 +93,7 @@
         {
             long stopWatchTicksDiff = timestamp - telemetry.BeginTimeInTicks;
             double durationInTicks = stopWatchTicksDiff * StopwatchTicksToTimeSpanTicks;
-            StopImpl(telemetry, TimeSpan.FromTicks((long)durationInTicks));
+            StopImpl(telemetry, TimeSpan.FromTicks((long)Math.Round(durationInTicks)));
         }
 
         /// <summary>


### PR DESCRIPTION
@karolz-ms reported a failure in the OperationTelemetryCanRecordPreciseDurations test on a physical machine where stopwatch ticks did not match timespan ticks. In that case, we need to allow for some epsilon in the test.

I also modified the implementation to use Math.Round when converting to TimeSpan ticks which gives a further, slight accuracy improvement in those cases.