### PR TITLE
Fix for AclsAreAppliedToLocalAppData and AclsAreAppliedToTemp

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/ApplicationFolderProviderTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/ApplicationFolderProviderTest.cs
@@ -223,7 +223,7 @@
             Assert.AreEqual(new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Value, rulesCollection[0].IdentityReference.Value);
 
             Assert.IsFalse(rulesCollection[1].IsInherited);
-            Assert.AreEqual(WindowsIdentity.GetCurrent().Owner.Value, rulesCollection[1].IdentityReference.Value);
+            Assert.AreEqual(WindowsIdentity.GetCurrent().User.Value, rulesCollection[1].IdentityReference.Value);
 
             localAppData.Delete(true);
         }
@@ -252,7 +252,7 @@
             Assert.AreEqual(new SecurityIdentifier(WellKnownSidType.BuiltinAdministratorsSid, null).Value, rulesCollection[0].IdentityReference.Value);
 
             Assert.IsFalse(rulesCollection[1].IsInherited);
-            Assert.AreEqual(WindowsIdentity.GetCurrent().Owner.Value, rulesCollection[1].IdentityReference.Value);
+            Assert.AreEqual(WindowsIdentity.GetCurrent().User.Value, rulesCollection[1].IdentityReference.Value);
 
             localAppData.Delete(true);
         }


### PR DESCRIPTION
AclsAreAppliedToLocalAppData and AclsAreAppliedToTemp are failing if VS is running elevated