### PR TITLE
mark InMemoryChannel as internal sdk operation. This will allow excep…

### DIFF
--- a/src/Core/Managed/Operation.AL.Shared/Extensibility/SdkInternalOperationsMonitor.cs
+++ b/src/Core/Managed/Operation.AL.Shared/Extensibility/SdkInternalOperationsMonitor.cs
@@ -1,0 +1,40 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// Helps to define whether thread is performing SDK internal operation at the moment.
+    /// </summary>
+    public static class SdkInternalOperationsMonitor
+    {
+        private static AsyncLocal<object> asyncLocalContext = new AsyncLocal<object>();
+
+        private static object syncObj = new object();
+
+        /// <summary>
+        /// Determines whether the current thread executing the internal operation.
+        /// </summary>
+        /// <returns>true if the current thread executing the internal operation; otherwise, false.</returns>
+        public static bool IsEntered()
+        {
+            return asyncLocalContext.Value != null;
+        }
+
+        /// <summary>
+        /// Marks the thread as executing the internal operation.
+        /// </summary>
+        public static void Enter()
+        {
+            asyncLocalContext.Value = syncObj;
+        }
+
+        /// <summary>
+        /// Unmarks the thread as executing the internal operation.
+        /// </summary>
+        public static void Exit()
+        {
+            asyncLocalContext.Value = null;
+        }
+    }
+}

--- a/src/Core/Managed/Operation.AL.Shared/Operation.AL.Shared.projitems
+++ b/src/Core/Managed/Operation.AL.Shared/Operation.AL.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\AsyncLocalBasedOperationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\AsyncLocalHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationContextForAsyncLocal.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\SdkInternalOperationsMonitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/src/Core/Managed/Operation.CC.Shared/Extensibility/SdkInternalOperationsMonitor.cs
+++ b/src/Core/Managed/Operation.CC.Shared/Extensibility/SdkInternalOperationsMonitor.cs
@@ -1,0 +1,64 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility
+{
+    using System;
+    using System.Runtime.Remoting.Messaging;
+
+    /// <summary>
+    /// Helps to define whether thread is performing SDK internal operation at the moment.
+    /// </summary>
+    public static class SdkInternalOperationsMonitor
+    {
+        internal const string InternalOperationsMonitorSlotName = "Microsoft.ApplicationInsights.InternalSdkOperation";
+
+        private static Object syncObj = new object();
+
+        /// <summary>
+        /// Determines whether the current thread executing the internal operation.
+        /// </summary>
+        /// <returns>true if the current thread executing the internal operation; otherwise, false.</returns>
+        public static bool IsEntered()
+        {
+            object data = null;
+            try
+            {
+                data = CallContext.LogicalGetData(InternalOperationsMonitorSlotName);
+            }
+            catch (Exception)
+            {
+                // CallContext may fail in partially trusted environment
+            }
+
+            return data != null;
+        }
+
+        /// <summary>
+        /// Marks the thread as executing the internal operation.
+        /// </summary>
+        public static void Enter()
+        {
+            try
+            {
+                CallContext.LogicalSetData(InternalOperationsMonitorSlotName, syncObj);
+            }
+            catch (Exception)
+            {
+                // CallContext may fail in partially trusted environment
+            }
+        }
+
+        /// <summary>
+        /// Unmarks the thread as executing the internal operation.
+        /// </summary>
+        public static void Exit()
+        {
+            try
+            {
+                CallContext.FreeNamedDataSlot(InternalOperationsMonitorSlotName);
+            }
+            catch (Exception)
+            {
+                // CallContext may fail in partially trusted environment
+            }
+        }
+    }
+}

--- a/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.projitems
+++ b/src/Core/Managed/Operation.CC.Shared/Operation.CC.Shared.projitems
@@ -16,6 +16,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextBasedOperationHolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CallContextHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\OperationContextForCallContext.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\SdkInternalOperationsMonitor.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryClientExtensions.cs" />
   </ItemGroup>
 </Project>

--- a/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
+++ b/src/Core/Managed/Shared/Channel/InMemoryTransmitter.cs
@@ -6,12 +6,10 @@ namespace Microsoft.ApplicationInsights.Channel
 {
     using System;
     using System.Collections.Generic;
-    using System.Diagnostics;
     using System.Globalization;
-    using System.Linq;
-    using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
+    using Extensibility;
     using Extensibility.Implementation;
     using Extensibility.Implementation.Tracing;
 
@@ -80,7 +78,19 @@ namespace Microsoft.ApplicationInsights.Channel
         /// </summary>
         internal void Flush(TimeSpan timeout)
         {
-            this.DequeueAndSend(timeout);
+#if !CORE_PCL
+            SdkInternalOperationsMonitor.Enter();
+            try
+            {
+#endif
+                this.DequeueAndSend(timeout);
+#if !CORE_PCL
+            }
+            finally
+            {
+                SdkInternalOperationsMonitor.Exit();
+            }
+#endif
         }
 
         /// <summary>
@@ -89,17 +99,29 @@ namespace Microsoft.ApplicationInsights.Channel
         /// </summary>
         private void Runner()
         {
-            using (this.startRunnerEvent = new AutoResetEvent(false))
+#if !CORE_PCL
+            SdkInternalOperationsMonitor.Enter();
+            try
             {
-                while (this.enabled)
+#endif
+                using (this.startRunnerEvent = new AutoResetEvent(false))
                 {
-                    // Pulling all items from the buffer and sending as one transmissiton.
-                    this.DequeueAndSend(timeout: default(TimeSpan)); // when default(TimeSpan) is provided, value is ignored and default timeout of 100 sec is used
+                    while (this.enabled)
+                    {
+                        // Pulling all items from the buffer and sending as one transmissiton.
+                        this.DequeueAndSend(timeout: default(TimeSpan)); // when default(TimeSpan) is provided, value is ignored and default timeout of 100 sec is used
 
-                    // Waiting for the flush delay to elapse
-                    this.startRunnerEvent.WaitOne(this.sendingInterval);
+                        // Waiting for the flush delay to elapse
+                        this.startRunnerEvent.WaitOne(this.sendingInterval);
+                    }
                 }
+#if !CORE_PCL
             }
+            finally
+            {
+                SdkInternalOperationsMonitor.Exit();
+            }
+#endif
         }
 
         /// <summary>

--- a/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
+++ b/src/Core/Managed/Shared/Channel/TelemetryBuffer.cs
@@ -118,7 +118,7 @@
             }
         }
 
-        public IEnumerable<ITelemetry> Dequeue()
+        public virtual IEnumerable<ITelemetry> Dequeue()
         {
             List<ITelemetry> telemetryToFlush = null;
 


### PR DESCRIPTION
…tions statistics to pick mark those exceptions as internal

This PR creates a foundation to address the feedback for exception statistics: https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/212:

>One of the biggest feedbacks so far for exception statistics is that internal SDK exceptions should be marked somehow or filtered. 

If approach looks OK - I'll mark server telemetry channel and configuration reading logic as well.