### PR TITLE
Sergkanz/task timer deprecation

### DIFF
--- a/Test/CoreSDK.Test/Shared/Core.Shared.Tests.projitems
+++ b/Test/CoreSDK.Test/Shared/Core.Shared.Tests.projitems
@@ -51,7 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SnapshottingCollectionTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SnapshottingListTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TagsTest.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TaskTimerTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TaskTimerInternalTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\DiagnoisticsEventThrottlingInitializationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\DiagnoisticsEventThrottlingManagerInitializationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\DiagnoisticsEventThrottlingManagerTest.cs" />

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerInternalTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerInternalTest.cs
@@ -18,7 +18,7 @@
     using Assert = Xunit.Assert;
 
     [TestClass]
-    public class TaskTimerTest
+    public class TaskTimerInternalTest
     {
         [TestClass]
         public class Delay

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerTest.cs
@@ -26,14 +26,14 @@
             [TestMethod]
             public void DefaultValueIsOneMinuteBecauseItHasToBeSomethingValid()
             {
-                var timer = new TaskTimer();
+                var timer = new TaskTimerInternal();
                 Assert.Equal(TimeSpan.FromMinutes(1), timer.Delay);
             }
 
             [TestMethod]
             public void CanBeChangedByConfigurableChannelComponents()
             {
-                var timer = new TaskTimer();
+                var timer = new TaskTimerInternal();
                 timer.Delay = TimeSpan.FromSeconds(42);
                 Assert.Equal(42, timer.Delay.TotalSeconds);
             }
@@ -41,7 +41,7 @@
             [TestMethod]
             public void CanBeSetToInfiniteToPreventTimerFromFiring()
             {
-                var timer = new TaskTimer();
+                var timer = new TaskTimerInternal();
                 timer.Delay = new TimeSpan(0, 0, 0, 0, -1);
                 Assert.Equal(new TimeSpan(0, 0, 0, 0, -1), timer.Delay);
             }
@@ -49,14 +49,14 @@
             [TestMethod]
             public void ThrowsArgumentOutOfRangeExceptionWhenNewValueIsZeroOrLess()
             {
-                var timer = new TaskTimer();
+                var timer = new TaskTimerInternal();
                 Assert.Throws<ArgumentOutOfRangeException>(() => timer.Delay = TimeSpan.Zero);
             }
 
             [TestMethod]
             public void ThrowsArgumentOutOfRangeExceptionWhenNewValueIsMoreThanMaxIntMilliseconds()
             {
-                var timer = new TaskTimer();
+                var timer = new TaskTimerInternal();
                 Assert.Throws<ArgumentOutOfRangeException>(() => timer.Delay = TimeSpan.FromMilliseconds((double)int.MaxValue + 1));
             }
         }
@@ -67,14 +67,14 @@
             [TestMethod]
             public void ReturnsFalseIfTimerWasNeverStarted()
             {
-                var timer = new TaskTimer();
+                var timer = new TaskTimerInternal();
                 Assert.False(timer.IsStarted);
             }
 
             [TestMethod]
             public void ReturnsTrueWhileUntilActionIsInvoked()
             {
-                var timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
+                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
 
                 var actionStarted = new ManualResetEventSlim();
                 var actionCanFinish = new ManualResetEventSlim();
@@ -107,7 +107,7 @@
                 {
                     listener.EnableEvents(CoreEventSource.Log, EventLevel.Error);
 
-                    var timer = new TaskTimer {Delay = TimeSpan.FromMilliseconds(1)};
+                    var timer = new TaskTimerInternal {Delay = TimeSpan.FromMilliseconds(1)};
                     var actionInvoked = new ManualResetEventSlim();
 
                     timer.Start(() => { actionInvoked.Set(); return null; });
@@ -123,7 +123,7 @@
             [TestMethod]
             public void InvokesActionAfterDelay()
             {
-                var timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
+                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
 
                 var actionInvoked = new ManualResetEventSlim();
                 timer.Start(() => Task.Factory.StartNew(actionInvoked.Set));
@@ -135,7 +135,7 @@
             [TestMethod]
             public void CancelsPreviousActionWhenStartIsCalledMultipleTimes()
             {
-                var timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
+                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
 
                 int invokationCount = 0;
                 var lastActionInvoked = new ManualResetEventSlim();
@@ -156,7 +156,7 @@
             [Timeout(1500)]
             public void HandlesAsyncExceptionThrownByTheDelegate()
             {
-                TaskTimer timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
+                TaskTimerInternal timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
 
                 using (TestEventListener listener = new TestEventListener())
                 {
@@ -172,7 +172,7 @@
             [Timeout(1500)]
             public void HandlesSyncExceptionThrownByTheDelegate()
             {
-                TaskTimer timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
+                TaskTimerInternal timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
 
                 using (TestEventListener listener = new TestEventListener())
                 {
@@ -192,7 +192,7 @@
             {
                 AsyncTest.Run(async () =>
                 {
-                    var timer = new TaskTimer { Delay = TimeSpan.FromMilliseconds(1) };
+                    var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
         
                     bool actionInvoked = false;
                     timer.Start(() => Task.Factory.StartNew(() => actionInvoked = true));

--- a/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimerInternal.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimerInternal.cs
@@ -1,0 +1,170 @@
+﻿// <copyright file="TaskTimerInternal.cs" company="Microsoft">
+// Copyright © Microsoft. All Rights Reserved.
+// </copyright>
+
+namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+#if CORE_PCL || NET45 || NET46
+    using TaskEx = System.Threading.Tasks.Task;
+#endif
+
+    /// <summary>
+    /// Runs a task after a certain delay and log any error.
+    /// </summary>
+    internal class TaskTimerInternal : IDisposable
+    {
+        /// <summary>
+        /// Represents an infinite time span.
+        /// </summary>
+        public static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, Timeout.Infinite);
+
+        private TimeSpan delay = TimeSpan.FromMinutes(1);
+        private CancellationTokenSource tokenSource;
+
+        /// <summary>
+        /// Gets or sets the delay before the task starts. 
+        /// </summary>
+        public TimeSpan Delay 
+        { 
+            get
+            {
+                return this.delay;
+            }
+
+            set
+            {
+                if ((value <= TimeSpan.Zero || value.TotalMilliseconds > int.MaxValue) && value != InfiniteTimeSpan)
+                {
+                    throw new ArgumentOutOfRangeException("value");
+                }
+
+                this.delay = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether value that indicates if a task has already started.
+        /// </summary>
+        public bool IsStarted
+        {
+            get { return this.tokenSource != null; }
+        }
+
+        /// <summary>
+        /// Start the task.
+        /// </summary>
+        /// <param name="elapsed">The task to run.</param>
+        public void Start(Func<Task> elapsed)
+        {
+            var newTokenSource = new CancellationTokenSource();
+
+            TaskEx.Delay(this.Delay, newTokenSource.Token)
+                .ContinueWith(
+#if !NET40
+                async previousTask =>
+#else
+                    previousTask =>
+#endif
+                    {
+                        CancelAndDispose(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
+                        try
+                        {
+                            Task task = elapsed();
+
+                            // Task may be executed syncronously
+                            // It should return Task.FromResult but just in case we check for null if someone returned null
+                            if (task != null)
+                            {
+#if !NET40
+                                await task.ConfigureAwait(false);
+#else
+                                task.ContinueWith(
+                                    userTask =>
+                                    {
+                                        try
+                                        {
+                                            userTask.RethrowIfFaulted();
+                                        }
+                                        catch (Exception exception)
+                                        {
+                                            LogException(exception);
+                                        }
+                                    },
+                                    CancellationToken.None,
+                                    TaskContinuationOptions.ExecuteSynchronously,
+                                    TaskScheduler.Default);
+#endif
+                            }
+                        }
+                        catch (Exception exception)
+                        {
+                            LogException(exception);
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+
+            CancelAndDispose(Interlocked.Exchange(ref this.tokenSource, newTokenSource));
+        }
+
+        /// <summary>
+        /// Cancels the current task.
+        /// </summary>
+        public void Cancel()
+        {
+            CancelAndDispose(Interlocked.Exchange(ref this.tokenSource, null));
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Log exception thrown by outer code.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        private static void LogException(Exception exception)
+        {
+            var aggregateException = exception as AggregateException;
+            if (aggregateException != null)
+            {
+                aggregateException = aggregateException.Flatten();
+                foreach (Exception e in aggregateException.InnerExceptions)
+                {
+                    CoreEventSource.Log.LogError(e.ToInvariantString());
+                }
+            }
+
+            CoreEventSource.Log.LogError(exception.ToInvariantString());
+        }
+
+        private static void CancelAndDispose(CancellationTokenSource tokenSource)
+        {
+            if (tokenSource != null)
+            {
+                tokenSource.Cancel();
+                tokenSource.Dispose();
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.Cancel();
+            }
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/DiagnoisticsEventThrottlingScheduler.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Tracing/DiagnoisticsEventThrottlingScheduler.cs
@@ -16,7 +16,7 @@
     internal class DiagnoisticsEventThrottlingScheduler 
         : IDiagnoisticsEventThrottlingScheduler, IDisposable
     {
-        private readonly IList<TaskTimer> timers = new List<TaskTimer>();
+        private readonly IList<TaskTimerInternal> timers = new List<TaskTimerInternal>();
         private volatile bool disposed = false;
 
         ~DiagnoisticsEventThrottlingScheduler()
@@ -61,7 +61,7 @@
                 throw new ArgumentNullException("token");
             }
 
-            var timer = token as TaskTimer;
+            var timer = token as TaskTimerInternal;
             if (timer == null)
             {
                 throw new ArgumentException("token");
@@ -92,11 +92,11 @@
             }
         }
 
-        private static TaskTimer InternalCreateAndStartTimer(
+        private static TaskTimerInternal InternalCreateAndStartTimer(
             int intervalInMilliseconds,
             Action action)
         {
-            var timer = new TaskTimer
+            var timer = new TaskTimerInternal
             {
                 Delay = TimeSpan.FromMilliseconds(intervalInMilliseconds)
             };

--- a/src/Core/Managed/Shared/Extensibility/MetricManager.cs
+++ b/src/Core/Managed/Shared/Extensibility/MetricManager.cs
@@ -43,7 +43,7 @@
         /// <summary>
         /// Metric aggregation snapshot task.
         /// </summary>
-        private TaskTimer snapshotTimer;
+        private TaskTimerInternal snapshotTimer;
 
         /// <summary>
         /// Last time snapshot was initiated.
@@ -75,7 +75,7 @@
 
             this.lastSnapshotStartDateTime = DateTimeOffset.UtcNow;
 
-            this.snapshotTimer = new TaskTimer() { Delay = GetWaitTime() };
+            this.snapshotTimer = new TaskTimerInternal() { Delay = GetWaitTime() };
             this.snapshotTimer.Start(this.SnapshotAndReschedule);
         }
 

--- a/src/Core/Managed/Shared/Shared.projitems
+++ b/src/Core/Managed/Shared/Shared.projitems
@@ -62,6 +62,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\HttpWebResponseWrapper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SdkVersionUtils.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SimpleMetricStatisticsAggregator.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TaskTimer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TelemetryDebugWriter.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\CloudContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\DeviceContext.cs" />
@@ -82,7 +83,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SeverityLevelExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SnapshottingCollection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\SnapshottingList.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TaskTimer.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TaskTimerInternal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Telemetry.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\TelemetryContextExtensions.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\External\ExceptionDetails.cs" />

--- a/src/TelemetryChannels/ServerTelemetryChannel/Net40/TaskEx.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Net40/TaskEx.cs
@@ -1,0 +1,105 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    internal static class TaskEx
+    {
+        /// <summary>
+        /// Check and rethrow exception for failed task.
+        /// </summary>
+        /// <param name="task">Task to check.</param>
+        public static void RethrowIfFaulted(this Task task)
+        {
+            if (!task.IsCompleted)
+            {
+                throw new ArgumentException("Task is not yet completed");
+            }
+
+            if (task.IsFaulted)
+            {
+                throw new AggregateException(task.Exception).Flatten();
+            }
+        }
+
+        /// <summary>
+        /// Creates a task that completes after a specified time interval.
+        /// </summary>
+        /// <param name="timeout">The time span to wait before completing the returned task.</param>
+        /// <returns>A Task that represents the time delay.</returns>
+        public static Task Delay(TimeSpan timeout)
+        {
+            return Delay(timeout, CancellationToken.None);
+        }
+
+        /// <summary>
+        /// Creates a task that completes after a specified time interval.
+        /// </summary>
+        /// <param name="timeout">The time span to wait before completing the returned task.</param>
+        /// <param name="token">The cancellation token that will interrupt delay.</param>
+        /// <returns>A Task that represents the time delay.</returns>
+        public static Task Delay(TimeSpan timeout, CancellationToken token)
+        {
+            TaskCompletionSource<object> tcs = new TaskCompletionSource<object>();
+
+            if (timeout.Ticks <= 0)
+            {
+                tcs.SetResult(null);
+                return tcs.Task;
+            }
+
+            Timer timer = null;
+            timer = new Timer(
+                state =>
+                    {
+                        timer.Dispose();
+                        tcs.TrySetResult(null);
+                    }, 
+                null, 
+                timeout, 
+                TimeSpan.FromMilliseconds(Timeout.Infinite));
+
+            token.Register(
+                () =>
+                    {
+                        timer.Dispose();
+                        tcs.TrySetCanceled();
+                    });
+
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Creates a Task that's completed successfully with the specified result.
+        /// </summary>
+        /// <typeparam name="TResult">The type of the result returned by the task.</typeparam>
+        /// <param name="result">The result to store into the completed task.</param>
+        /// <returns>The successfully completed task.</returns>
+        public static Task<TResult> FromResult<TResult>(TResult result)
+        {
+            TaskCompletionSource<TResult> tcs = new TaskCompletionSource<TResult>();
+            tcs.SetResult(result);
+            return tcs.Task;
+        }
+
+        /// <summary>
+        /// Creates a task that will complete when any of the supplied tasks have completed.
+        /// </summary>
+        /// <param name="tasks">The tasks to wait on for completion.</param>
+        /// <returns>A task that represents the completion of one of the supplied tasks. The return Task's Result is the task that completed.</returns>
+        public static Task<Task> WhenAny(params Task[] tasks)
+        {
+            if (tasks.Length == 0)
+            {
+                throw new ArgumentException("The tasks argument contains no tasks");
+            }
+
+            TaskCompletionSource<Task> taskCompletionSource = new TaskCompletionSource<Task>();
+
+            Task.Factory.ContinueWhenAny(tasks, completedTask => taskCompletionSource.SetResult(completedTask), TaskContinuationOptions.ExecuteSynchronously);
+
+            return taskCompletionSource.Task;
+        }
+    }
+}

--- a/src/TelemetryChannels/ServerTelemetryChannel/Net40/TelemetryChannel.Net40.csproj
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Net40/TelemetryChannel.Net40.csproj
@@ -77,6 +77,9 @@
     <Analyzer Include="..\..\..\..\..\packages\Desktop.Analyzers.1.1.0\analyzers\dotnet\cs\Desktop.Analyzers.dll" />
     <Analyzer Include="..\..\..\..\..\packages\Desktop.Analyzers.1.1.0\analyzers\dotnet\cs\Desktop.CSharp.Analyzers.dll" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Include="TaskEx.cs" />
+  </ItemGroup>
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets" Condition="Exists('..\..\..\..\..\packages\StyleCop.MSBuild.4.7.49.0\build\StyleCop.MSBuild.Targets')" />

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
@@ -20,7 +20,7 @@
         private readonly object lockConsecutiveErrors = new object();
         private readonly TimeSpan minIntervalToUpdateConsecutiveErrors;
 
-        private TaskTimer pauseTimer = new TaskTimer { Delay = TimeSpan.FromSeconds(SlotDelayInSeconds) };
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(SlotDelayInSeconds) };
         private bool exponentialBackoffReported = false;
         private int consecutiveErrors;
         private DateTimeOffset nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TaskTimerInternal.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TaskTimerInternal.cs
@@ -1,0 +1,171 @@
+﻿// <copyright file="TaskTimerInternal.cs" company="Microsoft">
+// Copyright © Microsoft. All Rights Reserved.
+// </copyright>
+
+namespace Microsoft.ApplicationInsights.Extensibility.Implementation
+{
+    using System;
+    using System.Threading;
+    using System.Threading.Tasks;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using WindowsServer.TelemetryChannel.Implementation;
+
+#if CORE_PCL || NET45 || NET46
+    using TaskEx = System.Threading.Tasks.Task;
+#endif
+
+    /// <summary>
+    /// Runs a task after a certain delay and log any error.
+    /// </summary>
+    internal class TaskTimerInternal : IDisposable
+    {
+        /// <summary>
+        /// Represents an infinite time span.
+        /// </summary>
+        public static readonly TimeSpan InfiniteTimeSpan = new TimeSpan(0, 0, 0, 0, Timeout.Infinite);
+
+        private TimeSpan delay = TimeSpan.FromMinutes(1);
+        private CancellationTokenSource tokenSource;
+
+        /// <summary>
+        /// Gets or sets the delay before the task starts. 
+        /// </summary>
+        public TimeSpan Delay 
+        { 
+            get
+            {
+                return this.delay;
+            }
+
+            set
+            {
+                if ((value <= TimeSpan.Zero || value.TotalMilliseconds > int.MaxValue) && value != InfiniteTimeSpan)
+                {
+                    throw new ArgumentOutOfRangeException("value");
+                }
+
+                this.delay = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets a value indicating whether value that indicates if a task has already started.
+        /// </summary>
+        public bool IsStarted
+        {
+            get { return this.tokenSource != null; }
+        }
+
+        /// <summary>
+        /// Start the task.
+        /// </summary>
+        /// <param name="elapsed">The task to run.</param>
+        public void Start(Func<Task> elapsed)
+        {
+            var newTokenSource = new CancellationTokenSource();
+
+            TaskEx.Delay(this.Delay, newTokenSource.Token)
+                .ContinueWith(
+#if !NET40
+                async previousTask =>
+#else
+                    previousTask =>
+#endif
+                    {
+                        CancelAndDispose(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
+                        try
+                        {
+                            Task task = elapsed();
+
+                            // Task may be executed syncronously
+                            // It should return Task.FromResult but just in case we check for null if someone returned null
+                            if (task != null)
+                            {
+#if !NET40
+                                await task.ConfigureAwait(false);
+#else
+                                task.ContinueWith(
+                                    userTask =>
+                                    {
+                                        try
+                                        {
+                                            userTask.RethrowIfFaulted();
+                                        }
+                                        catch (Exception exception)
+                                        {
+                                            LogException(exception);
+                                        }
+                                    },
+                                    CancellationToken.None,
+                                    TaskContinuationOptions.ExecuteSynchronously,
+                                    TaskScheduler.Default);
+#endif
+                            }
+                        }
+                        catch (Exception exception)
+                        {
+                            LogException(exception);
+                        }
+                    },
+                    CancellationToken.None,
+                    TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
+                    TaskScheduler.Default);
+
+            CancelAndDispose(Interlocked.Exchange(ref this.tokenSource, newTokenSource));
+        }
+
+        /// <summary>
+        /// Cancels the current task.
+        /// </summary>
+        public void Cancel()
+        {
+            CancelAndDispose(Interlocked.Exchange(ref this.tokenSource, null));
+        }
+
+        /// <summary>
+        /// Releases unmanaged and - optionally - managed resources.
+        /// </summary>
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        /// <summary>
+        /// Log exception thrown by outer code.
+        /// </summary>
+        /// <param name="exception">Exception to log.</param>
+        private static void LogException(Exception exception)
+        {
+            var aggregateException = exception as AggregateException;
+            if (aggregateException != null)
+            {
+                aggregateException = aggregateException.Flatten();
+                foreach (Exception e in aggregateException.InnerExceptions)
+                {
+                    TelemetryChannelEventSource.Log.LogError(e.ToInvariantString());
+                }
+            }
+
+            TelemetryChannelEventSource.Log.LogError(exception.ToInvariantString());
+        }
+
+        private static void CancelAndDispose(CancellationTokenSource tokenSource)
+        {
+            if (tokenSource != null)
+            {
+                tokenSource.Cancel();
+                tokenSource.Dispose();
+            }
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                this.Cancel();
+            }
+        }
+    }
+}

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -18,7 +18,7 @@
     {
         private static readonly TimeSpan DefaultFlushDelay = TimeSpan.FromSeconds(30);
 
-        private readonly TaskTimer flushTimer;
+        private readonly TaskTimerInternal flushTimer;
         private readonly TelemetrySerializer serializer;
 
         private int capacity = 500;
@@ -47,7 +47,7 @@
 
         protected TelemetryBuffer()
         {
-            this.flushTimer = new TaskTimer { Delay = DefaultFlushDelay };
+            this.flushTimer = new TaskTimerInternal { Delay = DefaultFlushDelay };
             this.transmissionBuffer = new List<ITelemetry>(this.Capacity);
         }
 

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -472,6 +472,15 @@
                 this.ApplicationName);
         }
 
+        [Event(66, Message = "[msg=Log Error];[msg={0}]", Level = EventLevel.Error)]
+        public void LogError(string msg, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                66,
+                msg ?? string.Empty,
+                this.ApplicationName);
+        }
+
         private string GetApplicationName()
         {
             string name;

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Shared.projitems
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ErrorHandlingTransmissionPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ExceptionHandler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ExponentialMovingAverageCounter.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\TaskTimerInternal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\ThrottlingTransmissionPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\BackoffLogicManager.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\IApplicationFolderProvider.cs" />


### PR DESCRIPTION
There is no place for `TaskTimer` class in Application Insights API. It was implemented before.

>`TaskTimer` is defined in the `Microsoft.ApplicationInsights` assembly because it is still used here as well as in other AI packages that depend on it. However, it doesn't need to be public anymore because we no longer publish WinRT assemblies. The class was implemented as public because WinRT didn't support internal class visibility at the time. Instead we placed it in the "Implementation" namespace and decided that semver does not apply to public types in this namespace. It should be safe to make `TaskTimer` internal straight away. 