### PR TITLE
Rationalize product.props settings.

### DIFF
--- a/Global.props
+++ b/Global.props
@@ -66,8 +66,8 @@
         <BinRoot>$([System.IO.Path]::GetFullPath( $(BinRoot) ))</BinRoot>
                 
         <RelativeOutputPathBase>$(MSBuildProjectDirectory.Substring($(EnlistmentRoot.Length)))</RelativeOutputPathBase>
-        
-        <BaseIntermediateOutputPath>$(EnlistmentRoot)\..\obj</BaseIntermediateOutputPath>
+
+        <BaseIntermediateOutputPath>$(EnlistmentRoot)\..\obj\$(MSBuildProjectName)</BaseIntermediateOutputPath>
         <BaseIntermediateOutputPath>$([System.IO.Path]::GetFullPath( $(BaseIntermediateOutputPath) ))</BaseIntermediateOutputPath>
 
         <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -99,9 +99,6 @@
         <RestorePackages>true</RestorePackages>
         <RequireRestoreConsent>false</RequireRestoreConsent>
         
-        <!-- Set the root namespace for all assemblies in this project hierarchy --> 
-        <RootNamespace>Microsoft.ApplicationInsights</RootNamespace>        
-      
         <!-- Disable StyleCop by default to prevent StyleCop.MSBuild package from slowing down the debug build -->
         <StyleCopEnabled>false</StyleCopEnabled>
     </PropertyGroup>

--- a/src/Core/Managed/Core.csproj
+++ b/src/Core/Managed/Core.csproj
@@ -5,8 +5,6 @@
 
   <PropertyGroup>
     <Company>Microsoft</Company>
-    <!-- This is not the final NuGet package ID, but it must be distinct from the real one or else we get 'Ambiguous project name' during dotnet restore. -->
-    <PackageId>Microsoft.ApplicationInsights.Core</PackageId>
     <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>

--- a/src/Core/NuGet/Core.NuGet.csproj
+++ b/src/Core/NuGet/Core.NuGet.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
+  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Common.props'))\Common.props" />
 
   <PropertyGroup>
     <TargetFrameworks>net45</TargetFrameworks>

--- a/src/Core/Product.props
+++ b/src/Core/Product.props
@@ -6,10 +6,10 @@
     <CorePath>$(RelativeOutputPathBase.Substring(4))</CorePath>	
     <OutputPath>$(BinRoot)\$(Configuration)\$(CorePath)</OutputPath>
     <OutputPath>$([System.IO.Path]::GetFullPath( $(OutputPath) ))\</OutputPath>
-    <BaseIntermediateOutputPath>$(BaseIntermediateOutputPath)\$(MSBuildProjectName)</BaseIntermediateOutputPath>
   </PropertyGroup>
   
   <PropertyGroup>
+    <RootNamespace>Microsoft.ApplicationInsights</RootNamespace>
     <AssemblyName>$(RootNamespace)</AssemblyName>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).XML</DocumentationFile>
   </PropertyGroup>

--- a/src/TelemetryChannels/ServerTelemetryChannel/Product.props
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Product.props
@@ -11,25 +11,6 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel</RootNamespace>
     <AssemblyName>Microsoft.AI.ServerTelemetryChannel</AssemblyName>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <DocumentationFile>$(OutputPath)\$(AssemblyName).XML</DocumentationFile>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <DefineConstants>$(DefineConstants);DEBUG;TRACE</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(Configuration)' == 'Release'">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <RunCodeAnalysis>true</RunCodeAnalysis>
-    <StyleCopEnabled>True</StyleCopEnabled>
-    <StyleCopTreatErrorsAsWarnings>False</StyleCopTreatErrorsAsWarnings>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <DefineConstants>$(DefineConstants);TRACE</DefineConstants>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fixes #455

1. Move BaseIntermediateOutputPath adjustment into Global.props. This prevents collisions with project.assets.json files.
2. Move setting of RootNamespace out of Global.props into Product.props
3. Remove workaround for colliding package IDs between Core.csproj and Core.NuGet.csproj