### PR TITLE
Enable OperationCorrelationTelemetryInitializer in NetStandard build

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -87,7 +87,6 @@
             Assert.False(string.IsNullOrEmpty(configuration.InstrumentationKey));
         }
 
-#if !NETSTANDARD1_3
         [TestMethod]
         public void InitializeAddsOperationContextTelemetryInitializerByDefault()
         {
@@ -97,8 +96,7 @@
             var contextInitializer = configuration.TelemetryInitializers[0];
             Assert.IsType<OperationCorrelationTelemetryInitializer>(contextInitializer);
         }
-#endif
-        
+
         [TestMethod]
         public void InitializeNotifiesTelemetryInitializersImplementingITelemetryModuleInterface()
         {

--- a/src/Core/Managed/Core.csproj
+++ b/src/Core/Managed/Core.csproj
@@ -28,7 +28,7 @@
     <Compile Include="net45\**\*.cs" Condition="'$(TargetFramework)' == 'net45'" />
     <Compile Include="net46\**\*.cs" Condition="'$(TargetFramework)' == 'net46'" />
     <Compile Include="netstandard1.3\**\*.cs" Condition="'$(TargetFramework)' == 'netstandard1.3'" />
-    <Compile Include="Operation.AL.Shared\**\*.cs" Condition="'$(TargetFramework)' == 'net46'" />
+    <Compile Include="Operation.AL.Shared\**\*.cs" Condition="'$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'netstandard1.3'" />
     <Compile Include="Operation.CC.Shared\**\*.cs" Condition="'$(TargetFramework)' == 'net40' or '$(TargetFramework)' == 'net45'" />
   </ItemGroup>
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -56,9 +56,8 @@
                 modules.Modules.Add(new DiagnosticsTelemetryModule());
             }
 
-#if !NETSTANDARD1_3
             configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
-#endif
+
             // Load configuration from the specified configuration
             if (!string.IsNullOrEmpty(serializedConfiguration))
             {


### PR DESCRIPTION
Fixes #467