### PR TITLE
Enable RichPayloadEventSource in NetStandard build

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/AjaxCallData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/AjaxCallData.cs
@@ -2,8 +2,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/AvailabilityData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/AvailabilityData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/DataPoint.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/DataPoint.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-    // TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/EventData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/EventData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-    // TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-    // TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/MessageData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/MessageData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/MetricData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/MetricData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/PageViewData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/PageViewData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/PageViewPerfData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/PageViewPerfData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/PerformanceCounterData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/PerformanceCounterData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/RemoteDependencyData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/RemoteDependencyData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/RequestData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/RequestData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/SessionStateData.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/SessionStateData.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/StackFrame.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/StackFrame.cs
@@ -2,8 +2,6 @@
 {
 #if NET45
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
-#elif NETSTANDARD1_3
-// TODO: This file can be included once RichPayloadEventSource is in the netstandard1.3 project
 #else
     /// <summary>
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.

--- a/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
+++ b/src/Core/Managed/Shared/OperationTelemetryExtensions.cs
@@ -40,9 +40,7 @@
             // Stopwatch.GetTimestamp() is used (instead of ElapsedTicks) as it is thread-safe.
             telemetry.BeginTimeInTicks = timestamp;
 
-#if !NETSTANDARD1_3
             RichPayloadEventSource.Log.ProcessOperationStart(telemetry);
-#endif
         }
 
         /// <summary>
@@ -113,9 +111,7 @@
                 telemetry.Timestamp = DateTimeOffset.UtcNow;
             }
 
-#if !NETSTANDARD1_3
             RichPayloadEventSource.Log.ProcessOperationStop(telemetry);
-#endif
         }
     }
 }

--- a/src/Core/Managed/Shared/TelemetryClient.cs
+++ b/src/Core/Managed/Shared/TelemetryClient.cs
@@ -374,10 +374,8 @@
                 // invokes the Process in the first processor in the chain
                 this.configuration.TelemetryProcessorChain.Process(telemetry);
 
-#if !NETSTANDARD1_3
                 // logs rich payload ETW event for any partners to process it                
                 RichPayloadEventSource.Log.Process(telemetry);
-#endif
             }
         }
 


### PR DESCRIPTION
Fixes #457 
As it happens, it was already a part of the build, we just weren't emitting the events during Start/Stop operations.