### PR TITLE
Allow prerelease DiagnosticSource package

### DIFF
--- a/src/Core/NuGet/Package.nuspec
+++ b/src/Core/NuGet/Package.nuspec
@@ -22,17 +22,17 @@
         <dependency id="Microsoft.Diagnostics.Tracing.EventSource.Redist" version="1.1.28"/>
       </group>
       <group targetFramework="net45">
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-*" />
       </group>
       <group targetFramework="net46">
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-*" />
       </group>
       <group targetFramework="wp8">
         <dependency id="Microsoft.Bcl.Async" version="1.0.168" />
       </group>
       <group targetFramework="netstandard1.3">
         <dependency id="NETStandard.Library" version="1.6.1" />
-        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0" />
+        <dependency id="System.Diagnostics.DiagnosticSource" version="4.4.0-*" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
Fix dependency version for DiagnosticSource: there is no stable 4.4.0 version yet