### PR TITLE
Update TaskTimeInternal to not cancel previous operation

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerInternalTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TaskTimerInternalTest.cs
@@ -135,28 +135,28 @@
             [TestMethod]
             public void StartIsCalledMultipleTimes()
             {
-                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
+                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(25) };
 
-                int invokationCount = 0;
+                int invocationCount = 0;
                 var firstActionInvoked = new ManualResetEventSlim();
                 var secondActionInvoked = new ManualResetEventSlim();
                 timer.Start(() => Task.Factory.StartNew(
                     () =>
                     {                       
-                        Interlocked.Increment(ref invokationCount);
+                        Interlocked.Increment(ref invocationCount);
                         firstActionInvoked.Set();
                     }));
                 timer.Start(
                     () => Task.Factory.StartNew(
                         () =>
                             {
-                                Interlocked.Increment(ref invokationCount);
+                                Interlocked.Increment(ref invocationCount);
                                 secondActionInvoked.Set();
                             }));
 
                 Assert.True(firstActionInvoked.Wait(50));
                 Assert.True(secondActionInvoked.Wait(50));
-                Assert.Equal(2, invokationCount);
+                Assert.Equal(2, invocationCount);
             }
 
             [TestMethod]
@@ -214,29 +214,29 @@
             [TestMethod]
             public void CancelAbortsOnlyLastTask()
             {
-                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(1) };
+                var timer = new TaskTimerInternal { Delay = TimeSpan.FromMilliseconds(25) };
 
-                int invokationCount = 0;
+                int invocationCount = 0;
                 var firstActionInvoked = new ManualResetEventSlim();
                 var secondActionInvoked = new ManualResetEventSlim();
                 timer.Start(() => Task.Factory.StartNew(
                     () =>
                     {
-                        Interlocked.Increment(ref invokationCount);
+                        Interlocked.Increment(ref invocationCount);
                         firstActionInvoked.Set();
                     }));
                 timer.Start(
                     () => Task.Factory.StartNew(
                         () =>
                         {
-                            Interlocked.Increment(ref invokationCount);
+                            Interlocked.Increment(ref invocationCount);
                             secondActionInvoked.Set();
                         }));
 
                 timer.Cancel();
 
                 Assert.True(firstActionInvoked.Wait(50));
-                Assert.Equal(1, invokationCount);
+                Assert.Equal(1, invocationCount);
             }
         }
     }

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTransmissionScheduledPolicy.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTransmissionScheduledPolicy.cs
@@ -1,0 +1,42 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Helpers
+{
+    using System;
+    using System.Threading;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
+
+    internal class StubTransmissionScheduledPolicy : StubTransmissionPolicy
+    {
+        public ManualResetEventSlim ActionInvoked = new ManualResetEventSlim();
+
+        public override void Initialize(Transmitter transmitter)
+        {
+            base.OnInitialize(transmitter);
+            this.Transmitter.TransmissionSent += this.HandleTransmissionSentEvent;
+        }
+
+        public void HandleTransmissionSentEvent(object sender, TransmissionProcessedEventArgs e)
+        {
+            if (e.Response != null && e.Response.StatusCode == 500)
+            {
+                this.MaxSenderCapacity = 0;
+                this.MaxBufferCapacity = 0;
+                this.Apply();
+
+                this.Transmitter.Enqueue(e.Transmission);
+
+                this.Transmitter.BackoffLogicManager.ScheduleRestore(
+                   DateTimeOffset.UtcNow.AddSeconds(2).ToString(),
+                   () =>
+                   {
+                       this.ActionInvoked.Set();
+
+                       this.MaxBufferCapacity = null;
+                       this.MaxSenderCapacity = null;
+                       this.Apply();
+
+                       return null;
+                   });
+            }
+        }
+    }
+}

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubPlatformFile.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubPlatformFolder.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTransmission.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTransmissionScheduledPolicy.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\TelemetryBufferWhichDoesNothingOnFlush.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTelemetrySerializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubTransmissionBuffer.cs" />

--- a/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimerInternal.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimerInternal.cs
@@ -57,12 +57,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         }
 
         /// <summary>
-        /// Start the task.
+        /// Starts the task. Updates the cancellation token and makes any tasks launched previously not available to be cancelled.
         /// </summary>
         /// <param name="elapsed">The task to run.</param>
         public void Start(Func<Task> elapsed)
         {
-            var newTokenSource = new CancellationTokenSource();            
+            var newTokenSource = new CancellationTokenSource();
 
             TaskEx.Delay(this.Delay, newTokenSource.Token)
                 .ContinueWith(
@@ -82,7 +82,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                             if (task != null)
                             {
 #if !NET40
-                                await task.ConfigureAwait(false);                                
+                                await task.ConfigureAwait(false);
 #else
                                 task.ContinueWith(
                                     userTask =>
@@ -100,12 +100,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                                     TaskContinuationOptions.ExecuteSynchronously,
                                     TaskScheduler.Default);
 #endif
-                            }                            
+                            }
                         }
                         catch (Exception exception)
-                        {                            
+                        {
                             LogException(exception);
-                        }                        
+                        }
                     },
                     CancellationToken.None,
                     TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TaskTimerInternal.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TaskTimerInternal.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         }
 
         /// <summary>
-        /// Start the task.
+        /// Starts the task. Updates the cancellation token and makes any tasks launched previously not available to be cancelled.
         /// </summary>
         /// <param name="elapsed">The task to run.</param>
         public void Start(Func<Task> elapsed)
@@ -83,7 +83,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                             if (task != null)
                             {
 #if !NET40
-                                await task.ConfigureAwait(false);                                
+                                await task.ConfigureAwait(false);
 #else
                                 task.ContinueWith(
                                     userTask =>

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TaskTimerInternal.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TaskTimerInternal.cs
@@ -31,8 +31,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         /// <summary>
         /// Gets or sets the delay before the task starts. 
         /// </summary>
-        public TimeSpan Delay 
-        { 
+        public TimeSpan Delay
+        {
             get
             {
                 return this.delay;
@@ -73,7 +73,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     previousTask =>
 #endif
                     {
-                        CancelAndDispose(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
+                        DisposeToken(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
                         try
                         {
                             Task task = elapsed();
@@ -83,7 +83,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                             if (task != null)
                             {
 #if !NET40
-                                await task.ConfigureAwait(false);
+                                await task.ConfigureAwait(false);                                
 #else
                                 task.ContinueWith(
                                     userTask =>
@@ -112,7 +112,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
 
-            CancelAndDispose(Interlocked.Exchange(ref this.tokenSource, newTokenSource));
+            DisposeToken(Interlocked.Exchange(ref this.tokenSource, newTokenSource));
         }
 
         /// <summary>
@@ -149,6 +149,14 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             }
 
             TelemetryChannelEventSource.Log.LogError(exception.ToInvariantString());
+        }
+
+        private static void DisposeToken(CancellationTokenSource tokenSource)
+        {
+            if (tokenSource != null)
+            {
+                tokenSource.Dispose();
+            }
         }
 
         private static void CancelAndDispose(CancellationTokenSource tokenSource)


### PR DESCRIPTION
SDK stops sending telemetry and does not start again. #480 