### PR TITLE
Fix StartOperation: do not start child activity 

### DIFF
--- a/Test/CoreSDK.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -25,7 +25,8 @@ namespace Microsoft.ApplicationInsights.Extensibility
             var telemetry = new DependencyTelemetry();
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
-            Assert.AreEqual("ParentOperationId", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual("ParentOperationId", telemetry.Context.Operation.Id);
+            Assert.AreEqual(parent.Id, telemetry.Context.Operation.ParentId);
             parent.Stop();
         }
 
@@ -95,10 +96,9 @@ namespace Microsoft.ApplicationInsights.Extensibility
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
             Assert.AreEqual("parent", telemetry.Context.Operation.Id);
-            Assert.AreEqual("parent", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(currentActivity.Id, telemetry.Context.Operation.ParentId);
+            Assert.IsTrue(telemetry.Context.Operation.ParentId.StartsWith("|parent."));
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual(currentActivity.Id, telemetry.Id);
-            Assert.IsTrue(telemetry.Id.StartsWith("|parent."));
 
             Assert.AreEqual(2, telemetry.Context.Properties.Count);
             Assert.AreEqual("v1", telemetry.Context.Properties["k1"]);
@@ -119,10 +119,10 @@ namespace Microsoft.ApplicationInsights.Extensibility
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
             Assert.AreEqual("activityRoot", telemetry.Context.Operation.Id);
-            Assert.AreEqual("activityRoot", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(currentActivity.Id, telemetry.Context.Operation.ParentId);
+            Assert.IsTrue(telemetry.Context.Operation.ParentId.StartsWith("|activityRoot."));
+
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual(currentActivity.Id, telemetry.Id);
-            Assert.IsTrue(telemetry.Id.StartsWith("|activityRoot."));
             Assert.AreEqual(1, telemetry.Context.Properties.Count);
             Assert.AreEqual("v1", telemetry.Context.Properties["k1"]);
             currentActivity.Stop();
@@ -136,18 +136,16 @@ namespace Microsoft.ApplicationInsights.Extensibility
             currentActivity.AddTag("OperationName", "test");
             currentActivity.AddBaggage("k1", "v1");
             currentActivity.Start();
-            var telemetry = new RequestTelemetry();
+            var telemetry = new TraceTelemetry();
 
             telemetry.Context.Operation.Id = "rootId";
             telemetry.Context.Operation.ParentId = null;
             telemetry.Context.Operation.Name = "operation";
-            telemetry.Id = "12345";
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
             Assert.AreEqual("rootId", telemetry.Context.Operation.Id);
             Assert.IsNull(telemetry.Context.Operation.ParentId);
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual("12345", telemetry.Id);
             Assert.AreEqual(0, telemetry.Context.Properties.Count);
             currentActivity.Stop();
         }
@@ -160,17 +158,15 @@ namespace Microsoft.ApplicationInsights.Extensibility
             currentActivity.AddTag("OperationName", "test");
             currentActivity.AddBaggage("k1", "v1");
             currentActivity.Start();
-            var telemetry = new RequestTelemetry();
+            var telemetry = new TraceTelemetry();
 
             telemetry.Context.Operation.ParentId = "parentId";
             telemetry.Context.Operation.Name = "operation";
-            telemetry.Id = "12345";
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
             Assert.AreEqual("activityRoot", telemetry.Context.Operation.Id);
             Assert.AreEqual("parentId", telemetry.Context.Operation.ParentId);
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual(currentActivity.Id, telemetry.Id);
             Assert.AreEqual(1, telemetry.Context.Properties.Count);
             Assert.AreEqual("v1", telemetry.Context.Properties["k1"]);
             currentActivity.Stop();

--- a/Test/CoreSDK.Test/Shared/TelemetryClientExtensionAsyncTests.cs
+++ b/Test/CoreSDK.Test/Shared/TelemetryClientExtensionAsyncTests.cs
@@ -76,12 +76,12 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
-                    Assert.Equal(id, item.Context.Operation.Id);
+                    Assert.Equal(GetRootOperationId(id), item.Context.Operation.Id);
                 }
                 else
                 {
                     Assert.Equal(id, ((RequestTelemetry)item).Id);
-                    Assert.Equal(id, item.Context.Operation.Id);
+                    Assert.Equal(GetRootOperationId(id), item.Context.Operation.Id);
                     Assert.Null(item.Context.Operation.ParentId);
                 }
             }
@@ -124,16 +124,26 @@
                 if (item is TraceTelemetry)
                 {
                     Assert.Equal(id, item.Context.Operation.ParentId);
-                    Assert.Equal(id, item.Context.Operation.Id);
+                    Assert.Equal(GetRootOperationId(id), item.Context.Operation.Id);
                 }
                 else
                 {
                     Assert.Equal(id, ((RequestTelemetry)item).Id);
-                    Assert.Equal(id, item.Context.Operation.Id);
+                    Assert.Equal(GetRootOperationId(id), item.Context.Operation.Id);
                     Assert.Null(item.Context.Operation.ParentId);
 
                 }
             }
+        }
+
+        private string GetRootOperationId(string operationId)
+        {
+#if NET40
+            return operationId;
+#else
+            Assert.True(operationId.StartsWith("|"));
+            return operationId.Substring(1, operationId.IndexOf('.') - 1);
+#endif
         }
     }
 }

--- a/Test/CoreSDK.Test/Shared/TelemetryClientExtensionTests.cs
+++ b/Test/CoreSDK.Test/Shared/TelemetryClientExtensionTests.cs
@@ -189,12 +189,12 @@
         {
             var operation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as OperationHolder<DependencyTelemetry>;
             var currentActivity = Activity.Current;
-            Assert.AreEqual(operation.Telemetry.Id, currentActivity.ParentId);
+            Assert.AreEqual(operation.Telemetry.Id, currentActivity.Id);
             Assert.AreEqual(operation.Telemetry.Context.Operation.Name, this.GetOperationName(currentActivity));
 
             var childOperation = this.telemetryClient.StartOperation<DependencyTelemetry>("OperationName") as OperationHolder<DependencyTelemetry>;
             var childActivity = Activity.Current;
-            Assert.AreEqual(childOperation.Telemetry.Id, childActivity.ParentId);
+            Assert.AreEqual(childOperation.Telemetry.Id, childActivity.Id);
             Assert.AreEqual(childOperation.Telemetry.Context.Operation.Name, this.GetOperationName(currentActivity));
 
             Assert.IsNull(currentActivity.Parent);

--- a/src/Core/Managed/Shared/ActivityExtensions.cs
+++ b/src/Core/Managed/Shared/ActivityExtensions.cs
@@ -11,7 +11,7 @@ namespace Microsoft.ApplicationInsights
     {
         private const string OperationNameTag = "OperationName";
         private static bool isInitialized = false;
-        private static bool isEnabled = false;
+        private static bool isAvailable = false;
 
         /// <summary>
         /// Executes action if Activity is available (DiagnosticSource DLL is available).
@@ -24,15 +24,15 @@ namespace Microsoft.ApplicationInsights
             Debug.Assert(action != null, "Action must not be null");
             if (!isInitialized)
             {
-                isEnabled = Initialize();
+                isAvailable = Initialize();
             }
 
-            if (isEnabled)
+            if (isAvailable)
             {
                 action.Invoke();
             }
 
-            return isEnabled;
+            return isAvailable;
         }
 
         internal static string GetOperationName(this Activity activity)

--- a/src/Core/Managed/Shared/Extensibility/Implementation/OperationHolder.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/OperationHolder.cs
@@ -82,7 +82,7 @@
                         isActivityAvailable = ActivityExtensions.TryRun(() =>
                         {
                             var currentActivity = Activity.Current;
-                            if (currentActivity == null || operationTelemetry.Id != currentActivity.ParentId ||
+                            if (currentActivity == null || operationTelemetry.Id != currentActivity.Id ||
                             operationTelemetry.Context.Operation.Name != currentActivity.GetOperationName())
                             {
                                 CoreEventSource.Log.InvalidOperationToStopError();

--- a/src/Core/Managed/Shared/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Core/Managed/Shared/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -39,12 +39,7 @@
 
                         if (string.IsNullOrEmpty(itemContext.ParentId))
                         {
-                            itemContext.ParentId = currentActivity.ParentId;
-                        }
-
-                        if (telemetryItem is OperationTelemetry)
-                        {
-                            ((OperationTelemetry)telemetryItem).Id = currentActivity.Id;
+                            itemContext.ParentId = currentActivity.Id;
                         }
 
                         foreach (var baggage in currentActivity.Baggage)


### PR DESCRIPTION
StartOperation is the same as Start Activity: every OperationTelemetry must have a corresponding Activity.
Imagine following scenario:

In the previous implementation, new Activity was created to represent children of the operation, however it would mean that every child telemetry in scope of parent would have just one activity representing them.
In case of multiple dependency calls within the same request, all of them must have different activities and different activity.Id (telemetry.id).

So this change fixes it:
- Activity is started to represent current operation being started in the StartOperation, not the child one
- OperationCorrelationTelemtryInitializer sets ParentId with Activity.Current.Id

This way every dependency call started with StartOperation will have unique Telemetry.Id