### PR TITLE
SDK stops sending telemetry and does not start again. #480

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTransmissionScheduledPolicy.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTransmissionScheduledPolicy.cs
@@ -29,11 +29,11 @@
                 this.pauseTimer.Start(
                    () =>
                    {
-                       this.ActionInvoked.Set();
-
                        this.MaxBufferCapacity = null;
                        this.MaxSenderCapacity = null;
                        this.Apply();
+
+                       this.ActionInvoked.Set();
 
                        return null;
                    });

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTransmissionScheduledPolicy.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/StubTransmissionScheduledPolicy.cs
@@ -7,6 +7,7 @@
     internal class StubTransmissionScheduledPolicy : StubTransmissionPolicy
     {
         public ManualResetEventSlim ActionInvoked = new ManualResetEventSlim();
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(10) };
 
         public override void Initialize(Transmitter transmitter)
         {
@@ -24,8 +25,8 @@
 
                 this.Transmitter.Enqueue(e.Transmission);
 
-                this.Transmitter.BackoffLogicManager.ScheduleRestore(
-                   DateTimeOffset.UtcNow.AddSeconds(2).ToString(),
+                this.pauseTimer.Delay = TimeSpan.FromMilliseconds(10);
+                this.pauseTimer.Start(
                    () =>
                    {
                        this.ActionInvoked.Set();

--- a/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimerInternal.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TaskTimerInternal.cs
@@ -30,8 +30,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         /// <summary>
         /// Gets or sets the delay before the task starts. 
         /// </summary>
-        public TimeSpan Delay 
-        { 
+        public TimeSpan Delay
+        {
             get
             {
                 return this.delay;
@@ -57,7 +57,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         }
 
         /// <summary>
-        /// Starts the task. Updates the cancellation token and makes any tasks launched previously not available to be cancelled.
+        /// Start the task.
         /// </summary>
         /// <param name="elapsed">The task to run.</param>
         public void Start(Func<Task> elapsed)
@@ -72,7 +72,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     previousTask =>
 #endif
                     {
-                        DisposeToken(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
+                        CancelAndDispose(Interlocked.CompareExchange(ref this.tokenSource, null, newTokenSource));
                         try
                         {
                             Task task = elapsed();
@@ -111,7 +111,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     TaskContinuationOptions.OnlyOnRanToCompletion | TaskContinuationOptions.ExecuteSynchronously,
                     TaskScheduler.Default);
 
-            DisposeToken(Interlocked.Exchange(ref this.tokenSource, newTokenSource));
+            CancelAndDispose(Interlocked.Exchange(ref this.tokenSource, newTokenSource));
         }
 
         /// <summary>
@@ -148,14 +148,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             }
 
             CoreEventSource.Log.LogError(exception.ToInvariantString());
-        }
-
-        private static void DisposeToken(CancellationTokenSource tokenSource)
-        {
-            if (tokenSource != null)
-            {
-                tokenSource.Dispose();
-            }
         }
 
         private static void CancelAndDispose(CancellationTokenSource tokenSource)

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
@@ -19,7 +19,7 @@
         
         private bool exponentialBackoffReported = false;
         private int consecutiveErrors;
-        private DateTimeOffset nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;        
+        private DateTimeOffset nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;
 
         public BackoffLogicManager()
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
@@ -8,7 +8,7 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 
-    internal class BackoffLogicManager : IDisposable
+    internal class BackoffLogicManager
     {
         private const int SlotDelayInSeconds = 10;
         private const int MaxDelayInSeconds = 3600;
@@ -19,8 +19,7 @@
 
         private readonly object lockConsecutiveErrors = new object();
         private readonly TimeSpan minIntervalToUpdateConsecutiveErrors;
-
-        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(SlotDelayInSeconds) };
+        
         private bool exponentialBackoffReported = false;
         private int consecutiveErrors;
         private DateTimeOffset nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;
@@ -59,29 +58,7 @@
 
         public TimeSpan DefaultBackoffEnabledReportingInterval { get; set; }
 
-        internal TimeSpan CurrentDelay
-        {
-            get { return this.pauseTimer.Delay; }
-        }
-
-        public void ScheduleRestore(WebHeaderCollection headers, Func<Task> elapsedFunc)
-        {
-            // Back-off for the Delay duration and enable sending capacity
-            string retryAfterHeader = string.Empty;
-            if (headers != null)
-            {
-                retryAfterHeader = headers.Get("Retry-After");
-            }
-
-            this.ScheduleRestore(retryAfterHeader, elapsedFunc);
-        }
-
-        public void ScheduleRestore(string retryAfterHeader, Func<Task> elapsedFunc)
-        {
-            // Back-off for the Delay duration and enable sending capacity
-            this.pauseTimer.Delay = this.GetBackOffTime(retryAfterHeader);
-            this.pauseTimer.Start(elapsedFunc);
-        }
+        internal TimeSpan CurrentDelay { get; private set; }
 
         public BackendResponse GetBackendResponse(string responseContent)
         {
@@ -123,9 +100,9 @@
         {
             this.LastStatusCode = statusCode;
             
-            if (!this.exponentialBackoffReported && this.pauseTimer.Delay > this.DefaultBackoffEnabledReportingInterval)
+            if (!this.exponentialBackoffReported && this.CurrentDelay > this.DefaultBackoffEnabledReportingInterval)
             {
-                TelemetryChannelEventSource.Log.BackoffEnabled(this.pauseTimer.Delay.TotalMinutes, statusCode);
+                TelemetryChannelEventSource.Log.BackoffEnabled(this.CurrentDelay.TotalMinutes, statusCode);
                 this.exponentialBackoffReported = true;
             }
 
@@ -152,10 +129,12 @@
             }
         }
 
-        public void Dispose()
+        public TimeSpan GetBackOffTimeInterval(string headerValue)
         {
-            this.Dispose(true);
-            GC.SuppressFinalize(this);
+            TimeSpan backOffTime = this.GetBackOffTime(headerValue);
+            this.CurrentDelay = backOffTime;
+
+            return backOffTime;
         }
 
         // Calculates the time to wait before retrying in case of an error based on
@@ -213,18 +192,6 @@
             TelemetryChannelEventSource.Log.TransmissionPolicyRetryAfterParseFailedWarning(retryAfter);
 
             return false;
-        }
-
-        private void Dispose(bool disposing)
-        {
-            if (disposing)
-            {
-                if (this.pauseTimer != null)
-                {
-                    this.pauseTimer.Dispose();
-                    this.pauseTimer = null;
-                }
-            }
         }
     }
 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/BackoffLogicManager.cs
@@ -1,16 +1,13 @@
 ﻿namespace Microsoft.ApplicationInsights.Channel.Implementation
 {
     using System;
-    using System.Net;
-    using System.Threading.Tasks;
     using System.Web.Script.Serialization;
-
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 
     internal class BackoffLogicManager
     {
-        private const int SlotDelayInSeconds = 10;
+        internal const int SlotDelayInSeconds = 10;
+
         private const int MaxDelayInSeconds = 3600;
         private const int DefaultBackoffEnabledReportingIntervalInMin = 30;
 
@@ -22,18 +19,20 @@
         
         private bool exponentialBackoffReported = false;
         private int consecutiveErrors;
-        private DateTimeOffset nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;
+        private DateTimeOffset nextMinTimeToUpdateConsecutiveErrors = DateTimeOffset.MinValue;        
 
         public BackoffLogicManager()
         {
             this.DefaultBackoffEnabledReportingInterval = TimeSpan.FromMinutes(DefaultBackoffEnabledReportingIntervalInMin);
             this.minIntervalToUpdateConsecutiveErrors = TimeSpan.FromSeconds(SlotDelayInSeconds);
+            this.CurrentDelay = TimeSpan.FromSeconds(SlotDelayInSeconds);
         }
 
         public BackoffLogicManager(TimeSpan defaultBackoffEnabledReportingInterval)
         {
             this.DefaultBackoffEnabledReportingInterval = defaultBackoffEnabledReportingInterval;
             this.minIntervalToUpdateConsecutiveErrors = TimeSpan.FromSeconds(SlotDelayInSeconds);
+            this.CurrentDelay = TimeSpan.FromSeconds(SlotDelayInSeconds);
         }
 
         internal BackoffLogicManager(TimeSpan defaultBackoffEnabledReportingInterval, TimeSpan minIntervalToUpdateConsecutiveErrors) 

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -12,9 +12,10 @@
     using TaskEx = System.Threading.Tasks.Task;
 #endif
 
-    internal class ErrorHandlingTransmissionPolicy : TransmissionPolicy
+    internal class ErrorHandlingTransmissionPolicy : TransmissionPolicy, IDisposable
     {
         private BackoffLogicManager backoffLogicManager;
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(10) };
 
         public override void Initialize(Transmitter transmitter)
         {
@@ -27,6 +28,12 @@
 
             base.Initialize(transmitter);
             transmitter.TransmissionSent += this.HandleTransmissionSentEvent;
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         private void HandleTransmissionSentEvent(object sender, TransmissionProcessedEventArgs e)
@@ -59,8 +66,8 @@
                             this.backoffLogicManager.ReportBackoffEnabled((int)httpWebResponse.StatusCode);
                             this.Transmitter.Enqueue(e.Transmission);
 
-                            this.backoffLogicManager.ScheduleRestore(
-                               httpWebResponse.RetryAfterHeader,
+                            this.pauseTimer.Delay = this.backoffLogicManager.GetBackOffTimeInterval(httpWebResponse.RetryAfterHeader);
+                            this.pauseTimer.Start(
                                () =>
                                     {
                                         this.MaxBufferCapacity = null;
@@ -130,6 +137,18 @@
                     // This code is for tracing purposes only; it cannot not throw
                 }
             }
-        }        
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (this.pauseTimer != null)
+                {
+                    this.pauseTimer.Dispose();
+                    this.pauseTimer = null;
+                }
+            }
+        }
     }
 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -15,7 +15,7 @@
     internal class ErrorHandlingTransmissionPolicy : TransmissionPolicy, IDisposable
     {
         private BackoffLogicManager backoffLogicManager;
-        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(10) };
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(BackoffLogicManager.SlotDelayInSeconds) };
 
         public override void Initialize(Transmitter transmitter)
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/PartialSuccessTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/PartialSuccessTransmissionPolicy.cs
@@ -15,7 +15,7 @@
     internal class PartialSuccessTransmissionPolicy : TransmissionPolicy, IDisposable
     {
         private BackoffLogicManager backoffLogicManager;
-        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(10) };
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(BackoffLogicManager.SlotDelayInSeconds) };
 
         public override void Initialize(Transmitter transmitter)
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
@@ -64,10 +64,10 @@
                     this.pauseTimer.Delay = this.backoffLogicManager.GetBackOffTimeInterval(httpWebResponse.RetryAfterHeader);
                     this.pauseTimer.Start(
                         () =>
-                                    {
-                                        this.ResetPolicy();
-                                        return TaskEx.FromResult<object>(null);
-                                    });
+                        {
+                            this.ResetPolicy();
+                            return TaskEx.FromResult<object>(null);
+                        });
                 }
             }
         }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
@@ -13,7 +13,7 @@
     internal class ThrottlingTransmissionPolicy : TransmissionPolicy, IDisposable
     {
         private BackoffLogicManager backoffLogicManager;
-        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(10) };
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(BackoffLogicManager.SlotDelayInSeconds) };
 
         public override void Initialize(Transmitter transmitter)
         {

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/ThrottlingTransmissionPolicy.cs
@@ -10,9 +10,10 @@
     using TaskEx = System.Threading.Tasks.Task;
 #endif
 
-    internal class ThrottlingTransmissionPolicy : TransmissionPolicy
+    internal class ThrottlingTransmissionPolicy : TransmissionPolicy, IDisposable
     {
         private BackoffLogicManager backoffLogicManager;
+        private TaskTimerInternal pauseTimer = new TaskTimerInternal { Delay = TimeSpan.FromSeconds(10) };
 
         public override void Initialize(Transmitter transmitter)
         {
@@ -25,6 +26,12 @@
 
             base.Initialize(transmitter);
             transmitter.TransmissionSent += this.HandleTransmissionSentEvent;
+        }
+
+        public void Dispose()
+        {
+            this.Dispose(true);
+            GC.SuppressFinalize(this);
         }
 
         private void HandleTransmissionSentEvent(object sender, TransmissionProcessedEventArgs e)
@@ -54,13 +61,13 @@
                     this.backoffLogicManager.ReportBackoffEnabled((int)httpWebResponse.StatusCode);
                     this.Transmitter.Enqueue(e.Transmission);
 
-                    this.backoffLogicManager.ScheduleRestore(
-                        httpWebResponse.RetryAfterHeader, 
+                    this.pauseTimer.Delay = this.backoffLogicManager.GetBackOffTimeInterval(httpWebResponse.RetryAfterHeader);
+                    this.pauseTimer.Start(
                         () =>
-                            {
-                                this.ResetPolicy();
-                                return TaskEx.FromResult<object>(null);
-                            });
+                                    {
+                                        this.ResetPolicy();
+                                        return TaskEx.FromResult<object>(null);
+                                    });
                 }
             }
         }
@@ -72,6 +79,18 @@
             this.MaxStorageCapacity = null;
             this.LogCapacityChanged();
             this.Apply();     
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (this.pauseTimer != null)
+                {
+                    this.pauseTimer.Dispose();
+                    this.pauseTimer = null;
+                }
+            }
         }
     }
 }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
@@ -316,11 +316,6 @@
                     policy.Dispose();
                 }
 
-                if (this.backoffLogicManager != null)
-                {
-                    this.backoffLogicManager.Dispose();
-                }
-
                 if (this.Storage != null)
                 {
                     this.Storage.Dispose();


### PR DESCRIPTION
Revert TaskTimeInternal changes and make each policy to have its own instance of the timer