### PR TITLE
Fix the issue that ExceptionDetails class doesn't decorate the EventData attribute correctly

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails.cs
@@ -4,7 +4,6 @@
     // .Net 4.5 has a custom implementation of RichPayloadEventSource
 #else
     /// <summary>
-    /// Additional implementation for ExceptionDetails.
     /// Partial class to add the EventData attribute and any additional customizations to the generated type.
     /// </summary>
 #if NET40

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails.cs
@@ -1,40 +1,19 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
-    using System;
-    
+#if NET45
+    // .Net 4.5 has a custom implementation of RichPayloadEventSource
+#else
     /// <summary>
     /// Additional implementation for ExceptionDetails.
+    /// Partial class to add the EventData attribute and any additional customizations to the generated type.
     /// </summary>
-#if NET46
-    [System.Diagnostics.Tracing.EventData]
-#elif NET40
+#if NET40
     [Microsoft.Diagnostics.Tracing.EventData]
+#else
+    [System.Diagnostics.Tracing.EventData]
 #endif
     internal partial class ExceptionDetails
     {
-        /// <summary>
-        /// Creates a new instance of ExceptionDetails from a System.Exception and a parent ExceptionDetails.
-        /// </summary>
-        internal static ExceptionDetails CreateWithoutStackInfo(Exception exception, ExceptionDetails parentExceptionDetails)
-        {
-            if (exception == null)
-            {
-                throw new ArgumentNullException("exception");
-            }
-
-            var exceptionDetails = new External.ExceptionDetails()
-            {
-                id = exception.GetHashCode(),
-                typeName = exception.GetType().FullName,
-                message = exception.Message
-            };
-
-            if (parentExceptionDetails != null)
-            {
-                exceptionDetails.outerId = parentExceptionDetails.id;
-            }
-
-            return exceptionDetails;
-        }
     }
+#endif
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
@@ -1,0 +1,35 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
+{
+    using System;
+
+    /// <summary>
+    /// Additional implementation for ExceptionDetails.
+    /// </summary>
+    internal partial class ExceptionDetails
+    {
+        /// <summary>
+        /// Creates a new instance of ExceptionDetails from a System.Exception and a parent ExceptionDetails.
+        /// </summary>
+        internal static ExceptionDetails CreateWithoutStackInfo(Exception exception, ExceptionDetails parentExceptionDetails)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            var exceptionDetails = new External.ExceptionDetails()
+            {
+                id = exception.GetHashCode(),
+                typeName = exception.GetType().FullName,
+                message = exception.Message
+            };
+
+            if (parentExceptionDetails != null)
+            {
+                exceptionDetails.outerId = parentExceptionDetails.id;
+            }
+
+            return exceptionDetails;
+        }
+    }
+}

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails_types.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails_types.cs
@@ -26,48 +26,48 @@
 
 namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
-    using System.Collections.Concurrent;
+    using System;
     using System.Collections.Generic;
 
-    
-    
+
+
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.4.1.0")]
     internal partial class ExceptionDetails
     {
-        
-        
+
+
         public int id { get; set; }
 
-        
-        
+
+
         public int outerId { get; set; }
 
-        
-        
-        
+
+
+
         public string typeName { get; set; }
 
-        
-        
-        
+
+
+
         public string message { get; set; }
 
-        
-        
+
+
         public bool hasFullStack { get; set; }
 
-        
-        
-        
+
+
+
         public string stack { get; set; }
 
-        
-        
+
+
         public IList<StackFrame> parsedStack { get; set; }
 
         public ExceptionDetails()
             : this("AI.ExceptionDetails", "ExceptionDetails")
-        {}
+        { }
 
         protected ExceptionDetails(string fullName, string name)
         {
@@ -76,6 +76,31 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             hasFullStack = true;
             stack = "";
             parsedStack = new List<StackFrame>();
+        }
+
+        /// <summary>
+        /// Creates a new instance of ExceptionDetails from a System.Exception and a parent ExceptionDetails.
+        /// </summary>
+        internal static ExceptionDetails CreateWithoutStackInfo(Exception exception, ExceptionDetails parentExceptionDetails)
+        {
+            if (exception == null)
+            {
+                throw new ArgumentNullException("exception");
+            }
+
+            var exceptionDetails = new External.ExceptionDetails()
+            {
+                id = exception.GetHashCode(),
+                typeName = exception.GetType().FullName,
+                message = exception.Message
+            };
+
+            if (parentExceptionDetails != null)
+            {
+                exceptionDetails.outerId = parentExceptionDetails.id;
+            }
+
+            return exceptionDetails;
         }
     }
 } // AI

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails_types.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails_types.cs
@@ -26,7 +26,7 @@
 
 namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
-    using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
 
 
@@ -76,31 +76,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             hasFullStack = true;
             stack = "";
             parsedStack = new List<StackFrame>();
-        }
-
-        /// <summary>
-        /// Creates a new instance of ExceptionDetails from a System.Exception and a parent ExceptionDetails.
-        /// </summary>
-        internal static ExceptionDetails CreateWithoutStackInfo(Exception exception, ExceptionDetails parentExceptionDetails)
-        {
-            if (exception == null)
-            {
-                throw new ArgumentNullException("exception");
-            }
-
-            var exceptionDetails = new External.ExceptionDetails()
-            {
-                id = exception.GetHashCode(),
-                typeName = exception.GetType().FullName,
-                message = exception.Message
-            };
-
-            if (parentExceptionDetails != null)
-            {
-                exceptionDetails.outerId = parentExceptionDetails.id;
-            }
-
-            return exceptionDetails;
         }
     }
 } // AI

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails_types.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/ExceptionDetails_types.cs
@@ -29,45 +29,45 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
     using System.Collections.Concurrent;
     using System.Collections.Generic;
 
-
-
+    
+    
     [System.CodeDom.Compiler.GeneratedCode("gbc", "0.4.1.0")]
     internal partial class ExceptionDetails
     {
-
-
+        
+        
         public int id { get; set; }
 
-
-
+        
+        
         public int outerId { get; set; }
 
-
-
-
+        
+        
+        
         public string typeName { get; set; }
 
-
-
-
+        
+        
+        
         public string message { get; set; }
 
-
-
+        
+        
         public bool hasFullStack { get; set; }
 
-
-
-
+        
+        
+        
         public string stack { get; set; }
 
-
-
+        
+        
         public IList<StackFrame> parsedStack { get; set; }
 
         public ExceptionDetails()
             : this("AI.ExceptionDetails", "ExceptionDetails")
-        { }
+        {}
 
         protected ExceptionDetails(string fullName, string name)
         {


### PR DESCRIPTION
As titled. Without this fix, it may throw exception when track exception
@pharring @SergeyKanzhelev @lmolkova 