### PR TITLE
Allow .NET Core apps to use applicationinsights.config

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/Platform/PlatformImplementationBase.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Platform/PlatformImplementationBase.cs
@@ -1,0 +1,142 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
+{
+    using System;
+    using System.Collections;
+    using System.IO;
+    using System.Security;
+    using System.Threading;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    /// <summary>
+    /// Base class implementation of <see cref="IPlatform"/>.
+    /// </summary>
+    internal abstract class PlatformImplementationBase : IPlatform
+    {
+        private readonly IDictionary environmentVariables;
+        private IDebugOutput debugOutput;
+        private string hostName;
+
+        protected PlatformImplementationBase()
+        {
+            try
+            {
+                this.environmentVariables = Environment.GetEnvironmentVariables();
+            }
+            catch (SecurityException e)
+            {
+                CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
+            }
+        }
+
+        /// <summary>
+        /// Gets the directory where the configuration file might be found.
+        /// </summary>
+        protected abstract string ConfigurationXmlDirectory { get; }
+
+        /// <summary>
+        /// Get the platform specific Debugger writer to the VS output console.
+        /// </summary>
+        /// <returns>The debugger writer.</returns>
+        public IDebugOutput GetDebugOutput()
+        {
+            return this.debugOutput ?? (this.debugOutput = new TelemetryDebugWriter());
+        }
+
+        /// <summary>
+        /// Get an environment variable value.
+        /// </summary>
+        /// <param name="name">The name of the variable.</param>
+        /// <returns>The value of the variable.</returns>
+        public string GetEnvironmentVariable(string name)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException();
+            }
+
+            object resultObj = this.environmentVariables?[name];
+            return resultObj != null ? resultObj.ToString() : null;
+        }
+
+        /// <summary>
+        /// Returns the machine name.
+        /// </summary>
+        /// <returns>The machine name.</returns>
+        public string GetMachineName()
+        {
+            return LazyInitializer.EnsureInitialized(ref this.hostName, this.GetHostName);
+        }
+
+        /// <summary>
+        /// Returns contents of the ApplicationInsights.config file in the application directory.
+        /// </summary>
+        public string ReadConfigurationXml()
+        {
+            // Config file should be in the base directory of the app domain
+            string configFilePath = Path.Combine(this.ConfigurationXmlDirectory, "ApplicationInsights.config");
+
+            try
+            {
+                // Ensure config file actually exists
+                if (File.Exists(configFilePath))
+                {
+                    return File.ReadAllText(configFilePath);
+                }
+            }
+            catch (FileNotFoundException)
+            {
+                // For cases when file was deleted/modified while reading
+                CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
+            }
+            catch (DirectoryNotFoundException)
+            {
+                // For cases when file was deleted/modified while reading
+                CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
+            }
+            catch (IOException)
+            {
+                // For cases when file was deleted/modified while reading
+                CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
+            }
+            catch (UnauthorizedAccessException)
+            {
+                CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
+            }
+            catch (SecurityException)
+            {
+                CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
+            }
+
+            return string.Empty;
+        }
+
+        /// <summary>
+        /// Gets the host (machine) name.
+        /// </summary>
+        /// <returns>The host name.</returns>
+        protected virtual string GetHostNameCore()
+        {
+            // This may return null in non-Windows environments.
+            return this.GetEnvironmentVariable("COMPUTERNAME");
+        }
+
+        /// <summary>
+        /// Gets the host name.
+        /// </summary>
+        /// <returns>The host name.</returns>
+        private string GetHostName()
+        {
+            try
+            {
+                return this.GetHostNameCore();
+            }
+            catch (Exception ex)
+            {
+                CoreEventSource.Log.FailedToGetMachineName(ex.Message);
+            }
+
+            return string.Empty;
+        }
+    }
+}

--- a/src/Core/Managed/netstandard1.3/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Core/Managed/netstandard1.3/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -1,53 +1,21 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
 {
     using System;
-    using System.Collections.Generic;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
-    internal class PlatformImplementation : IPlatform
+    /// <summary>
+    /// The .Net standard 1.3 implementation of the <see cref="IPlatform"/> interface.
+    /// </summary>
+    internal sealed class PlatformImplementation : PlatformImplementationBase
     {
-        private IDebugOutput debugOutput = null;
-        
-        public IDictionary<string, object> GetApplicationSettings()
-        {
-            return null;
-        }
-
-        public string ReadConfigurationXml()
-        {
-            return null;
-        }
-
-        public ExceptionDetails GetExceptionDetails(Exception exception, ExceptionDetails parentExceptionDetails)
-        {
-            return ExceptionConverter.ConvertToExceptionDetails(exception, parentExceptionDetails);
-        }
-
         /// <summary>
-        /// Returns the platform specific Debugger writer to the VS output console.
+        /// The directory where the configuration file might be found.
         /// </summary>
-        public IDebugOutput GetDebugOutput()
+        protected override string ConfigurationXmlDirectory
         {
-            if (this.debugOutput == null)
+            get
             {
-                this.debugOutput = new TelemetryDebugWriter(); 
+                return AppContext.BaseDirectory;
             }
-            
-            return this.debugOutput;
-        }
-
-        public string GetEnvironmentVariable(string name)
-        {
-            return null;
-        }
-
-        /// <summary>
-        /// Returns the machine name.
-        /// </summary>
-        /// <returns>The machine name.</returns>
-        public string GetMachineName()
-        {
-            return null;
         }
     }
 }


### PR DESCRIPTION
This allows .Net core applications referencing the base SDK to use applicationinsights.config via ```TelemetryConfiguration.CreateDefault()```

Created a common base class with a couple of abstract methods where NetStandard1.3 differs from desktop .Net FX.

