### PR TITLE
Small metrics-related fixes.

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/AutocollectedMetricsExtractor.cs
+++ b/src/Core/Managed/Shared/Extensibility/AutocollectedMetricsExtractor.cs
@@ -239,6 +239,13 @@
         /// <param name="fromItem">The item from which to extract metrics.</param>
         private void ExtractMetrics(ITelemetry fromItem)
         {
+            //// Workaround: There is a suspected but unconfirmed issue around Extractor performance with telemetry from which no metrics need to be extracted.
+            //// Putting this IF as a temporary workaround until this can be investigated. 
+            if (!((fromItem is RequestTelemetry) || (fromItem is DependencyTelemetry)))
+            {
+                return;
+            }
+
             if (!this.EnsureItemNotSampled(fromItem))
             {
                 return;

--- a/src/Core/Managed/Shared/Extensibility/Metric.cs
+++ b/src/Core/Managed/Shared/Extensibility/Metric.cs
@@ -12,7 +12,7 @@
     /// <summary>
     /// Represents aggregator for a single time series of a given metric.
     /// </summary>
-    public class Metric : IEquatable<Metric>
+    internal class Metric : IEquatable<Metric>
     {
         /// <summary>
         /// Aggregator manager for the aggregator.


### PR DESCRIPTION
* Metrics: When we made MetricManager private, we forgot the Metric class. Catching up on that.
* Metrics: Add a temporary workaround for a suspected but unconfirmed issue with Extractor performance on telemetry when no metrics are extracted.