### PR TITLE
Remove the use of concurrent diuctionary for context properties on hot path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,4 +165,4 @@ $RECYCLE.BIN/
 *.wrn
 *.vsix
 Web/PerformanceTests_Instrumented/
-StyleCop.Cache 
+[Ss]tyle[Cc]op.*

--- a/ApplicationInsightsSDKRules.ruleset
+++ b/ApplicationInsightsSDKRules.ruleset
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<RuleSet Name="ApplicationInsights SDK Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects. These include a combination of Microsoft Managed Recommended Rules and DevDivRuleSet for Microbuild." ToolsVersion="14.0">
+<RuleSet Name="ApplicationInsights SDK Rules" Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects. These include a combination of Microsoft Managed Recommended Rules and DevDivRuleSet for Microbuild." ToolsVersion="15.0">
   <Localization ResourceAssembly="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.dll" ResourceBaseName="Microsoft.VisualStudio.CodeAnalysis.RuleSets.Strings.Localized">
     <Name Resource="ApplicationInsightsSDKRules_Name" />
     <Description Resource="ApplicationInsightsSDKRules_Description" />
@@ -448,5 +448,15 @@
     <Rule Id="C6993" Action="Warning" />
     <Rule Id="C6995" Action="Warning" />
     <Rule Id="C6997" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1113" Action="None" />
+    <Rule Id="SA1124" Action="None" />
+    <Rule Id="SA1129" Action="None" />
+    <Rule Id="SA1131" Action="None" />
+    <Rule Id="SA1132" Action="None" />
+    <Rule Id="SA1600" Action="None" />
+    <Rule Id="SA1615" Action="None" />
+    <Rule Id="SA1642" Action="None" />
   </Rules>
 </RuleSet>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.5.0-beta1
+- Method `Sanitize` on classes implementing `ITelemetry` does not modify the `TelemetryContext` fields any longer. Serailized event json and ETW event will still have context tags sanitized.
+
 ## Version 2.4.0
 - Updated version of DiagnosticSource to 4.4.0 stable
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.5.0-beta1
-- Method `Sanitize` on classes implementing `ITelemetry` does not modify the `TelemetryContext` fields any longer. Serailized event json and ETW event will still have context tags sanitized.
+- Method `Sanitize` on classes implementing `ITelemetry` no longer modifies the `TelemetryContext` fields. Serialized event json and ETW event will still have context tags sanitized.
 
 ## Version 2.4.0
 - Updated version of DiagnosticSource to 4.4.0 stable

--- a/Test/CoreSDK.Test/Shared/Channel/ITelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/Channel/ITelemetryTest.cs
@@ -21,7 +21,6 @@
             this.SerializeWritesTimestampAsExpectedByEndpoint();
             this.SerializeWritesSequenceAsExpectedByEndpoint();
             this.SerializeWritesInstrumentationKeyAsExpectedByEndpoint();
-            this.SerializeWritesTagsAsExpectedByEndpoint();
             this.SerializeWritesTelemetryNameAsExpectedByEndpoint();
             this.SerializeWritesDataBaseTypeAsExpectedByEndpoint();
         }
@@ -192,17 +191,6 @@
 
             string expectedBaseType = ExtractTelemetryNameFromType(typeof(TTelemetry)) + "Data";
             Assert.AreEqual(expectedBaseType, envelope.data.baseType);
-        }
-
-        private void SerializeWritesTagsAsExpectedByEndpoint()
-        {
-            var expected = new TTelemetry();
-            expected.Context.Tags["Test Key"] = "Test Value";
-            expected.Sanitize();
-
-            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TTelemetry, TEndpointData>(expected);
-            
-            Assert.AreEqual("Test Value", actual.tags["Test Key"]);
         }
 
         private void SerializeWritesTelemetryNameAsExpectedByEndpoint()

--- a/Test/CoreSDK.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
@@ -23,7 +23,7 @@
             Assert.Equal<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(item.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
             Assert.Equal(expected.Sequence, item.seq);
             Assert.Equal(expected.Context.InstrumentationKey, item.iKey);
-            Assert.Equal(expected.Context.Tags.ToArray(), item.tags.ToArray());
+            Assert.Equal(expected.Context.SanitizedTags.ToArray(), item.tags.ToArray());
             Assert.Equal(typeof(AI.AvailabilityData).Name, item.data.baseType);
 
             Assert.Equal(expected.Duration, TimeSpan.Parse(item.data.baseData.duration));

--- a/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -19,7 +19,7 @@
             Assert.Equal<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(item.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
             Assert.Equal(expected.Sequence, item.seq);
             Assert.Equal(expected.Context.InstrumentationKey, item.iKey);
-            Assert.Equal(expected.Context.Tags.ToArray(), item.tags.ToArray());
+            Assert.Equal(expected.Context.SanitizedTags.ToArray(), item.tags.ToArray());
             Assert.Equal(typeof(AI.RemoteDependencyData).Name, item.data.baseType);
 
             Assert.Equal(expected.Id, item.data.baseData.id);

--- a/Test/CoreSDK.Test/Shared/DataContracts/TelemetryContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/TelemetryContextTest.cs
@@ -26,10 +26,11 @@
         }
 
         [TestMethod]
+        [Ignore]
         public void ConstructorInitializesTagsWithThreadSafeDictionaryObjects()
         {
             var context = new TelemetryContext();
-            Assert.IsType<ConcurrentDictionary<string, string>>(context.Tags);
+            Assert.IsType<ConcurrentDictionary<string, string>>(context.SanitizedTags);
         }
 
         [TestMethod]
@@ -93,31 +94,6 @@
         {
             TelemetryContext context = new TelemetryContext();
             Assert.NotNull(context.Internal);
-        }
-
-        [TestMethod]
-        public void InitializeCopiesTags()
-        {
-            string tagName = "TestTag";
-            string tagValue = "TestValue";
-            var source = new TelemetryContext { Tags = { { tagName, tagValue } } };
-            var target = new TelemetryContext();
-
-            target.Initialize(source, source.InstrumentationKey);
-
-            Assert.Equal(tagValue, target.Tags[tagName]);
-        }
-
-        [TestMethod]
-        public void InitializeDoesNotOverwriteTags()
-        {
-            string tagName = "TestTag";
-            var source = new TelemetryContext { Tags = { { tagName, "Source Value" } } };
-            var target = new TelemetryContext { Tags = { { tagName, "Target Value" } } };
-
-            target.Initialize(source, source.InstrumentationKey);
-
-            Assert.Equal("Target Value", target.Tags[tagName]);
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/DataContracts/TelemetryContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/DataContracts/TelemetryContextTest.cs
@@ -26,14 +26,6 @@
         }
 
         [TestMethod]
-        [Ignore]
-        public void ConstructorInitializesTagsWithThreadSafeDictionaryObjects()
-        {
-            var context = new TelemetryContext();
-            Assert.IsType<ConcurrentDictionary<string, string>>(context.SanitizedTags);
-        }
-
-        [TestMethod]
         public void InstrumentationKeyIsNotNullByDefaultToPreventNullReferenceExceptionsInUserCode()
         {
             var context = new TelemetryContext();

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/ComponentContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/ComponentContextTest.cs
@@ -21,16 +21,14 @@
         [TestMethod]
         public void VersionIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var tags = new Dictionary<string, string>();
-            var component = new ComponentContext(tags);
+            var component = new ComponentContext();
             Assert.Null(component.Version);
         }
 
         [TestMethod]
         public void VersionCanBeChangedByUserToSpecifyVersionOfTheirApplication()
         {
-            var tags = new Dictionary<string, string>();
-            var component = new ComponentContext(tags);
+            var component = new ComponentContext();
             component.Version = "4.2";
             Assert.Equal("4.2", component.Version);
         }
@@ -39,11 +37,12 @@
         public void VersionSetsCorrectTagKeyAndValue()
         {
             IDictionary<string, string> tags = new Dictionary<string, string>();
-            var component = new ComponentContext(tags);
+            var component = new ComponentContext();
 
             string componentVersion = "fakeVersion";
             component.Version = componentVersion;
 
+            component.UpdateTags(tags);
             Assert.True(tags.Contains(new KeyValuePair<string, string>(ContextTagKeys.Keys.ApplicationVersion, componentVersion)));
         }
     }

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/DeviceContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/DeviceContextTest.cs
@@ -17,14 +17,14 @@
         [TestMethod]
         public void TypeIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             Assert.Null(context.Type);
         }
 
         [TestMethod]
         public void TypeCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             context.Type = "test value";
             Assert.Equal("test value", context.Type);
         }
@@ -32,14 +32,14 @@
         [TestMethod]
         public void IdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             Assert.Null(context.Id);
         }
 
         [TestMethod]
         public void IdCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             context.Id = "test value";
             Assert.Equal("test value", context.Id);
         }
@@ -47,14 +47,14 @@
         [TestMethod]
         public void OperatingSystemIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             Assert.Null(context.OperatingSystem);
         }
 
         [TestMethod]
         public void OperatingSystemCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             context.OperatingSystem = "test value";
             Assert.Equal("test value", context.OperatingSystem);
         }
@@ -62,14 +62,14 @@
         [TestMethod]
         public void OemNameIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             Assert.Null(context.OemName);
         }
 
         [TestMethod]
         public void OemNameCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             context.OemName = "test value";
             Assert.Equal("test value", context.OemName);
         }
@@ -77,14 +77,14 @@
         [TestMethod]
         public void DeviceModelIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             Assert.Null(context.Model);
         }
 
         [TestMethod]
         public void DeviceModelCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
             context.Model = "test value";
             Assert.Equal("test value", context.Model);
         }
@@ -92,7 +92,7 @@
         [TestMethod]
         public void NetworkTypeIsNullByDefaultToPreventUnnecessaryTransmissionOfDefaultValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
 #pragma warning disable 618
             Assert.Null(context.NetworkType);
 #pragma warning restore 618
@@ -101,7 +101,7 @@
         [TestMethod]
         public void NetworkTypeCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
 #pragma warning disable 618
             context.NetworkType = "42";
             Assert.Equal("42", context.NetworkType);
@@ -111,7 +111,7 @@
         [TestMethod]
         public void ScreenResolutionIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
 #pragma warning disable 618
             Assert.Null(context.ScreenResolution);
 #pragma warning restore 618
@@ -120,7 +120,7 @@
         [TestMethod]
         public void ScreenResolutionCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
 #pragma warning disable 618
             context.ScreenResolution = "test value";
             Assert.Equal("test value", context.ScreenResolution);
@@ -130,7 +130,7 @@
         [TestMethod]
         public void LanguageIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
 #pragma warning disable 618
             Assert.Null(context.Language);
 #pragma warning restore 618
@@ -139,7 +139,7 @@
         [TestMethod]
         public void LanguageCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new DeviceContext(new Dictionary<string, string>(), new Dictionary<string, string>());
+            var context = new DeviceContext(new Dictionary<string, string>());
 #pragma warning disable 618
             context.Language = "test value";
             Assert.Equal("test value", context.Language);

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/InternalContextTests.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/InternalContextTests.cs
@@ -11,14 +11,14 @@
         [TestMethod]
         public void SdkVersionIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new InternalContext(new Dictionary<string, string>());
+            var context = new InternalContext();
             Assert.Null(context.SdkVersion);
         }
 
         [TestMethod]
         public void IpCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new InternalContext(new Dictionary<string, string>());
+            var context = new InternalContext();
             context.SdkVersion = "0.0.11.00.1";
             Assert.Equal("0.0.11.00.1", context.SdkVersion);
         }

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/LocationContextTests.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/LocationContextTests.cs
@@ -18,14 +18,14 @@
         [TestMethod]
         public void IpIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new LocationContext(new Dictionary<string, string>());
+            var context = new LocationContext();
             Assert.Null(context.Ip);
         }
 
         [TestMethod]
         public void IpCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new LocationContext(new Dictionary<string, string>());
+            var context = new LocationContext();
             context.Ip = "192.168.1.1";
             Assert.Equal("192.168.1.1", context.Ip);
         }

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/OperationContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/OperationContextTest.cs
@@ -17,42 +17,42 @@
         [TestMethod]
         public void IdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             Assert.Null(operation.Id);
         }
 
         [TestMethod]
         public void NameIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             Assert.Null(operation.Name);
         }
 
         [TestMethod]
         public void SyntheticSourceIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             Assert.Null(operation.SyntheticSource);
         }
 
         [TestMethod]
         public void ParentIdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             Assert.Null(operation.ParentId);
         }
 
         [TestMethod]
         public void RootIdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             Assert.Null(operation.Id);
         }
 
         [TestMethod]
         public void CorrelationVectorIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             Assert.Null(operation.CorrelationVector);
         }
 
@@ -60,7 +60,7 @@
         [TestMethod]
         public void IdCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             operation.Id = "42";
             Assert.Equal("42", operation.Id);
         }
@@ -68,7 +68,7 @@
         [TestMethod]
         public void NameCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             operation.Name = "SampleOperationName";
             Assert.Equal("SampleOperationName", operation.Name);
         }
@@ -76,7 +76,7 @@
         [TestMethod]
         public void SyntheticSourceCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             operation.SyntheticSource = "Sample";
             Assert.Equal("Sample", operation.SyntheticSource);
         }
@@ -84,7 +84,7 @@
         [TestMethod]
         public void ParentIdCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             operation.ParentId = "ParentId";
             Assert.Equal("ParentId", operation.ParentId);
         }
@@ -92,7 +92,7 @@
         [TestMethod]
         public void CorrelationVectorCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
-            var operation = new OperationContext(new Dictionary<string, string>());
+            var operation = new OperationContext();
             operation.CorrelationVector = "CorrelationVector";
             Assert.Equal("CorrelationVector", operation.CorrelationVector);
         }

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/PropertyTest.cs
@@ -334,61 +334,39 @@
             var internalContext = telemetryContext.Internal;
             internalContext.SdkVersion = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalSdkVersion] + 1);
             internalContext.AgentVersion = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalAgentVersion] + 1);
-            internalContext.NodeName = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalNodeName] + 1);            
+            internalContext.NodeName = new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalNodeName] + 1);
 
-            telemetryContext.SanitizeTelemetryContext();
+            var tags = telemetryContext.SanitizedTags;
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.ApplicationVersion]), componentContext.Version);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.ApplicationVersion]), tags[ContextTagKeys.Keys.ApplicationVersion]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceId]), deviceContext.Id);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceModel]), deviceContext.Model);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOEMName]), deviceContext.OemName);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOSVersion]), deviceContext.OperatingSystem);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceType]), deviceContext.Type);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceId]), tags[ContextTagKeys.Keys.DeviceId]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceModel]), tags[ContextTagKeys.Keys.DeviceModel]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOEMName]), tags[ContextTagKeys.Keys.DeviceOEMName]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceOSVersion]), tags[ContextTagKeys.Keys.DeviceOSVersion]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.DeviceType]), tags[ContextTagKeys.Keys.DeviceType]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.LocationIp]), locationContext.Ip);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.LocationIp]), tags[ContextTagKeys.Keys.LocationIp]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationId]), operationContext.Id);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationName]), operationContext.Name);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationParentId]), operationContext.ParentId);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationSyntheticSource]), operationContext.SyntheticSource);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationCorrelationVector]), operationContext.CorrelationVector);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationId]), tags[ContextTagKeys.Keys.OperationId]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationName]), tags[ContextTagKeys.Keys.OperationName]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationParentId]), tags[ContextTagKeys.Keys.OperationParentId]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationSyntheticSource]), tags[ContextTagKeys.Keys.OperationSyntheticSource]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.OperationCorrelationVector]), tags[ContextTagKeys.Keys.OperationCorrelationVector]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.SessionId]), sessionContext.Id);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.SessionId]), tags[ContextTagKeys.Keys.SessionId]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserId]), userContext.Id);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAccountId]), userContext.AccountId);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAgent]), userContext.UserAgent);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAuthUserId]), userContext.AuthenticatedUserId);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserId]), tags[ContextTagKeys.Keys.UserId]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAccountId]), tags[ContextTagKeys.Keys.UserAccountId]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAgent]), tags[ContextTagKeys.Keys.UserAgent]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.UserAuthUserId]), tags[ContextTagKeys.Keys.UserAuthUserId]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRole]), cloudContext.RoleName);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRoleInstance]), cloudContext.RoleInstance);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRole]), tags[ContextTagKeys.Keys.CloudRole]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.CloudRoleInstance]), tags[ContextTagKeys.Keys.CloudRoleInstance]);
 
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalSdkVersion]), internalContext.SdkVersion);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalAgentVersion]), internalContext.AgentVersion);
-            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalNodeName]), internalContext.NodeName);            
-        }
-
-        private static IEnumerable<char> GetInvalidNameCharacters()
-        {
-            var invalidCharacters = new List<char>();
-            for (int i = 0; i < 128; i++)
-            {
-                char c = Convert.ToChar(i);
-                if (!IsValidNameCharacter(c))
-                {
-                    invalidCharacters.Add(c);
-                }
-            }
-
-            return invalidCharacters;
-        }
-
-        private static bool IsValidNameCharacter(char c)
-        {
-            // Valid Characters:  a-z, A-Z, 0-9, /, \, (, ), _, -, ., sp
-            const string ValidSymbols = @"/\()_-. ";
-            return char.IsLetterOrDigit(c) || ValidSymbols.Contains(c.ToString());
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalSdkVersion]), tags[ContextTagKeys.Keys.InternalSdkVersion]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalAgentVersion]), tags[ContextTagKeys.Keys.InternalAgentVersion]);
+            Assert.Equal(new string('Z', Property.TagSizeLimits[ContextTagKeys.Keys.InternalNodeName]), tags[ContextTagKeys.Keys.InternalNodeName]);
         }
     }
 }

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/SessionContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/SessionContextTest.cs
@@ -17,14 +17,14 @@
         [TestMethod]
         public void IdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var session = new SessionContext(new Dictionary<string, string>());
+            var session = new SessionContext();
             Assert.Null(session.Id);
         }
 
         [TestMethod]
         public void IdCanBeChangedByUserToSupplyApplicationDefinedValue()
         {
-            var session = new SessionContext(new Dictionary<string, string>());
+            var session = new SessionContext();
             session.Id = "42";
             Assert.Equal("42", session.Id);
         }
@@ -32,14 +32,14 @@
         [TestMethod]
         public void IsFirstIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var session = new SessionContext(new Dictionary<string, string>());
+            var session = new SessionContext();
             Assert.Null(session.IsFirst);
         }
 
         [TestMethod]
         public void IsFirstCanBeSetByUserToSupplyCustomValue()
         {
-            var session = new SessionContext(new Dictionary<string, string>());
+            var session = new SessionContext();
             session.IsFirst = true;
             Assert.Equal(true, session.IsFirst);
         }
@@ -47,7 +47,7 @@
         [TestMethod]
         public void IsFirstCanBeSetToNullToRemoveItFromJsonPayload()
         {
-            var session = new SessionContext(new Dictionary<string, string>()) { IsFirst = true };
+            var session = new SessionContext() { IsFirst = true };
             session.IsFirst = null;
             Assert.Null(session.IsFirst);
         }

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TagsTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/TagsTest.cs
@@ -40,83 +40,6 @@
         }
 
         [TestMethod]
-        public void GetTagBoolValueOrNullReturnsCorrectBoolValue()
-        {
-            var tags = new Dictionary<string, string>();
-
-            string testKey = "testKey";
-            string testValue = "true";
-
-            tags[testKey] = testValue;
-
-            bool? tagValue = tags.GetTagBoolValueOrNull(testKey);
-
-            Assert.True(tagValue.Value);
-        }
-
-        [TestMethod]
-        public void GetTagBoolValueOrNullReturnsNull()
-        {
-            var tags = new Dictionary<string, string>();
-
-            bool? tagValue = tags.GetTagBoolValueOrNull("testKey");
-
-            Assert.Null(tagValue);
-        }
-
-        [TestMethod]
-        public void GetTagIntValueOrNullReturnsCorrectIntValue()
-        {
-            var tags = new Dictionary<string, string>();
-
-            string testKey = "testKey";
-            string testValue = "5";
-
-            tags[testKey] = testValue;
-
-            int? tagValue = tags.GetTagIntValueOrNull(testKey);
-
-            Assert.Equal(5, tagValue.Value);
-        }
-
-        [TestMethod]
-        public void GetTagIntValueOrNullReturnsNull()
-        {
-            var tags = new Dictionary<string, string>();
-
-            int? tagValue = tags.GetTagIntValueOrNull("testKey");
-
-            Assert.Null(tagValue);
-        }
-
-        [TestMethod]
-        public void GetTagDateTimeOffsetValueOrNullReturnsCorrectDateTimeOffsetValue()
-        {
-            var tags = new Dictionary<string, string>();
-
-            string testKey = "testKey";
-            string testValue = "2014-09-23T00:00:00.0000000-07:00";
-
-            tags[testKey] = testValue;
-
-            DateTimeOffset? tagValue = tags.GetTagDateTimeOffsetValueOrNull(testKey);
-
-            DateTimeOffset expectedValue = new DateTimeOffset(new DateTime(2014, 9, 23), TimeSpan.FromHours(-7));
-
-            Assert.Equal(expectedValue, tagValue);
-        }
-
-        [TestMethod]
-        public void GetTagDateTimeOffsetValueOrNullReturnsNull()
-        {
-            var tags = new Dictionary<string, string>();
-
-            DateTimeOffset? tagValue = tags.GetTagDateTimeOffsetValueOrNull("testKey");
-
-            Assert.Null(tagValue);
-        }
-
-        [TestMethod]
         public void SetStringValueOrRemoveSetsCorrectStringValue()
         {
             var tags = new Dictionary<string, string>();
@@ -129,42 +52,12 @@
             Assert.Equal(testValue, tags[testKey]);
         }
 
-#if NET40 || NET45
         [TestMethod]
         public void SetStringValueOrRemoveDoesNotThrowsWhenValueIsNull()
         {
             var tags = new Dictionary<string, string>();
 
             Assert.DoesNotThrow(() => tags.SetStringValueOrRemove("testKey", null));
-        }
-#endif
-
-        [TestMethod]
-        public void SetDateTimeOffsetValueOrRemoveSetsCorrectDateTimeOffsetValue()
-        {
-            var tags = new Dictionary<string, string>();
-
-            string testKey = "testKey";
-            DateTimeOffset testValue = new DateTimeOffset(new DateTime(2014, 9, 23), TimeSpan.FromHours(-7));
-
-            tags.SetDateTimeOffsetValueOrRemove(testKey, testValue);
-
-            Assert.Equal("2014-09-23T00:00:00.0000000-07:00", tags[testKey]);
-        }
-
-        [TestMethod]
-        public void SetDateTimeOffsetValueOrRemoveRemovesValue()
-        {
-            var tags = new Dictionary<string, string>();
-            
-            string testKey = "testKey";
-            string testValue = "2014-09-23T00:00:00.0000000-07:00";
-
-            tags[testKey] = testValue;
-
-            tags.SetDateTimeOffsetValueOrRemove(testKey, null);
-
-            Assert.False(tags.ContainsKey(testKey));
         }
 
         [TestMethod]

--- a/Test/CoreSDK.Test/Shared/Extensibility/Implementation/UserContextTest.cs
+++ b/Test/CoreSDK.Test/Shared/Extensibility/Implementation/UserContextTest.cs
@@ -21,7 +21,7 @@
         [TestMethod]
         public void IdCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new UserContext(new Dictionary<string, string>());
+            var context = new UserContext();
             context.Id = "test value";
             Assert.Equal("test value", context.Id);
         }
@@ -29,14 +29,14 @@
         [TestMethod]
         public void UserAgentIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new UserContext(new Dictionary<string, string>());
+            var context = new UserContext();
             Assert.Null(context.UserAgent);
         }
 
         [TestMethod]
         public void UserAgentCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new UserContext(new Dictionary<string, string>());
+            var context = new UserContext();
             context.UserAgent = "test value";
             Assert.Equal("test value", context.UserAgent);
         }
@@ -44,15 +44,15 @@
         [TestMethod]
         public void AccountIdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
-            var context = new UserContext(new Dictionary<string, string>());
+            var context = new UserContext();
             Assert.Null(context.AccountId);
         }
 
         [TestMethod]
         public void AccountIdCanBeChangedByUserToSpecifyACustomValue()
         {
-            var context = new UserContext(new Dictionary<string, string>());
-            context.AccountId = "test value";            
+            var context = new UserContext();
+            context.AccountId = "test value";
             Assert.Equal("test value", context.AccountId);
         }
     }

--- a/src/Core/Managed/Shared/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/AvailabilityTelemetry.cs
@@ -48,8 +48,8 @@
         /// <summary>
         /// Gets or sets the test run id.
         /// </summary>
-        public string Id  
-        {  
+        public string Id
+        {
             get { return this.Data.id; }
             set { this.Data.id = value; }
         }
@@ -69,7 +69,7 @@
         public TimeSpan Duration
         {
             get
-            {                
+            {
                 return Utils.ValidateDuration(this.Data.duration);
             }
 
@@ -161,8 +161,6 @@
 
             this.Data.properties.SanitizeProperties();
             this.Data.measurements.SanitizeMeasurements();
-
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/DependencyTelemetry.cs
@@ -33,7 +33,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class with the given <paramref name="dependencyName"/>, <paramref name="data"/>, 
+        /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class with the given <paramref name="dependencyName"/>, <paramref name="data"/>,
         /// <paramref name="startTime"/>, <paramref name="duration"/> and <paramref name="success"/> property values.
         /// </summary>
         [Obsolete("Use other constructors which allows to define dependency call with all the properties.")]
@@ -48,7 +48,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class with the given <paramref name="dependencyName"/>, <paramref name="target"/>, 
+        /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class with the given <paramref name="dependencyName"/>, <paramref name="target"/>,
         /// <paramref name="dependencyName"/>, <paramref name="data"/> property values.
         /// </summary>
         public DependencyTelemetry(string dependencyTypeName, string target, string dependencyName, string data)
@@ -61,8 +61,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class with the given <paramref name="dependencyName"/>, <paramref name="target"/>, 
-        /// <paramref name="dependencyName"/>, <paramref name="data"/>, <paramref name="startTime"/>, <paramref name="duration"/>, <paramref name="resultCode"/> 
+        /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class with the given <paramref name="dependencyName"/>, <paramref name="target"/>,
+        /// <paramref name="dependencyName"/>, <paramref name="data"/>, <paramref name="startTime"/>, <paramref name="duration"/>, <paramref name="resultCode"/>
         /// and <paramref name="success"/> and  property values.
         /// </summary>
         public DependencyTelemetry(string dependencyTypeName, string target, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, string resultCode, bool success)
@@ -96,9 +96,9 @@ namespace Microsoft.ApplicationInsights.DataContracts
             get { return this.context; }
         }
 
-        /// <summary>  
+        /// <summary>
         /// Gets or sets Dependency ID.
-        /// </summary>  
+        /// </summary>
         public override string Id
         {
             get { return this.InternalData.id; }
@@ -246,7 +246,6 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.Type = this.Type.SanitizeDependencyType();
             this.Data = this.Data.SanitizeData();
             this.Properties.SanitizeProperties();
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/EventTelemetry.cs
@@ -14,7 +14,7 @@
     public sealed class EventTelemetry : ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics
     {
         internal const string TelemetryName = "Event";
-         
+
         internal readonly string BaseType = typeof(EventData).Name;
         internal readonly EventData Data;
         private readonly TelemetryContext context;
@@ -48,7 +48,7 @@
         /// Gets or sets the value that defines absolute order of the telemetry item.
         /// </summary>
         public string Sequence { get; set; }
-        
+
         /// <summary>
         /// Gets the context associated with the current telemetry item.
         /// </summary>
@@ -56,7 +56,7 @@
         {
             get { return this.context; }
         }
-        
+
         /// <summary>
         /// Gets or sets the name of the event.
         /// </summary>
@@ -103,7 +103,6 @@
             this.Name = Utils.PopulateRequiredStringValue(this.Name, "name", typeof(EventTelemetry).FullName);
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/ExceptionTelemetry.cs
@@ -105,19 +105,19 @@
                 this.Properties["handledAt"] = value.ToString();
             }
         }
-        
+
         /// <summary>
         /// Gets or sets the original exception tracked by this <see cref="ITelemetry"/>.
         /// </summary>
         public Exception Exception
         {
-            get 
+            get
             {
                 return this.exception;
             }
 
-            set 
-            { 
+            set
+            {
                 this.exception = value;
                 this.UpdateExceptions(value);
             }
@@ -234,7 +234,6 @@
             // Sanitize on the ExceptionDetails stack information for raw stack and parsed stack is done while creating the object in ExceptionConverter.cs
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
-            this.Context.SanitizeTelemetryContext();
         }
 
         private void ConvertExceptionTree(Exception exception, ExceptionDetails parentExceptionDetails, List<ExceptionDetails> exceptions)
@@ -288,11 +287,11 @@
 
                 // remove all but the first N exceptions
                 exceptions.RemoveRange(Constants.MaxExceptionCountToSave, exceptions.Count - Constants.MaxExceptionCountToSave);
-                
+
                 // we'll add our new exception and parent it to the root exception (first one in the list)
-                exceptions.Add(ExceptionConverter.ConvertToExceptionDetails(countExceededException, exceptions[0])); 
+                exceptions.Add(ExceptionConverter.ConvertToExceptionDetails(countExceededException, exceptions[0]));
             }
-            
+
             this.Data.exceptions = exceptions;
         }
     }

--- a/src/Core/Managed/Shared/DataContracts/InnerExceptionCountExceededException.cs
+++ b/src/Core/Managed/Shared/DataContracts/InnerExceptionCountExceededException.cs
@@ -1,7 +1,7 @@
 namespace Microsoft.ApplicationInsights.DataContracts
 {
     using System;
-#if !NETSTANDARD1_3 
+#if !NETSTANDARD1_3
     using System.Runtime.Serialization;
 #endif
 
@@ -11,7 +11,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
 #if !NETSTANDARD1_3
     [Serializable]
 #endif
-    internal class InnerExceptionCountExceededException : 
+    internal class InnerExceptionCountExceededException :
         Exception
     {
         /// <summary>

--- a/src/Core/Managed/Shared/DataContracts/MetricTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/MetricTelemetry.cs
@@ -19,9 +19,9 @@
 
         internal readonly MetricData Data;
         internal readonly DataPoint Metric;
-        
+
         /// <summary>
-        /// Initializes a new instance of the <see cref="MetricTelemetry"/> class with empty 
+        /// Initializes a new instance of the <see cref="MetricTelemetry"/> class with empty
         /// properties.
         /// </summary>
         public MetricTelemetry()
@@ -37,7 +37,7 @@
         }
 
         /// <summary>
-        /// Obsolete - use MetricTelemetry(name,count,sum,min,max,standardDeviation). Initializes a new instance of the <see cref="MetricTelemetry"/> class with the 
+        /// Obsolete - use MetricTelemetry(name,count,sum,min,max,standardDeviation). Initializes a new instance of the <see cref="MetricTelemetry"/> class with the
         /// specified <paramref name="metricName"/> and <paramref name="metricValue"/>.
         /// </summary>
         /// <exception cref="ArgumentException">The <paramref name="metricName"/> is null or empty string.</exception>
@@ -196,8 +196,6 @@
             {
                 this.StandardDeviation = Utils.SanitizeNanAndInfinity(this.StandardDeviation.Value);
             }
-
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/PageViewTelemetry.cs
@@ -12,8 +12,8 @@
     /// Telemetry type used to track page views.
     /// </summary>
     /// <remarks>
-    /// You can send information about pages viewed by your application to Application Insights by 
-    /// passing an instance of the <see cref="PageViewTelemetry"/> class to the <see cref="TelemetryClient.TrackPageView(PageViewTelemetry)"/> 
+    /// You can send information about pages viewed by your application to Application Insights by
+    /// passing an instance of the <see cref="PageViewTelemetry"/> class to the <see cref="TelemetryClient.TrackPageView(PageViewTelemetry)"/>
     /// method.
     /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#page-views">Learn more</a>
     /// </remarks>
@@ -38,7 +38,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="PageViewTelemetry"/> class with the 
+        /// Initializes a new instance of the <see cref="PageViewTelemetry"/> class with the
         /// specified <paramref name="pageName"/>.
         /// </summary>
         /// <exception cref="ArgumentException">The <paramref name="pageName"/> is null or empty string.</exception>
@@ -85,7 +85,7 @@
                 {
                     return null;
                 }
-                
+
                 return new Uri(this.Data.url, UriKind.RelativeOrAbsolute);
             }
 
@@ -105,7 +105,7 @@
         /// <summary>
         /// Gets or sets the page view duration.
         /// </summary>
-        public TimeSpan Duration 
+        public TimeSpan Duration
         {
             get { return Utils.ValidateDuration(this.Data.duration); }
             set { this.Data.duration = value.ToString(); }
@@ -149,7 +149,6 @@
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
             this.Url = this.Url.SanitizeUri();
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/PerformanceCounterTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/PerformanceCounterTelemetry.cs
@@ -31,7 +31,7 @@
         /// <param name="counterName">Performance counter name.</param>
         /// <param name="instanceName">Instance name.</param>
         /// <param name="value">Performance counter value.</param>
-        public PerformanceCounterTelemetry(string categoryName, string counterName, string instanceName, double value) 
+        public PerformanceCounterTelemetry(string categoryName, string counterName, string instanceName, double value)
             : this()
         {
             this.CategoryName = categoryName;

--- a/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/RequestTelemetry.cs
@@ -11,8 +11,8 @@
     /// Encapsulates information about a web request handled by the application.
     /// </summary>
     /// <remarks>
-    /// You can send information about requests processed by your web application to Application Insights by 
-    /// passing an instance of the <see cref="RequestTelemetry"/> class to the <see cref="TelemetryClient.TrackRequest(RequestTelemetry)"/> 
+    /// You can send information about requests processed by your web application to Application Insights by
+    /// passing an instance of the <see cref="RequestTelemetry"/> class to the <see cref="TelemetryClient.TrackRequest(RequestTelemetry)"/>
     /// method.
     /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackrequest">Learn more</a>
     /// </remarks>
@@ -38,7 +38,7 @@
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="RequestTelemetry"/> class with the given <paramref name="name"/>, 
+        /// Initializes a new instance of the <see cref="RequestTelemetry"/> class with the given <paramref name="name"/>,
         /// <paramref name="startTime"/>, <paramref name="duration"/>, <paramref name="responseCode"/> and <paramref name="success"/> property values.
         /// </summary>
         public RequestTelemetry(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success)
@@ -69,13 +69,13 @@
             get { return this.context; }
         }
 
-        /// <summary>  
+        /// <summary>
         /// Gets or sets Request ID.
-        /// </summary>  
-        public override string Id  
-        {  
-            get { return this.Data.id; }  
-            set { this.Data.id = value; }  
+        /// </summary>
+        public override string Id
+        {
+            get { return this.Data.id; }
+            set { this.Data.id = value; }
         }
 
         /// <summary>
@@ -159,12 +159,12 @@
                 return new Uri(this.Data.url, UriKind.RelativeOrAbsolute);
             }
 
-            set 
+            set
             {
                 this.Data.url = value?.ToString();
             }
         }
-        
+
         /// <summary>
         /// Gets a dictionary of application-defined request metrics.
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#properties">Learn more</a>
@@ -212,7 +212,7 @@
             this.Metrics.SanitizeMeasurements();
             this.Url = this.Url.SanitizeUri();
 
-            // Set for backward compatibility:  
+            // Set for backward compatibility:
             this.Data.id = this.Data.id.SanitizeName();
             this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
 
@@ -222,8 +222,6 @@
                 this.ResponseCode = "200";
                 this.Success = true;
             }
-
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
+++ b/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
@@ -148,14 +148,14 @@
         {
             Property.Initialize(ref this.instrumentationKey, instrumentationKey);
 
-            source.component?.CopyTo(this);
-            source.device?.CopyTo(this);
-            source.cloud?.CopyTo(this);
-            source.session?.CopyTo(this);
-            source.user?.CopyTo(this);
-            source.operation?.CopyTo(this);
-            source.location?.CopyTo(this);
-            source.Internal.CopyTo(this);
+            this.component?.CopyFrom(source);
+            this.device?.CopyFrom(source);
+            this.cloud?.CopyFrom(source);
+            this.session?.CopyFrom(source);
+            this.user?.CopyFrom(source);
+            this.operation?.CopyFrom(source);
+            this.location?.CopyFrom(source);
+            this.Internal.CopyFrom(source);
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
+++ b/src/Core/Managed/Shared/DataContracts/TelemetryContext.cs
@@ -15,7 +15,6 @@
     public sealed class TelemetryContext
     {
         private readonly IDictionary<string, string> properties;
-        private readonly IDictionary<string, string> tags;
 
         private string instrumentationKey;
 
@@ -26,7 +25,7 @@
         private UserContext user;
         private OperationContext operation;
         private LocationContext location;
-        private InternalContext internalContext;
+        private InternalContext internalContext = new InternalContext();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryContext"/> class.
@@ -40,7 +39,6 @@
         {
             Debug.Assert(properties != null, "properties");
             this.properties = properties;
-            this.tags = new ConcurrentDictionary<string, string>();
         }
 
         /// <summary>
@@ -48,8 +46,8 @@
         /// </summary>
         /// <remarks>
         /// By default, this property is initialized with the <see cref="TelemetryConfiguration.InstrumentationKey"/> value
-        /// of the <see cref="TelemetryConfiguration.Active"/> instance of <see cref="TelemetryConfiguration"/>. You can specify it 
-        /// for all telemetry tracked via a particular <see cref="TelemetryClient"/> or for a specific <see cref="ITelemetry"/> 
+        /// of the <see cref="TelemetryConfiguration.Active"/> instance of <see cref="TelemetryConfiguration"/>. You can specify it
+        /// for all telemetry tracked via a particular <see cref="TelemetryClient"/> or for a specific <see cref="ITelemetry"/>
         /// instance.
         /// </remarks>
         public string InstrumentationKey
@@ -57,13 +55,13 @@
             get { return this.instrumentationKey ?? string.Empty; }
             set { Property.Set(ref this.instrumentationKey, value); }
         }
-        
+
         /// <summary>
         /// Gets the object describing the component tracked by this <see cref="TelemetryContext"/>.
         /// </summary>
-        public ComponentContext Component 
+        public ComponentContext Component
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.component, () => new ComponentContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.component, () => new ComponentContext()); }
         }
 
         /// <summary>
@@ -71,7 +69,7 @@
         /// </summary>
         public DeviceContext Device
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.device, () => new DeviceContext(this.Tags, this.Properties)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.device, () => new DeviceContext(this.Properties)); }
         }
 
         /// <summary>
@@ -79,7 +77,7 @@
         /// </summary>
         public CloudContext Cloud
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.cloud, () => new CloudContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.cloud, () => new CloudContext()); }
         }
 
         /// <summary>
@@ -87,7 +85,7 @@
         /// </summary>
         public SessionContext Session
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.session, () => new SessionContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.session, () => new SessionContext()); }
         }
 
         /// <summary>
@@ -95,7 +93,7 @@
         /// </summary>
         public UserContext User
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.user, () => new UserContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.user, () => new UserContext()); }
         }
 
         /// <summary>
@@ -104,7 +102,7 @@
         /// </summary>
         public OperationContext Operation
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.operation, () => new OperationContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.operation, () => new OperationContext()); }
         }
 
         /// <summary>
@@ -112,7 +110,7 @@
         /// </summary>
         public LocationContext Location
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.location, () => new LocationContext(this.Tags)); }
+            get { return LazyInitializer.EnsureInitialized(ref this.location, () => new LocationContext()); }
         }
 
         /// <summary>
@@ -124,27 +122,40 @@
             get { return this.properties; }
         }
 
-        internal InternalContext Internal
-        {
-            get { return LazyInitializer.EnsureInitialized(ref this.internalContext, () => new InternalContext(this.Tags)); }
-        }
+        internal InternalContext Internal => this.internalContext;
 
         /// <summary>
         /// Gets a dictionary of context tags.
         /// </summary>
-        internal IDictionary<string, string> Tags
+        internal IDictionary<string, string> SanitizedTags
         {
-            get { return this.tags; }
+            get
+            {
+                var result = new Dictionary<string, string>();
+                this.component?.UpdateTags(result);
+                this.device?.UpdateTags(result);
+                this.cloud?.UpdateTags(result);
+                this.session?.UpdateTags(result);
+                this.user?.UpdateTags(result);
+                this.operation?.UpdateTags(result);
+                this.location?.UpdateTags(result);
+                this.Internal.UpdateTags(result);
+                return result;
+            }
         }
 
         internal void Initialize(TelemetryContext source, string instrumentationKey)
         {
             Property.Initialize(ref this.instrumentationKey, instrumentationKey);
 
-            if (source.tags != null && source.tags.Count > 0)
-            {
-                Utils.CopyDictionary(source.tags, this.Tags);
-            }
+            source.component?.CopyTo(this);
+            source.device?.CopyTo(this);
+            source.cloud?.CopyTo(this);
+            source.session?.CopyTo(this);
+            source.user?.CopyTo(this);
+            source.operation?.CopyTo(this);
+            source.location?.CopyTo(this);
+            source.Internal.CopyTo(this);
         }
     }
 }

--- a/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
+++ b/src/Core/Managed/Shared/DataContracts/TraceTelemetry.cs
@@ -109,7 +109,6 @@
             this.Data.message = this.Data.message.SanitizeMessage();
             this.Data.message = Utils.PopulateRequiredStringValue(this.Data.message, "message", typeof(TraceTelemetry).FullName);
             this.Data.properties.SanitizeProperties();
-            this.Context.SanitizeTelemetryContext();
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
@@ -9,20 +9,17 @@
     /// </summary>
     public sealed class CloudContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal CloudContext(IDictionary<string, string> tags)
+        internal CloudContext()
         {
-            this.tags = tags;
         }
-        
+
         /// <summary>
         /// Gets or sets the role name.
         /// </summary>
         public string RoleName
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.CloudRole); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.CloudRole, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -30,8 +27,21 @@
         /// </summary>
         public string RoleInstance
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.CloudRoleInstance); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.CloudRoleInstance, value); }
+            get;
+            set;
+        }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.CloudRole, this.RoleName);
+            tags.UpdateTagValue(ContextTagKeys.Keys.CloudRoleInstance, this.RoleInstance);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Cloud;
+            target.RoleName = Tags.CopyTagValue(target.RoleName, this.RoleName);
+            target.RoleInstance = Tags.CopyTagValue(target.RoleInstance, this.RoleInstance);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/CloudContext.cs
@@ -9,6 +9,9 @@
     /// </summary>
     public sealed class CloudContext
     {
+        private string roleName;
+        private string roleInstance;
+
         internal CloudContext()
         {
         }
@@ -18,8 +21,8 @@
         /// </summary>
         public string RoleName
         {
-            get;
-            set;
+            get { return this.roleName == string.Empty ? null : this.roleName; }
+            set { this.roleName = value; }
         }
 
         /// <summary>
@@ -27,8 +30,8 @@
         /// </summary>
         public string RoleInstance
         {
-            get;
-            set;
+            get { return this.roleInstance == string.Empty ? null : this.roleInstance; }
+            set { this.roleInstance = value; }
         }
 
         internal void UpdateTags(IDictionary<string, string> tags)
@@ -37,11 +40,11 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.CloudRoleInstance, this.RoleInstance);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Cloud;
-            target.RoleName = Tags.CopyTagValue(target.RoleName, this.RoleName);
-            target.RoleInstance = Tags.CopyTagValue(target.RoleInstance, this.RoleInstance);
+            var source = telemetryContext.Cloud;
+            Tags.CopyTagValue(source.RoleName, ref this.roleName);
+            Tags.CopyTagValue(source.RoleInstance, ref this.roleInstance);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/ComponentContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/ComponentContext.cs
@@ -15,6 +15,8 @@
     /// </remarks>
     public sealed class ComponentContext
     {
+        private string version;
+
         internal ComponentContext()
         {
         }
@@ -22,17 +24,21 @@
         /// <summary>
         /// Gets or sets the application version.
         /// </summary>
-        public string Version { get; set; }
+        public string Version
+        {
+            get { return this.version == string.Empty ? null : this.version; }
+            set { this.version = value; }
+        }
 
         internal void UpdateTags(IDictionary<string, string> tags)
         {
             tags.UpdateTagValue(ContextTagKeys.Keys.ApplicationVersion, this.Version);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
             var target = telemetryContext.Component;
-            target.Version = Tags.CopyTagValue(target.Version, this.Version);
+            Tags.CopyTagValue(target.Version, ref this.version);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/ComponentContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/ComponentContext.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
+    using System;
     using System.Collections.Generic;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
@@ -8,26 +9,30 @@
     /// Encapsulates information describing an Application Insights component.
     /// </summary>
     /// <remarks>
-    /// This class matches the "Application" schema concept. We are intentionally calling it "Component" for consistency 
-    /// with terminology used by our portal and services and to encourage standardization of terminology within our 
+    /// This class matches the "Application" schema concept. We are intentionally calling it "Component" for consistency
+    /// with terminology used by our portal and services and to encourage standardization of terminology within our
     /// organization. Once a consensus is reached, we will change type and property names to match.
     /// </remarks>
     public sealed class ComponentContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal ComponentContext(IDictionary<string, string> tags)
+        internal ComponentContext()
         {
-            this.tags = tags;
         }
 
         /// <summary>
         /// Gets or sets the application version.
         /// </summary>
-        public string Version
+        public string Version { get; set; }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.ApplicationVersion); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.ApplicationVersion, value); }
+            tags.UpdateTagValue(ContextTagKeys.Keys.ApplicationVersion, this.Version);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Component;
+            target.Version = Tags.CopyTagValue(target.Version, this.Version);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
@@ -12,6 +12,12 @@
     {
         private readonly IDictionary<string, string> properties;
 
+        private string type;
+        private string id;
+        private string operatingSystem;
+        private string oemName;
+        private string model;
+
         internal DeviceContext(IDictionary<string, string> properties)
         {
             this.properties = properties;
@@ -20,15 +26,19 @@
         /// <summary>
         /// Gets or sets the type for the current device.
         /// </summary>
-        public string Type { get; set; }
+        public string Type
+        {
+            get { return this.type == string.Empty ? null : this.type; }
+            set { this.type = value; }
+        }
 
         /// <summary>
         /// Gets or sets a device unique ID.
         /// </summary>
         public string Id
         {
-            get;
-            set;
+            get { return this.id == string.Empty ? null : this.id; }
+            set { this.id = value; }
         }
 
         /// <summary>
@@ -36,8 +46,8 @@
         /// </summary>
         public string OperatingSystem
         {
-            get;
-            set;
+            get { return this.operatingSystem == string.Empty ? null : this.operatingSystem; }
+            set { this.operatingSystem = value; }
         }
 
         /// <summary>
@@ -45,8 +55,8 @@
         /// </summary>
         public string OemName
         {
-            get;
-            set;
+            get { return this.oemName == string.Empty ? null : this.oemName; }
+            set { this.oemName = value; }
         }
 
         /// <summary>
@@ -54,8 +64,8 @@
         /// </summary>
         public string Model
         {
-            get;
-            set;
+            get { return this.model == string.Empty ? null : this.model; }
+            set { this.model = value; }
         }
 
         /// <summary>
@@ -98,14 +108,14 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.DeviceModel, this.Model);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Device;
-            target.Type = Tags.CopyTagValue(target.Type, this.Type);
-            target.Id = Tags.CopyTagValue(target.Id, this.Id);
-            target.OperatingSystem = Tags.CopyTagValue(target.OperatingSystem, this.OperatingSystem);
-            target.OemName = Tags.CopyTagValue(target.OemName, this.OemName);
-            target.Model = Tags.CopyTagValue(target.Model, this.Model);
+            var source = telemetryContext.Device;
+            Tags.CopyTagValue(source.Type, ref this.type);
+            Tags.CopyTagValue(source.Id, ref this.id);
+            Tags.CopyTagValue(source.OperatingSystem, ref this.operatingSystem);
+            Tags.CopyTagValue(source.OemName, ref this.oemName);
+            Tags.CopyTagValue(source.Model, ref this.model);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/DeviceContext.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
     /// <summary>
@@ -9,31 +10,25 @@
     /// </summary>
     public sealed class DeviceContext
     {
-        private readonly IDictionary<string, string> tags;
         private readonly IDictionary<string, string> properties;
 
-        internal DeviceContext(IDictionary<string, string> tags, IDictionary<string, string> properties)
+        internal DeviceContext(IDictionary<string, string> properties)
         {
-            this.tags = tags;
             this.properties = properties;
         }
-        
+
         /// <summary>
         /// Gets or sets the type for the current device.
         /// </summary>
-        public string Type
-        {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceType); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceType, value); }
-        }
+        public string Type { get; set; }
 
         /// <summary>
         /// Gets or sets a device unique ID.
         /// </summary>
         public string Id
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceId, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -41,8 +36,8 @@
         /// </summary>
         public string OperatingSystem
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceOSVersion); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceOSVersion, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -50,8 +45,8 @@
         /// </summary>
         public string OemName
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceOEMName); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceOEMName, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -59,12 +54,12 @@
         /// </summary>
         public string Model
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.DeviceModel); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.DeviceModel, value); }
+            get;
+            set;
         }
 
         /// <summary>
-        /// Gets or sets the <a href="http://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib">IANA interface type</a> 
+        /// Gets or sets the <a href="http://www.iana.org/assignments/ianaiftype-mib/ianaiftype-mib">IANA interface type</a>
         /// for the internet connected network adapter.
         /// </summary>
         [Obsolete("Use custom properties.")]
@@ -92,6 +87,25 @@
         {
             get { return this.properties.GetTagValueOrNull("ai.device.language"); }
             set { this.properties.SetStringValueOrRemove("ai.device.language", value); }
+        }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.DeviceType, this.Type);
+            tags.UpdateTagValue(ContextTagKeys.Keys.DeviceId, this.Id);
+            tags.UpdateTagValue(ContextTagKeys.Keys.DeviceOSVersion, this.OperatingSystem);
+            tags.UpdateTagValue(ContextTagKeys.Keys.DeviceOEMName, this.OemName);
+            tags.UpdateTagValue(ContextTagKeys.Keys.DeviceModel, this.Model);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Device;
+            target.Type = Tags.CopyTagValue(target.Type, this.Type);
+            target.Id = Tags.CopyTagValue(target.Id, this.Id);
+            target.OperatingSystem = Tags.CopyTagValue(target.OperatingSystem, this.OperatingSystem);
+            target.OemName = Tags.CopyTagValue(target.OemName, this.OemName);
+            target.Model = Tags.CopyTagValue(target.Model, this.Model);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/External/Tags.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/External/Tags.cs
@@ -13,55 +13,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
     /// </summary>
     internal static class Tags
     {
-        internal static bool? GetTagBoolValueOrNull(this IDictionary<string, string> tags, string tagKey)
-        {
-            string tagValue = GetTagValueOrNull(tags, tagKey);
-            if (string.IsNullOrEmpty(tagValue))
-            {
-                return null;
-            }
-
-            return bool.Parse(tagValue);
-        }
-
-        internal static DateTimeOffset? GetTagDateTimeOffsetValueOrNull(this IDictionary<string, string> tags, string tagKey)
-        {
-            string tagValue = GetTagValueOrNull(tags, tagKey);
-            if (string.IsNullOrEmpty(tagValue))
-            {
-                return null;
-            }
-
-            return DateTimeOffset.Parse(tagValue, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind);
-        }
-
-        internal static int? GetTagIntValueOrNull(this IDictionary<string, string> tags, string tagKey)
-        {
-            string tagValue = GetTagValueOrNull(tags, tagKey);
-            if (string.IsNullOrEmpty(tagValue))
-            {
-                return null;
-            }
-
-            return int.Parse(tagValue, CultureInfo.InvariantCulture);
-        }
-
         internal static void SetStringValueOrRemove(this IDictionary<string, string> tags, string tagKey, string tagValue)
         {
             SetTagValueOrRemove(tags, tagKey, tagValue);
-        }
-
-        internal static void SetDateTimeOffsetValueOrRemove(this IDictionary<string, string> tags, string tagKey, DateTimeOffset? tagValue)
-        {
-            if (tagValue == null)
-            {
-                SetTagValueOrRemove(tags, tagKey, tagValue);
-            }
-            else
-            {
-                string tagValueString = tagValue.Value.ToString("O", CultureInfo.InvariantCulture);
-                SetTagValueOrRemove(tags, tagKey, tagValueString);
-            }
         }
 
         internal static void SetTagValueOrRemove<T>(this IDictionary<string, string> tags, string tagKey, T tagValue)
@@ -69,24 +23,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             SetTagValueOrRemove(tags, tagKey, Convert.ToString(tagValue, CultureInfo.InvariantCulture));
         }
 
-        internal static string CopyTagValue(string sourceValue, string targetValue)
+        internal static void CopyTagValue(bool? sourceValue, ref bool? targetValue)
         {
-            if (string.IsNullOrEmpty(sourceValue) && !string.IsNullOrEmpty(targetValue))
+            if (sourceValue.HasValue && !targetValue.HasValue)
             {
-                return targetValue;
+                targetValue = sourceValue;
             }
-
-            return sourceValue;
-        }
-
-        internal static bool? CopyTagValue(bool? sourceValue, bool? targetValue)
-        {
-            if (!sourceValue.HasValue && targetValue.HasValue)
-            {
-                return targetValue;
-            }
-
-            return sourceValue;
         }
 
         internal static string GetTagValueOrNull(this IDictionary<string, string> tags, string tagKey)
@@ -111,6 +53,14 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
                 }
 
                 tags.Add(tagKey, tagValue);
+            }
+        }
+
+        internal static void CopyTagValue(string sourceValue, ref string targetValue)
+        {
+            if (!string.IsNullOrEmpty(sourceValue) && string.IsNullOrEmpty(targetValue))
+            {
+                targetValue = sourceValue;
             }
         }
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/InternalContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/InternalContext.cs
@@ -12,6 +12,10 @@
     /// </summary>
     public sealed class InternalContext
     {
+        private string sdkVersion;
+        private string agentVersion;
+        private string nodeName;
+
         internal InternalContext()
         {
         }
@@ -21,8 +25,8 @@
         /// </summary>
         public string SdkVersion
         {
-            get;
-            set;
+            get { return this.sdkVersion == string.Empty ? null : this.sdkVersion; }
+            set { this.sdkVersion = value; }
         }
 
         /// <summary>
@@ -30,8 +34,8 @@
         /// </summary>
         public string AgentVersion
         {
-            get;
-            set;
+            get { return this.agentVersion == string.Empty ? null : this.agentVersion; }
+            set { this.agentVersion = value; }
         }
 
         /// <summary>
@@ -39,8 +43,8 @@
         /// </summary>
         public string NodeName
         {
-            get;
-            set;
+            get { return this.nodeName == string.Empty ? null : this.nodeName; }
+            set { this.nodeName = value; }
         }
 
         internal void UpdateTags(IDictionary<string, string> tags)
@@ -50,12 +54,12 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.InternalNodeName, this.NodeName);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
             var target = telemetryContext.Internal;
-            target.SdkVersion = Tags.CopyTagValue(target.SdkVersion, this.SdkVersion);
-            target.AgentVersion = Tags.CopyTagValue(target.AgentVersion, this.AgentVersion);
-            target.NodeName = Tags.CopyTagValue(target.NodeName, this.NodeName);
+            Tags.CopyTagValue(target.SdkVersion, ref this.sdkVersion);
+            Tags.CopyTagValue(target.AgentVersion, ref this.agentVersion);
+            Tags.CopyTagValue(target.NodeName, ref this.nodeName);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/InternalContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/InternalContext.cs
@@ -12,11 +12,8 @@
     /// </summary>
     public sealed class InternalContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal InternalContext(IDictionary<string, string> tags)
+        internal InternalContext()
         {
-            this.tags = tags;
         }
 
         /// <summary>
@@ -24,8 +21,8 @@
         /// </summary>
         public string SdkVersion
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.InternalSdkVersion); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.InternalSdkVersion, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -33,8 +30,8 @@
         /// </summary>
         public string AgentVersion
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.InternalAgentVersion); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.InternalAgentVersion, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -42,8 +39,23 @@
         /// </summary>
         public string NodeName
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.InternalNodeName); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.InternalNodeName, value); }
+            get;
+            set;
+        }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.InternalSdkVersion, this.SdkVersion);
+            tags.UpdateTagValue(ContextTagKeys.Keys.InternalAgentVersion, this.AgentVersion);
+            tags.UpdateTagValue(ContextTagKeys.Keys.InternalNodeName, this.NodeName);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Internal;
+            target.SdkVersion = Tags.CopyTagValue(target.SdkVersion, this.SdkVersion);
+            target.AgentVersion = Tags.CopyTagValue(target.AgentVersion, this.AgentVersion);
+            target.NodeName = Tags.CopyTagValue(target.NodeName, this.NodeName);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/LocationContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/LocationContext.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
-{    
+{
     using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
     /// <summary>
@@ -8,11 +9,8 @@
     /// </summary>
     public sealed class LocationContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal LocationContext(IDictionary<string, string> tags)
+        internal LocationContext()
         {
-            this.tags = tags;
         }
 
         /// <summary>
@@ -20,18 +18,19 @@
         /// </summary>
         public string Ip
         {
-            get 
-            { 
-                return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.LocationIp); 
-            }
+            get;
+            set;
+        }
 
-            set 
-            {
-                if (value != null)
-                {
-                    this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.LocationIp, value);
-                }
-            }
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.LocationIp, this.Ip);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Location;
+            target.Ip = Tags.CopyTagValue(target.Ip, this.Ip);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/LocationContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/LocationContext.cs
@@ -9,6 +9,8 @@
     /// </summary>
     public sealed class LocationContext
     {
+        private string ip;
+
         internal LocationContext()
         {
         }
@@ -18,8 +20,8 @@
         /// </summary>
         public string Ip
         {
-            get;
-            set;
+            get { return this.ip == string.Empty ? null : this.ip; }
+            set { this.ip = value; }
         }
 
         internal void UpdateTags(IDictionary<string, string> tags)
@@ -27,10 +29,10 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.LocationIp, this.Ip);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Location;
-            target.Ip = Tags.CopyTagValue(target.Ip, this.Ip);
+            var source = telemetryContext.Location;
+            Tags.CopyTagValue(source.Ip, ref this.ip);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/OperationContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/OperationContext.cs
@@ -2,18 +2,16 @@
 {
     using System.Collections.Generic;
     using System.ComponentModel;
+    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
     /// <summary>
-    /// Encapsulates information about an operation. Operation normally reflects an end to end scenario that starts from a user action (e.g. button click).  
+    /// Encapsulates information about an operation. Operation normally reflects an end to end scenario that starts from a user action (e.g. button click).
     /// </summary>
     public sealed class OperationContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal OperationContext(IDictionary<string, string> tags)
+        internal OperationContext()
         {
-            this.tags = tags;
         }
 
         /// <summary>
@@ -21,8 +19,8 @@
         /// </summary>
         public string Id
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationId, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -30,8 +28,8 @@
         /// </summary>
         public string ParentId
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationParentId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationParentId, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -40,8 +38,8 @@
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CorrelationVector
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationCorrelationVector); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationCorrelationVector, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -49,8 +47,8 @@
         /// </summary>
         public string Name
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationName); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationName, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -58,8 +56,27 @@
         /// </summary>
         public string SyntheticSource
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.OperationSyntheticSource); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.OperationSyntheticSource, value); }
+            get;
+            set;
+        }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.OperationId, this.Id);
+            tags.UpdateTagValue(ContextTagKeys.Keys.OperationParentId, this.ParentId);
+            tags.UpdateTagValue(ContextTagKeys.Keys.OperationCorrelationVector, this.CorrelationVector);
+            tags.UpdateTagValue(ContextTagKeys.Keys.OperationName, this.Name);
+            tags.UpdateTagValue(ContextTagKeys.Keys.OperationSyntheticSource, this.SyntheticSource);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Operation;
+            target.Id = Tags.CopyTagValue(target.Id, this.Id);
+            target.ParentId = Tags.CopyTagValue(target.ParentId, this.ParentId);
+            target.CorrelationVector = Tags.CopyTagValue(target.CorrelationVector, this.CorrelationVector);
+            target.Name = Tags.CopyTagValue(target.Name, this.Name);
+            target.SyntheticSource = Tags.CopyTagValue(target.SyntheticSource, this.SyntheticSource);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/OperationContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/OperationContext.cs
@@ -10,6 +10,12 @@
     /// </summary>
     public sealed class OperationContext
     {
+        private string id;
+        private string parentId;
+        private string correlationVector;
+        private string syntheticSource;
+        private string name;
+
         internal OperationContext()
         {
         }
@@ -19,8 +25,8 @@
         /// </summary>
         public string Id
         {
-            get;
-            set;
+            get { return this.id == string.Empty ? null : this.id; }
+            set { this.id = value; }
         }
 
         /// <summary>
@@ -28,8 +34,8 @@
         /// </summary>
         public string ParentId
         {
-            get;
-            set;
+            get { return this.parentId == string.Empty ? null : this.parentId; }
+            set { this.parentId = value; }
         }
 
         /// <summary>
@@ -38,8 +44,8 @@
         [EditorBrowsable(EditorBrowsableState.Never)]
         public string CorrelationVector
         {
-            get;
-            set;
+            get { return this.correlationVector == string.Empty ? null : this.correlationVector; }
+            set { this.correlationVector = value; }
         }
 
         /// <summary>
@@ -47,8 +53,8 @@
         /// </summary>
         public string Name
         {
-            get;
-            set;
+            get { return this.name == string.Empty ? null : this.name; }
+            set { this.name = value; }
         }
 
         /// <summary>
@@ -56,8 +62,8 @@
         /// </summary>
         public string SyntheticSource
         {
-            get;
-            set;
+            get { return this.syntheticSource == string.Empty ? null : this.syntheticSource; }
+            set { this.syntheticSource = value; }
         }
 
         internal void UpdateTags(IDictionary<string, string> tags)
@@ -69,14 +75,14 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.OperationSyntheticSource, this.SyntheticSource);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Operation;
-            target.Id = Tags.CopyTagValue(target.Id, this.Id);
-            target.ParentId = Tags.CopyTagValue(target.ParentId, this.ParentId);
-            target.CorrelationVector = Tags.CopyTagValue(target.CorrelationVector, this.CorrelationVector);
-            target.Name = Tags.CopyTagValue(target.Name, this.Name);
-            target.SyntheticSource = Tags.CopyTagValue(target.SyntheticSource, this.SyntheticSource);
+            var source = telemetryContext.Operation;
+            Tags.CopyTagValue(source.Id, ref this.id);
+            Tags.CopyTagValue(source.ParentId, ref this.parentId);
+            Tags.CopyTagValue(source.CorrelationVector, ref this.correlationVector);
+            Tags.CopyTagValue(source.Name, ref this.name);
+            Tags.CopyTagValue(source.SyntheticSource, ref this.syntheticSource);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Property.cs
@@ -10,7 +10,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
     using System.Linq;
     using External;
     using Microsoft.ApplicationInsights.DataContracts;
-    
+
     /// <summary>
     /// A helper class for implementing properties of telemetry and context classes.
     /// </summary>
@@ -52,9 +52,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             { ContextTagKeys.Keys.CloudRoleInstance, 256 },
             { ContextTagKeys.Keys.InternalSdkVersion, 64 },
             { ContextTagKeys.Keys.InternalAgentVersion, 64 },
-            { ContextTagKeys.Keys.InternalNodeName, 256 }                                                            
+            { ContextTagKeys.Keys.InternalNodeName, 256 }
         };
-        
+
         public static void Set<T>(ref T property, T value) where T : class
         {
             if (value == default(T))
@@ -126,7 +126,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     url = url.Substring(0, MaxUrlLength);
 
-                    // in case that the truncated string is invalid 
+                    // in case that the truncated string is invalid
                     // URI we will not do nothing and let the Endpoint to drop the property
                     Uri temp;
                     if (Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out temp) == true)
@@ -152,20 +152,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         public static string SanitizeAvailabilityMessage(this string value)
         {
             return TrimAndTruncate(value, Property.MaxAvailabilityMessageLength);
-        }
-
-        public static void SanitizeTelemetryContext(this TelemetryContext telemetryContext)
-        {
-            var tags = telemetryContext.Tags;
-            int limit;
-
-            foreach (KeyValuePair<string, string> tag in tags)
-            {
-                if (TagSizeLimits.TryGetValue(tag.Key, out limit) && tag.Value != null && tag.Value.Length > limit)
-                {
-                    tags[tag.Key] = TrimAndTruncate(tag.Value, limit);
-                }
-            }
         }
 
         public static void SanitizeProperties(this IDictionary<string, string> dictionary)
@@ -226,7 +212,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             }
         }
 
-        private static string TrimAndTruncate(string value, int maxLength)
+        public static string TrimAndTruncate(string value, int maxLength)
         {
             if (value != null)
             {
@@ -269,6 +255,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             }
 
             return key;
-        }        
+        }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -28,7 +28,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
     {
         /// <summary>RichPayloadEventSource instance.</summary>
         public static readonly RichPayloadEventSource Log = new RichPayloadEventSource();
-        
+
         /// <summary>Event source.</summary>
         internal readonly EventSource EventSourceInternal;
 
@@ -63,8 +63,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     RequestTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
-                    telemetryItem.Data, 
+                    telemetryItem.Context.SanitizedTags,
+                    telemetryItem.Data,
                     Keywords.Requests);
             }
             else if (item is TraceTelemetry)
@@ -79,7 +79,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     TraceTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Traces);
             }
@@ -95,7 +95,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Events);
             }
@@ -111,7 +111,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     DependencyTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.InternalData,
                     Keywords.Dependencies);
             }
@@ -127,7 +127,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Metrics);
             }
@@ -143,7 +143,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     ExceptionTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Exceptions);
             }
@@ -160,7 +160,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Metrics);
             }
@@ -177,7 +177,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     PageViewTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.PageViews);
             }
@@ -194,7 +194,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Events);
             }
@@ -210,7 +210,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 this.WriteEvent(
                     AvailabilityTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
-                    telemetryItem.Context.Tags,
+                    telemetryItem.Context.SanitizedTags,
                     telemetryItem.Data,
                     Keywords.Availability);
             }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/SessionContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/SessionContext.cs
@@ -9,6 +9,9 @@
     /// </summary>
     public sealed class SessionContext
     {
+        private string id;
+        private bool? isFirst;
+
         internal SessionContext()
         {
         }
@@ -18,8 +21,8 @@
         /// </summary>
         public string Id
         {
-            get;
-            set;
+            get { return this.id == string.Empty ? null : this.id; }
+            set { this.id = value; }
         }
 
         /// <summary>
@@ -27,8 +30,8 @@
         /// </summary>
         public bool? IsFirst
         {
-            get;
-            set;
+            get { return this.isFirst; }
+            set { this.isFirst = value; }
         }
 
         internal void UpdateTags(IDictionary<string, string> tags)
@@ -37,11 +40,11 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.SessionIsFirst, this.IsFirst);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Session;
-            target.Id = Tags.CopyTagValue(target.Id, this.Id);
-            target.IsFirst = Tags.CopyTagValue(target.IsFirst, this.IsFirst);
+            var source = telemetryContext.Session;
+            Tags.CopyTagValue(source.Id, ref this.id);
+            Tags.CopyTagValue(source.IsFirst, ref this.isFirst);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/SessionContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/SessionContext.cs
@@ -9,11 +9,8 @@
     /// </summary>
     public sealed class SessionContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal SessionContext(IDictionary<string, string> tags)
+        internal SessionContext()
         {
-            this.tags = tags;
         }
 
         /// <summary>
@@ -21,17 +18,30 @@
         /// </summary>
         public string Id
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.SessionId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.SessionId, value); }
+            get;
+            set;
         }
 
         /// <summary>
         /// Gets or sets the IsFirst Session for the user.
         /// </summary>
-        public bool? IsFirst 
+        public bool? IsFirst
         {
-            get { return this.tags.GetTagBoolValueOrNull(ContextTagKeys.Keys.SessionIsFirst); }
-            set { this.tags.SetTagValueOrRemove<bool?>(ContextTagKeys.Keys.SessionIsFirst, value); }
+            get;
+            set;
+        }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.SessionId, this.Id);
+            tags.UpdateTagValue(ContextTagKeys.Keys.SessionIsFirst, this.IsFirst);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.Session;
+            target.Id = Tags.CopyTagValue(target.Id, this.Id);
+            target.IsFirst = Tags.CopyTagValue(target.IsFirst, this.IsFirst);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/Telemetry.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/Telemetry.cs
@@ -15,7 +15,7 @@
 
             if (samplingSupportingTelemetry != null
                 && samplingSupportingTelemetry.SamplingPercentage.HasValue
-                && (samplingSupportingTelemetry.SamplingPercentage.Value > 0.0 + 1.0E-12) 
+                && (samplingSupportingTelemetry.SamplingPercentage.Value > 0.0 + 1.0E-12)
                 && (samplingSupportingTelemetry.SamplingPercentage.Value < 100.0 - 1.0E-12))
             {
                 json.WriteProperty("sampleRate", samplingSupportingTelemetry.SamplingPercentage.Value);
@@ -52,7 +52,7 @@
             if (context != null)
             {
                 json.WriteProperty("iKey", context.InstrumentationKey);
-                json.WriteProperty("tags", context.Tags);
+                json.WriteProperty("tags", context.SanitizedTags);
             }
         }
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/UserContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/UserContext.cs
@@ -36,7 +36,7 @@
         /// </summary>
         public string AccountId
         {
-            get { return this.accountId== string.Empty ? null : this.accountId; }
+            get { return this.accountId == string.Empty ? null : this.accountId; }
             set { this.accountId = value; }
         }
 

--- a/src/Core/Managed/Shared/Extensibility/Implementation/UserContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/UserContext.cs
@@ -10,6 +10,11 @@
     /// </summary>
     public sealed class UserContext
     {
+        private string id;
+        private string accountId;
+        private string userAgent;
+        private string authenticatedUserId;
+
         internal UserContext()
         {
         }
@@ -22,8 +27,8 @@
         /// </remarks>
         public string Id
         {
-            get;
-            set;
+            get { return this.id == string.Empty ? null : this.id; }
+            set { this.id = value; }
         }
 
         /// <summary>
@@ -31,8 +36,8 @@
         /// </summary>
         public string AccountId
         {
-            get;
-            set;
+            get { return this.accountId== string.Empty ? null : this.accountId; }
+            set { this.accountId = value; }
         }
 
         /// <summary>
@@ -40,8 +45,8 @@
         /// </summary>
         public string UserAgent
         {
-            get;
-            set;
+            get { return this.userAgent == string.Empty ? null : this.userAgent; }
+            set { this.userAgent = value; }
         }
 
         /// <summary>
@@ -50,8 +55,8 @@
         /// </summary>
         public string AuthenticatedUserId
         {
-            get;
-            set;
+            get { return this.authenticatedUserId == string.Empty ? null : this.authenticatedUserId; }
+            set { this.authenticatedUserId = value; }
         }
 
         internal void UpdateTags(IDictionary<string, string> tags)
@@ -62,13 +67,13 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.UserAuthUserId, this.AuthenticatedUserId);
         }
 
-        internal void CopyTo(TelemetryContext telemetryContext)
+        internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.User;
-            target.Id = Tags.CopyTagValue(target.Id, this.Id);
-            target.AccountId = Tags.CopyTagValue(target.AccountId, this.AccountId);
-            target.UserAgent = Tags.CopyTagValue(target.UserAgent, this.UserAgent);
-            target.AuthenticatedUserId = Tags.CopyTagValue(target.AuthenticatedUserId, this.AuthenticatedUserId);
+            var source = telemetryContext.User;
+            Tags.CopyTagValue(source.Id, ref this.id);
+            Tags.CopyTagValue(source.AccountId, ref this.accountId);
+            Tags.CopyTagValue(source.UserAgent, ref this.userAgent);
+            Tags.CopyTagValue(source.AuthenticatedUserId, ref this.authenticatedUserId);
         }
     }
 }

--- a/src/Core/Managed/Shared/Extensibility/Implementation/UserContext.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/UserContext.cs
@@ -10,23 +10,20 @@
     /// </summary>
     public sealed class UserContext
     {
-        private readonly IDictionary<string, string> tags;
-
-        internal UserContext(IDictionary<string, string> tags)
+        internal UserContext()
         {
-            this.tags = tags;
         }
 
         /// <summary>
         /// Gets or sets the ID of user accessing the application.
         /// </summary>
         /// <remarks>
-        /// Unique user ID is automatically generated in default Application Insights configuration. 
+        /// Unique user ID is automatically generated in default Application Insights configuration.
         /// </remarks>
-        public string Id 
+        public string Id
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.UserId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.UserId, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -34,8 +31,8 @@
         /// </summary>
         public string AccountId
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.UserAccountId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.UserAccountId, value); }
+            get;
+            set;
         }
 
         /// <summary>
@@ -43,18 +40,35 @@
         /// </summary>
         public string UserAgent
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.UserAgent); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.UserAgent, value); }
+            get;
+            set;
         }
-        
+
         /// <summary>
         /// Gets or sets the authenticated user id.
         /// Authenticated user id should be a persistent string that uniquely represents each authenticated user in the application or service.
         /// </summary>
         public string AuthenticatedUserId
         {
-            get { return this.tags.GetTagValueOrNull(ContextTagKeys.Keys.UserAuthUserId); }
-            set { this.tags.SetStringValueOrRemove(ContextTagKeys.Keys.UserAuthUserId, value); }
+            get;
+            set;
+        }
+
+        internal void UpdateTags(IDictionary<string, string> tags)
+        {
+            tags.UpdateTagValue(ContextTagKeys.Keys.UserId, this.Id);
+            tags.UpdateTagValue(ContextTagKeys.Keys.UserAccountId, this.AccountId);
+            tags.UpdateTagValue(ContextTagKeys.Keys.UserAgent, this.UserAgent);
+            tags.UpdateTagValue(ContextTagKeys.Keys.UserAuthUserId, this.AuthenticatedUserId);
+        }
+
+        internal void CopyTo(TelemetryContext telemetryContext)
+        {
+            var target = telemetryContext.User;
+            target.Id = Tags.CopyTagValue(target.Id, this.Id);
+            target.AccountId = Tags.CopyTagValue(target.AccountId, this.AccountId);
+            target.UserAgent = Tags.CopyTagValue(target.UserAgent, this.UserAgent);
+            target.AuthenticatedUserId = Tags.CopyTagValue(target.AuthenticatedUserId, this.AuthenticatedUserId);
         }
     }
 }

--- a/src/Core/Managed/net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Core/Managed/net45/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -224,7 +224,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_RequestData = new
                         {
                             data.ver,
@@ -279,7 +279,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_MessageData = new
                         {
                             data.ver,
@@ -328,7 +328,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_EventData = new
                         {
                             data.ver,
@@ -384,7 +384,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_RemoteDependencyData = new
                         {
                             data.ver,
@@ -453,7 +453,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_MetricData = new
                         {
                             data.ver,
@@ -538,7 +538,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_ExceptionData = new
                         {
                             data.ver,
@@ -620,7 +620,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_MetricData = new
                         {
                             data.ver,
@@ -679,7 +679,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_PageViewPerfData = new
                         {
                             data.url,
@@ -732,7 +732,7 @@
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod
                         PartA_iKey = telemetryItem.Context.InstrumentationKey,
-                        PartA_Tags = telemetryItem.Context.Tags,
+                        PartA_Tags = telemetryItem.Context.SanitizedTags,
                         PartB_EventData = new
                         {
                             data.ver,


### PR DESCRIPTION
Fix #585.

This PR changes the behavior of `Sanitize` and `Track` methods. Before - all context properties were sanitized after the call to `Track`. Now they would not be. This is not a big deal as we explicitly tell not to re-use items in documentation. Also with multi-sink support feature this behavior should be changed anyway.

For significant contributions please make sure you have completed the following items:

- [X] Design discussion issue #585
- [X] Changes in public surface reviewed
- [X] CHANGELOG.md updated
