### PR TITLE
Add multi-channel capability (part 2: configuration)

### DIFF
--- a/src/Core/Managed/Shared/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Core/Managed/Shared/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -212,6 +212,19 @@
             builder.Build();
         }
 
+        /// <summary>
+        /// Loads a collection of <see cref="TelemetrySink"/> from configuration.
+        /// </summary>
+        /// <param name="definition">Configuration element representing a collection of <see cref="TelemetrySink"/> instances.</param>
+        /// <param name="telemetryConfiguration">Telemetry configuration to use for new sinks.</param>
+        /// <remarks>
+        /// There are a few of reasons why special handling for TelemetrySinks collection is necessary. 
+        /// 1. Just like for TelemetryProcessors, sinks have to be created using a constructor that takes parameters(telemetry configuration in the sink case).
+        /// 2. There is special logic involving default sink (always present, and designated by the name "default"). Default sink is never created from configuration.
+        /// 3. If the sink is referred to multiple times in the configuration (by the same name), we apply all the configuration to a single, named instance.
+        /// This part is somewhat arbitrary, but we had to choose some behavior in case we are facing repeated sink configuration with the same name,
+        /// and this is a reasonable choice.
+        /// </remarks>
         protected static void LoadTelemetrySinks(XElement definition, TelemetryConfiguration telemetryConfiguration)
         {
             IEnumerable<XElement> elems = definition.Elements(XmlNamespace + AddElementName);

--- a/src/Core/Managed/Shared/Extensibility/TelemetryConfiguration.cs
+++ b/src/Core/Managed/Shared/Extensibility/TelemetryConfiguration.cs
@@ -66,6 +66,7 @@
 
             this.instrumentationKey = instrumentationKey;
             var defaultSink = new TelemetrySink(this, channel);
+            defaultSink.Name = "default";
             this.telemetrySinks.Add(defaultSink);
         }
 


### PR DESCRIPTION
This is related to [issue 559](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/559) and completes the implementation of multi-channel capability.