### PR TITLE
Fix typo in Transmitter log about moving data from buffer to sender

### DIFF
--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryChannelEventSource.cs
@@ -332,8 +332,8 @@
             this.WriteEvent(48, transmissionId ?? string.Empty, exception ?? string.Empty, this.ApplicationName);
         }
 
-        [Event(49, Message = "MovedFromSenderToBuffer.", Level = EventLevel.Verbose)]
-        public void MovedFromSenderToBuffer(string appDomainName = "Incorrect")
+        [Event(49, Message = "MovedFromBufferToSender.", Level = EventLevel.Verbose)]
+        public void MovedFromBufferToSender(string appDomainName = "Incorrect")
         {
             this.WriteEvent(49, this.ApplicationName);
         }

--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/Transmitter.cs
@@ -205,7 +205,7 @@
             if (this.Sender.Capacity > 0)
             {
                 this.MoveTransmissions(this.Buffer.Dequeue, this.Sender.Enqueue);
-                TelemetryChannelEventSource.Log.MovedFromSenderToBuffer();
+                TelemetryChannelEventSource.Log.MovedFromBufferToSender();
             }
         }
 


### PR DESCRIPTION
In the ApplyPolicies method of Transimitter, the log information should be 'MovedFromBufferToSender' instead of 'MovedFromSenderToBuffer'.
