### PR TITLE
Fix random build breaks

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -58,6 +58,7 @@
 
         <!-- Collect all NuGet packages in the same folder for convenience during testing -->
         <PackageOutputDir>$(BinRoot)\$(Configuration)\NuGet</PackageOutputDir>
+        <PackageOutputPath>$(PackageOutputDir)</PackageOutputPath>
 
         <AppxPackageDir>$(OutputPath)</AppxPackageDir>
 

--- a/Test/TestFramework/Shared/TestEventListener.cs
+++ b/Test/TestFramework/Shared/TestEventListener.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework
 {
+    using Microsoft.ApplicationInsights.Extensibility;
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
@@ -10,24 +11,105 @@
 #if NET40
     using Microsoft.Diagnostics.Tracing;
 #endif
+#if NET40 || NET45
+    using System.Runtime.Remoting.Messaging;
+#endif
 
     internal class TestEventListener : EventListener
     {
+#if NET40 || NET45
+
+        public static class CurrentContextEvents
+        {
+            internal const string InternalOperationsMonitorSlotName = "Microsoft.ApplicationInsights.TestEventListener";
+
+            private static Object syncObj = new object();
+
+            public static bool IsEntered()
+            {
+                object data = null;
+                try
+                {
+                    data = CallContext.LogicalGetData(InternalOperationsMonitorSlotName);
+                }
+                catch (Exception)
+                {
+                    // CallContext may fail in partially trusted environment
+                }
+
+                return data != null;
+            }
+
+            public static void Enter()
+            {
+                try
+                {
+                    CallContext.LogicalSetData(InternalOperationsMonitorSlotName, syncObj);
+                }
+                catch (Exception)
+                {
+                    // CallContext may fail in partially trusted environment
+                }
+            }
+
+            public static void Exit()
+            {
+                try
+                {
+                    CallContext.FreeNamedDataSlot(InternalOperationsMonitorSlotName);
+                }
+                catch (Exception)
+                {
+                    // CallContext may fail in partially trusted environment
+                }
+            }
+        }
+#else
+        public static class CurrentContextEvents
+        {
+            private static AsyncLocal<object> asyncLocalContext = new AsyncLocal<object>();
+
+            private static object syncObj = new object();
+
+            public static bool IsEntered()
+            {
+                return asyncLocalContext.Value != null;
+            }
+
+            public static void Enter()
+            {
+                asyncLocalContext.Value = syncObj;
+            }
+
+            public static void Exit()
+            {
+                asyncLocalContext.Value = null;
+            }
+        }
+#endif
+
         private readonly ConcurrentQueue<EventWrittenEventArgs> events;
         private readonly AutoResetEvent eventWritten;
 
         private readonly bool waitForDelayedEvents;
+        private readonly bool listenForCurrentContext;
 
-        public TestEventListener(bool waitForDelayedEvents = true)
+        public TestEventListener(bool waitForDelayedEvents = true, bool listenForCurrentContext = true)
         {
             this.events = new ConcurrentQueue<EventWrittenEventArgs>();
             this.eventWritten = new AutoResetEvent(false);
             this.waitForDelayedEvents = waitForDelayedEvents;
+            this.listenForCurrentContext = listenForCurrentContext;
             this.OnOnEventWritten = e =>
             {
                 this.events.Enqueue(e);
                 this.eventWritten.Set();
             };
+
+            if (this.listenForCurrentContext)
+            {
+                CurrentContextEvents.Enter();
+            }
         }
 
         public Action<EventSource> OnOnEventSourceCreated { get; set; }
@@ -60,7 +142,10 @@
         
         protected override void OnEventWritten(EventWrittenEventArgs eventData)
         {
-            this.OnOnEventWritten(eventData);
+            if (listenForCurrentContext && CurrentContextEvents.IsEntered())
+            {
+                this.OnOnEventWritten(eventData);
+            }
         }
 
         protected override void OnEventSourceCreated(EventSource eventSource)
@@ -71,6 +156,12 @@
             {
                 callback(eventSource);
             }
+        }
+
+        public override void Dispose()
+        {
+            CurrentContextEvents.Exit();
+            base.Dispose();
         }
     }
 }

--- a/Test/TestFramework/Shared/TestEventListener.cs
+++ b/Test/TestFramework/Shared/TestEventListener.cs
@@ -48,7 +48,7 @@
                 }
                 catch (Exception)
                 {
-                    // CallContext may fail in partially trusted environment
+                    throw new InvalidOperationException("Please run this test in full trust environment");
                 }
             }
 
@@ -60,7 +60,7 @@
                 }
                 catch (Exception)
                 {
-                    // CallContext may fail in partially trusted environment
+                    throw new InvalidOperationException("Please run this test in full trust environment");
                 }
             }
         }

--- a/Test/TestFramework/Shared/TestEventListener.cs
+++ b/Test/TestFramework/Shared/TestEventListener.cs
@@ -160,7 +160,10 @@
 
         public override void Dispose()
         {
-            CurrentContextEvents.Exit();
+            if (listenForCurrentContext)
+            {
+                CurrentContextEvents.Exit();
+            }
             base.Dispose();
         }
     }

--- a/src/ServerTelemetryChannel/Managed/TelemetryChannel.csproj
+++ b/src/ServerTelemetryChannel/Managed/TelemetryChannel.csproj
@@ -20,6 +20,7 @@
     <!--https://docs.microsoft.com/en-us/nuget/schema/msbuild-targets-->
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
     <IncludeSymbols>True</IncludeSymbols>
+    <!--PackageOutputPath>Defined in Directory.Build.props</PackageOutputPath-->
     <PackageId>Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel</PackageId>
     <!--PackageVersion is defined in GlobalStaticVersion.props-->
     <!--PackageVersion></PackageVersion-->


### PR DESCRIPTION
Fix build breaks related to tests synchronization by introducing context aware event source listener.

Also fix for NuGet package location