### PR TITLE
Fix null check to use string.IsNullOrEmpty. 

### DIFF
--- a/src/ServerTelemetryChannel/Managed/Shared/Implementation/SamplingScoreGenerator.cs
+++ b/src/ServerTelemetryChannel/Managed/Shared/Implementation/SamplingScoreGenerator.cs
@@ -36,7 +36,7 @@
 
         internal static int GetSamplingHashCode(this string input)
         {
-            if (input == null)
+            if (string.IsNullOrEmpty(input))
             {
                 return 0;
             }


### PR DESCRIPTION
Even though unlikely, if a string.empty is passed as input to SamplingScoreGenerator.GetSamplingHashCode it will result in an infinite loop. Fixing it for correctness sake.

Fix #641.


For significant contributions please make sure you have completed the following items:

- [yes ] Design discussion issue #641 
- [n/a - not public facing] Changes in public surface reviewed
- [n/a - trivial] CHANGELOG.md updated
