### PR TITLE
Made sampling based on UserId configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.5.0-beta2
-
+- Turned off sampling based on UserId by default, made the use of this sample scoring configurable in the AdaptiveSamplingTelemetryProcessor
 
 ## Version 2.5.0-beta1
 - Method `Sanitize` on classes implementing `ITelemetry` no longer modifies the `TelemetryContext` fields. Serialized event json and ETW event will still have context tags sanitized.

--- a/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,4 @@
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor.AllowSamplingBasedOnUserId.get -> bool
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor.AllowSamplingBasedOnUserId.set -> void
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.SamplingTelemetryProcessor.AllowSamplingBasedOnUserId.get -> bool
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.SamplingTelemetryProcessor.AllowSamplingBasedOnUserId.set -> void

--- a/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -36,3 +36,7 @@ Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChan
 Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel.ServerTelemetryChannel() -> void
 Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel.StorageFolder.get -> string
 Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel.StorageFolder.set -> void
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor.AllowSamplingBasedOnUserId.get -> bool
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor.AllowSamplingBasedOnUserId.set -> void
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.SamplingTelemetryProcessor.AllowSamplingBasedOnUserId.get -> bool
+Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.SamplingTelemetryProcessor.AllowSamplingBasedOnUserId.set -> void

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingScoreGeneratorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingScoreGeneratorTest.cs
@@ -27,8 +27,8 @@
             requestTelemetry.Context.User.Id = userId;
             requestTelemetry.Context.Operation.Id = GenerateRandomOperaitonId();
 
-            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry);
-            var requestTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(requestTelemetry);
+            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry, true);
+            var requestTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(requestTelemetry, true);
 
             Assert.AreEqual(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 12);
         }
@@ -44,10 +44,36 @@
             var requestTelemetry = new RequestTelemetry();
             requestTelemetry.Context.Operation.Id = operationId;
 
-            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry);
-            var requestTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(requestTelemetry);
+            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry, true);
+            var requestTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(requestTelemetry, true);
 
             Assert.AreEqual(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 12);
+        }
+
+        [TestMethod]
+        public void SamplingScoreGeneratedSkipsUserId()
+        {
+            string operationId = GenerateRandomOperaitonId();
+            string userId = GenerateRandomUserId();
+
+            var eventTelemetry = new EventTelemetry();
+            eventTelemetry.Context.Operation.Id = operationId;
+            eventTelemetry.Context.User.Id = userId;
+
+            var requestTelemetry = new RequestTelemetry();
+            requestTelemetry.Context.Operation.Id = operationId;
+            requestTelemetry.Context.User.Id = userId;
+
+            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry, true);
+            var requestTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(requestTelemetry, true);
+
+            Assert.AreEqual(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 12);
+
+            var eventTelemetrySamplingScoreNoUserConfig = SamplingScoreGenerator.GetSamplingScore(eventTelemetry, true);
+            var requestTelemetrySamplingScoreNoUserConfig = SamplingScoreGenerator.GetSamplingScore(requestTelemetry, true);
+
+            Assert.AreNotEqual(eventTelemetrySamplingScore, eventTelemetrySamplingScoreNoUserConfig);
+            Assert.AreNotEqual(requestTelemetrySamplingScore, requestTelemetrySamplingScoreNoUserConfig);
         }
 
         [TestMethod]
@@ -56,8 +82,8 @@
             var eventTelemetry = new EventTelemetry();
             var traceTelemetry = new TraceTelemetry();
 
-            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry);
-            var traceTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(traceTelemetry);
+            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry, true);
+            var traceTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(traceTelemetry, true);
 
             Assert.AreNotEqual(eventTelemetrySamplingScore, traceTelemetrySamplingScore);
         }

--- a/src/ServerTelemetryChannel/Managed/Shared/AdaptiveSamplingTelemetryProcessor.cs
+++ b/src/ServerTelemetryChannel/Managed/Shared/AdaptiveSamplingTelemetryProcessor.cs
@@ -15,7 +15,7 @@
         /// Fixed-rate sampling telemetry processor.
         /// </summary>
         private readonly SamplingTelemetryProcessor samplingProcessor;
-        
+
         /// <summary>
         /// Sampling percentage estimator settings.
         /// </summary>
@@ -217,6 +217,23 @@
             set
             {
                 this.estimatorSettings.MovingAverageRatio = value;
+            }
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether to enable sample scoring for telemetry items based on the Context.User.Id flag. Default
+        /// is false.
+        /// </summary>
+        public bool AllowSamplingBasedOnUserId
+        {
+            get
+            {
+                return this.samplingProcessor.AllowSamplingBasedOnUserId;
+            }
+
+            set
+            {
+                this.samplingProcessor.AllowSamplingBasedOnUserId = value;
             }
         }
 

--- a/src/ServerTelemetryChannel/Managed/Shared/Implementation/SamplingScoreGenerator.cs
+++ b/src/ServerTelemetryChannel/Managed/Shared/Implementation/SamplingScoreGenerator.cs
@@ -13,12 +13,13 @@
         /// Generates telemetry sampling score between 0 and 100.
         /// </summary>
         /// <param name="telemetry">Telemetry item to score.</param>
+        /// <param name="allowUserId">Sampling score can be determined by using the Context.User.Id information, default is false.</param>
         /// <returns>Item sampling score.</returns>
-        public static double GetSamplingScore(ITelemetry telemetry)
+        public static double GetSamplingScore(ITelemetry telemetry, bool allowUserId = false)
         {
             double samplingScore = 0;
 
-            if (telemetry.Context.User.Id != null)
+            if (allowUserId && telemetry.Context.User.Id != null)
             {
                 samplingScore = (double)telemetry.Context.User.Id.GetSamplingHashCode() / int.MaxValue;
             }

--- a/src/ServerTelemetryChannel/Managed/Shared/SamplingTelemetryProcessor.cs
+++ b/src/ServerTelemetryChannel/Managed/Shared/SamplingTelemetryProcessor.cs
@@ -56,6 +56,7 @@
                 { RequestTelemetryName, typeof(RequestTelemetry) },
                 { TraceTelemetryName, typeof(TraceTelemetry) },
             };
+            this.AllowSamplingBasedOnUserId = false;
         }
 
         /// <summary>
@@ -125,6 +126,17 @@
         }
 
         /// <summary>
+        /// Gets or sets a value indicating whether or not we should calculate sampling based on the Context.User.Id field.
+        /// Default is false.
+        /// 
+        /// <remarks>
+        /// Calculation of the sampling score based on user_Id field is disabled by default to ensure successful correlation across many 
+        /// services on operation_Id field.
+        /// </remarks>
+        /// </summary>
+        public bool AllowSamplingBasedOnUserId { get; set; }
+
+        /// <summary>
         /// Gets or sets data sampling percentage (between 0 and 100) for all <see cref="ITelemetry"/>
         /// objects logged in this <see cref="TelemetryClient"/>.
         /// </summary>
@@ -187,7 +199,7 @@
             //// Ok, now we can actually sample:
 
             samplingSupportingTelemetry.SamplingPercentage = samplingPercentage;
-            bool isSampledIn = SamplingScoreGenerator.GetSamplingScore(item) < samplingPercentage;
+            bool isSampledIn = SamplingScoreGenerator.GetSamplingScore(item, this.AllowSamplingBasedOnUserId) < samplingPercentage;
 
             if (isSampledIn)
             {


### PR DESCRIPTION
- Moved the configuration out as far as the AdaptiveSamplingTelemetryProcessor
- Added unit test to ensure sampling with/without user id is tested
- Updated changelog for beta 2.5.0-beta2
- Updated PublicAPI.Unshipped.txt

Linked to issue #625

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #625 
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated
