### PR TITLE
Remove sampling score on telemetry items related to Context.User.Id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.5.0-beta2
-- Remove calculation of sampling-score based on Context.User.Id
+- Remove calculation of sampling-score based on Context.User.Id [For more information, please see issue #625](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/625)
 
 ## Version 2.5.0-beta1
 - Method `Sanitize` on classes implementing `ITelemetry` no longer modifies the `TelemetryContext` fields. Serialized event json and ETW event will still have context tags sanitized.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.5.0-beta2
-
+- Remove calculation of sampling-score based on Context.User.Id
 
 ## Version 2.5.0-beta1
 - Method `Sanitize` on classes implementing `ITelemetry` no longer modifies the `TelemetryContext` fields. Serialized event json and ETW event will still have context tags sanitized.

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingScoreGeneratorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingScoreGeneratorTest.cs
@@ -15,22 +15,30 @@
         private static readonly Random Rand = new Random();
 
         [TestMethod]
-        public void SamplingScoreGeneratedUsingUserIdIfPresent()
+        public void SamplingScoreIsntChangedByUserId()
         {
-            string userId = GenerateRandomUserId();
+            string opId = GenerateRandomOperaitonId();
 
             var eventTelemetry = new EventTelemetry();
-            eventTelemetry.Context.User.Id = userId;
-            eventTelemetry.Context.Operation.Id = GenerateRandomOperaitonId();
+            eventTelemetry.Context.Operation.Id = opId;
+            eventTelemetry.Context.User.Id = GenerateRandomUserId();
 
             var requestTelemetry = new RequestTelemetry();
-            requestTelemetry.Context.User.Id = userId;
-            requestTelemetry.Context.Operation.Id = GenerateRandomOperaitonId();
+            requestTelemetry.Context.Operation.Id = opId;
+            requestTelemetry.Context.User.Id = GenerateRandomUserId();
 
-            var eventTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(eventTelemetry);
-            var requestTelemetrySamplingScore = SamplingScoreGenerator.GetSamplingScore(requestTelemetry);
+            var eventTelemetrySamplingScoreNoUserId = SamplingScoreGenerator.GetSamplingScore(eventTelemetry);
+            var requestTelemetrySamplingScoreNoUserId = SamplingScoreGenerator.GetSamplingScore(requestTelemetry);
 
-            Assert.AreEqual(eventTelemetrySamplingScore, requestTelemetrySamplingScore, 12);
+            Assert.AreEqual(eventTelemetrySamplingScoreNoUserId, requestTelemetrySamplingScoreNoUserId, 12);
+
+            eventTelemetry.Context.User.Id = string.Empty;
+            requestTelemetry.Context.User.Id = string.Empty;
+            var eventTelemetrySamplingScoreWithUserId = SamplingScoreGenerator.GetSamplingScore(eventTelemetry);
+            var requestTelemetrySamplingScoreWithUserId = SamplingScoreGenerator.GetSamplingScore(requestTelemetry);
+
+            Assert.AreEqual(eventTelemetrySamplingScoreNoUserId, eventTelemetrySamplingScoreWithUserId);
+            Assert.AreEqual(requestTelemetrySamplingScoreNoUserId, requestTelemetrySamplingScoreWithUserId);
         }
 
         [TestMethod]

--- a/src/ServerTelemetryChannel/Managed/Shared/Implementation/SamplingScoreGenerator.cs
+++ b/src/ServerTelemetryChannel/Managed/Shared/Implementation/SamplingScoreGenerator.cs
@@ -18,11 +18,7 @@
         {
             double samplingScore = 0;
 
-            if (telemetry.Context.User.Id != null)
-            {
-                samplingScore = (double)telemetry.Context.User.Id.GetSamplingHashCode() / int.MaxValue;
-            }
-            else if (telemetry.Context.Operation.Id != null)
+            if (telemetry.Context.Operation.Id != null)
             {
                 samplingScore = (double)telemetry.Context.Operation.Id.GetSamplingHashCode() / int.MaxValue;
             }


### PR DESCRIPTION
No need to keep the sample scoring with Context.User.Id. Remove the code and tests surrounding this calculation.

Issue #625

- [x] Design discussion issue #
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated