### PR TITLE
AdaptiveSampling causes starvation of Telemetry over time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - Fixes a bug in ServerTelemetryChannel which caused application to crash on non-windows platforms. 
 			[Details on fix and workaround #654] (https://github.com/Microsoft/ApplicationInsights-dotnet/issues/654)
 			Original issue (https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/551)
+- [Fixed a bug with the `AdaptiveSamplingTelemetryProcessor` that would cause starvation over time. Issue #756 (dotnet-server)](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/756)
 
 ## Version 2.5.0-beta1
 - Method `Sanitize` on classes implementing `ITelemetry` no longer modifies the `TelemetryContext` fields. Serialized event json and ETW event will still have context tags sanitized.

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -50,9 +50,9 @@
         {
             var sentTelemetry = new List<ITelemetry>();
             var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
-                {
-                    SamplingPercentage = 20
-                };
+            {
+                SamplingPercentage = 20
+            };
 
             do
             {
@@ -61,6 +61,20 @@
             while (sentTelemetry.Count == 0);
 
             Assert.AreEqual(20, ((ISupportSampling)sentTelemetry[0]).SamplingPercentage);
+        }
+
+        [TestMethod]
+        public void EarlyExitWhenProcessingAt100Percent()
+        {
+            var sentTelemetry = new List<ITelemetry>();
+            var processor = new SamplingTelemetryProcessor(new StubTelemetryProcessor(null) { OnProcess = t => sentTelemetry.Add(t) })
+            {
+                SamplingPercentage = 100.0
+            };
+
+            processor.Process(new RequestTelemetry());
+
+            Assert.IsFalse(((ISupportSampling)sentTelemetry[0]).SamplingPercentage.HasValue);
         }
 
         [TestMethod]

--- a/src/ServerTelemetryChannel/AdaptiveSamplingTelemetryProcessor.cs
+++ b/src/ServerTelemetryChannel/AdaptiveSamplingTelemetryProcessor.cs
@@ -56,7 +56,7 @@
 
             // make estimator telemetry processor  work after sampling was done
             this.estimatorProcessor = new SamplingPercentageEstimatorTelemetryProcessor(settings, this.SamplingPercentageChanged, next);
-            this.samplingProcessor = new SamplingTelemetryProcessor(this.estimatorProcessor);
+            this.samplingProcessor = new SamplingTelemetryProcessor(next, this.estimatorProcessor);
         }
 
         /// <summary>

--- a/src/ServerTelemetryChannel/Implementation/SamplingPercentageEstimatorTelemetryProcessor.cs
+++ b/src/ServerTelemetryChannel/Implementation/SamplingPercentageEstimatorTelemetryProcessor.cs
@@ -5,7 +5,6 @@
 
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 
     /// <summary>
     /// Represents a method that is invoked every time sampling percentage is evaluated


### PR DESCRIPTION
My proposed fix for Microsoft/ApplicationInsights-dotnet-server#756.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.
- [x] Design discussion issue Microsoft/ApplicationInsights-dotnet-server#756
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [x] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.

The problem: `AdaptiveSamplingTelemetryProcessor` in the default configuration within the 
ApplicationInsights.config file will cause starvation of telemetry over time.

The root cause: `AdaptiveSamplingTelemetryProcessor` makes use of `SamplingTelemetryProcessor`
chained directly to `SamplingPercentageEstimatorTelemetryProcessor`. This causes all telemtry,
sampled or not, to pass into the estimator and become counted as part of the calculation of the
moving average, and therefore part of the adapted sampling average applied to the chain. Some
telemetry passing through the AdaptiveSamplingTelemetryProcessor should never be counted in that
calculation (for instance, if the telemetry is of a type that should never be sampled at all, or
if the telemetry item has already been sampled by a prior ITelemetryProcessor).

The proposed fix: Alter the `SamplingTelemetryProcessor` so that it has two `Next` properties
to send `ITelemetry` items to, one for sampled items and one for unsampled items. 

- Make an internal constructor that populates the new `UnsampledNext` property, and update the 
  public one to ensure that the `Next` and `UnsampledNext` properties are both pointing at a valid
 `ITelemetryProcessor` later in the pipeline.
- Update the `AdaptiveSamplingTelemetryProcessor` constructor to use the internal constructor of
  `SamplingTelemetryProcessor`, giving it the true next `ITelemetryProcessor` in the pipeline as
  the unsampledNext processor, and the `SamplingPercentageEstimatorTelemetryProcessor` as the
  sampledNext processor.
- Update the `SamplingTelemetryProcessor.Process` method to call the `UnsampledNext` processor 
  whenever there should be no sampling done on the current item at all.

## Root Cause (with pictures!) ##

The way that the `SamplingTelemetryProcessor` works is that it either accepts or rejects telemetry. This is entirely desirable behavior and users can employ the `SamplingTelemetryProcessor` if they wish to do so, when their situation does not require any adaptive corrections of data rates over time. Telemetry items are sampled out based on the percent of data desired, and any skipped item that it encounters is allowed to continue through the pipeline.

![samplingdataflow](https://user-images.githubusercontent.com/11466735/33493885-603f415c-d676-11e7-8feb-d34ff56c3b28.png)

And the `AdaptiveSamplingTelemetryProcessor` leverages the `SamplingTelemetryProcessor`, but injects a new processor after it in the pipeline, which calculates a new sample percent as items are handed to it, which feeds back to into the `SamplingTelemetryProcessor` over time to achieve a constant amount of data flowing through the pipeline, and that will respond to changes in the quantity of telemetry being sent.

![adaptivesamplingdataflow-problem](https://user-images.githubusercontent.com/11466735/33493983-a894bef0-d676-11e7-9750-719ae693d24a.png)

Unfortunately, not all telemetry items being sent through the `SamplingTelemetryProcessor` are the same. Some are evaluated and dropped, some are evaluated and allowed to progress through the pipeline, and some are simply unevaluated and allow to progress through the pipeline. It's the last class of telemetry item that is a problem here - unevaluated items should not be counted against the current sample percentage.

![adaptivesamplingdataflow-solutionenhanced](https://user-images.githubusercontent.com/11466735/33503085-48f55664-d697-11e7-867d-a42eb0b90df7.png)

## Data Tests ##

Using the above hypothesis I made use of a testing program (thanks @zakimaksyutov!) that I extended to collect data and organize it into a spreadsheet-friendly format. I have a lot of data from the tests, but here's some summary charts (full data attached below).

The test program runs for N minutes (I ran it for 30) and emits 100 RequestTelemetry items per second, and 10 EventTelemetry items per second throughout the entire test period. A custom ITelemetryProcessor is injected into the end of the pipeline to count the number of Requests and Events that are actually emitted, making it through the `AdaptiveSamplingTelemetryProcessor`.

*Note that the data in these summary charts include data after the initial 2-minute sampling period where the data is left unsampled at 100%*

Requests and Events emitted over 30 minutes, prior to fix (using SDK 2.5.0-beta1):

![beforefix-dataafterninitialsampleperiod](https://user-images.githubusercontent.com/11466735/33494734-137c82a0-d679-11e7-81e1-9672ecd17a14.png)

Requests and Events emitted over 30 minutes, after applying my fix (SDK 2.5.0-beta2-local_build):

![fixappliedandupdated-dataafterninitialsampleperiod](https://user-images.githubusercontent.com/11466735/33502284-54deebbe-d694-11e7-8242-7d5b99e54582.png)

~~From the data above it appears that we've corrected the initial starvation problem. However, there appears to be another issue where the data flow increases after about 1000 seconds (16 minutes) and the rate is higher than I might expect. I am currently looking at that problem as a separate issue.~~ (Fixed)

The raw data with added charts & summarized tables:
[Work-Comparison-AdaptiveSamplingStarve.xlsx](https://github.com/Microsoft/ApplicationInsights-dotnet/files/1522943/Work-Comparison-AdaptiveSamplingStarve.xlsx)

*EDIT*: Added template checkboxes for PRs
*EDIT*: After further fixes, updated resulting data emitted chart, updated XLS data analysis file, and the solution flow diagram