### PR TITLE
Consolidate naming for the heartbeat feature throughout the SDK

### DIFF
--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net40/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net40/PublicAPI.Unshipped.txt
@@ -1,15 +1,15 @@
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -1,15 +1,15 @@
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,15 +1,15 @@
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -1,15 +1,15 @@
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHealthProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.get -> System.TimeSpan
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.HeartbeatInterval.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.get -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.IsHeartbeatEnabled.set -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool
+Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.IHeartbeatPropertyManager.SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null) -> bool

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/HeartbeatTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/HeartbeatTests.cs
@@ -89,7 +89,7 @@
 
                 try
                 {
-                    Assert.IsTrue(hbeat.AddHealthProperty("test01", "this is a value", true));
+                    Assert.IsTrue(hbeat.AddHeartbeatProperty("test01", "this is a value", true));
                 }
                 catch (Exception e)
                 {
@@ -159,7 +159,7 @@
             using (var hbeat = new HeartbeatProvider())
             {
                 string testerKey = "tester123";
-                Assert.IsTrue(hbeat.AddHealthProperty(testerKey, "test", true));
+                Assert.IsTrue(hbeat.AddHeartbeatProperty(testerKey, "test", true));
                 hbeat.Initialize(configuration: null);
 
                 MetricTelemetry payload = (MetricTelemetry)hbeat.GatherData();
@@ -218,7 +218,7 @@
             {
                 hbeat.Initialize(configuration: null);
                 string testerKey = "tester123";
-                hbeat.AddHealthProperty(testerKey, "test", false);
+                hbeat.AddHeartbeatProperty(testerKey, "test", false);
 
                 var msg = (MetricTelemetry)hbeat.GatherData();
                 Assert.IsTrue(msg.Sum >= 1.0);
@@ -235,8 +235,8 @@
                 var msg = (MetricTelemetry)hbeat.GatherData();
                 Assert.IsTrue(msg.Sum == 0.0);
 
-                hbeat.AddHealthProperty("tester01", "test failure 1", false);
-                hbeat.AddHealthProperty("tester02", "test failure 2", false);
+                hbeat.AddHeartbeatProperty("tester01", "test failure 1", false);
+                hbeat.AddHeartbeatProperty("tester02", "test failure 2", false);
                 msg = (MetricTelemetry)hbeat.GatherData();
 
                 Assert.IsTrue(msg.Sum == 2.0);
@@ -276,8 +276,8 @@
             {
                 hbeat.Initialize(configuration: null);
 
-                Assert.IsTrue(hbeat.AddHealthProperty("test01", "some test value", true));
-                Assert.IsFalse(hbeat.AddHealthProperty("test01", "some other test value", true));
+                Assert.IsTrue(hbeat.AddHeartbeatProperty("test01", "some test value", true));
+                Assert.IsFalse(hbeat.AddHeartbeatProperty("test01", "some other test value", true));
             }
         }
 
@@ -288,9 +288,9 @@
             {
                 hbeat.Initialize(configuration: null);
 
-                Assert.IsFalse(hbeat.SetHealthProperty("test01", "some other test value", true));
-                Assert.IsTrue(hbeat.AddHealthProperty("test01", "some test value", true));
-                Assert.IsTrue(hbeat.SetHealthProperty("test01", "some other test value", true));
+                Assert.IsFalse(hbeat.SetHeartbeatProperty("test01", "some other test value", true));
+                Assert.IsTrue(hbeat.AddHeartbeatProperty("test01", "some test value", true));
+                Assert.IsTrue(hbeat.SetHeartbeatProperty("test01", "some other test value", true));
             }
         }
 
@@ -303,7 +303,7 @@
 
                 foreach (string key in HeartbeatDefaultPayload.DefaultFields)
                 {
-                    Assert.IsFalse(hbeat.SetHealthProperty(key, "test", true));
+                    Assert.IsFalse(hbeat.SetHeartbeatProperty(key, "test", true));
                 }
             }
         }
@@ -317,7 +317,7 @@
 
                 foreach (string key in HeartbeatDefaultPayload.DefaultFields)
                 {
-                    Assert.IsFalse(hbeat.AddHealthProperty(key, "test", true));
+                    Assert.IsFalse(hbeat.AddHeartbeatProperty(key, "test", true));
                 }
             }
         }
@@ -345,8 +345,8 @@
 
                 string key = "setValueTest";
 
-                Assert.IsTrue(hbeat.AddHealthProperty(key, "value01", true));
-                Assert.IsTrue(hbeat.SetHealthProperty(key, "value02"));
+                Assert.IsTrue(hbeat.AddHeartbeatProperty(key, "value01", true));
+                Assert.IsTrue(hbeat.SetHeartbeatProperty(key, "value02"));
                 var msg = (MetricTelemetry)hbeat.GatherData();
                 
                 Assert.IsNotNull(msg);
@@ -364,8 +364,8 @@
 
                 string key = "healthSettingTest";
 
-                Assert.IsTrue(hbeat.AddHealthProperty(key, "value01", true));
-                Assert.IsTrue(hbeat.SetHealthProperty(key, null, false));
+                Assert.IsTrue(hbeat.AddHeartbeatProperty(key, "value01", true));
+                Assert.IsTrue(hbeat.SetHeartbeatProperty(key, null, false));
                 var msg = (MetricTelemetry)hbeat.GatherData();
                 
                 Assert.IsNotNull(msg);

--- a/docs/ExtendingHeartbeatProperties.md
+++ b/docs/ExtendingHeartbeatProperties.md
@@ -2,15 +2,15 @@ _This document was last updated 11/25/2016 and is applicable to SDK version 2.5.
 
 # Extending Heartbeat Properties in Application Insights #
 
-The .NET Application Insights SDKs provide a new feature called Health Heartbeat. This feature
-sends health related data as well as environment-specific information at pre-configured
-intervals. The feature will allow you to extend the properties that will be sent every interval,
-and will also allow you to set a flag denoting a healthy or unhealthy status for each property
-you add to the heartbeat payload.
+The .NET Application Insights SDKs provide a new feature called Heartbeat. This feature
+sends environment-specific information at pre-configured intervals. The feature will allow 
+you to extend the properties that will be sent every interval, and will also allow you to 
+set a flag denoting a healthy or unhealthy status for each property you add to the heartbeat 
+payload.
 
 ## A General Code Example ##
 
-In order to add the extended properties of your choice to the Health Heartbeat as a developer
+In order to add the extended properties of your choice to the Heartbeat as a developer
 of an ITelemetryModule, you can follow the following pattern. Note that you must first add the
 properties you want to include in the payload, and you can update (via set) the vaules and health
 status of those properties for the duration of the application life cycle.
@@ -22,7 +22,7 @@ through the available modules looking for an implementation of `IHeartbeatProper
 
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     ...
-    // heartbeat property manager to add/update my health properties into:
+    // heartbeat property manager to add/update my heartbeat-delivered properties into:
     private IHeartbeatPropertyManager heartbeatManager= null;
     ...
     public void Initialize(TelemetryConfiguration configuration)
@@ -45,30 +45,30 @@ property fields that you want to see in the heartbeat payload for the duration o
 application's lifecycle.
 
     ...
-    this.heartbeatManager.AddHealthProperty(propertyName: "myHealthProperty", propertyValue: this.MyHealthProperty, isHealthy: true);
+    this.heartbeatManager.AddHeartbeatProperty(propertyName: "myHeartbeatProperty", propertyValue: this.MyHeartbeatProperty, isHealthy: true);
     ...
 
 Outside of your `Initialize` method, you can update the values you've added by using the 
-`SetHealthProperty` method very simply. For instance, you can add a health property called 
-'myHealthProperty' in the initialize method as above, and then from within a property elsewhere
+`SetHeartbeatProperty` method very simply. For instance, you can add a property called 
+'myHeartbeatProperty' in the initialize method as above, and then from within a property elsewhere
 in your class, you can update the value in the heartbeat payload as follows:
 
-    public string MyHealthProperty
+    public string MyHeartbeatProperty
     {
-        get => this.myHealthPropertyValue;
+        get => this.myHeartbeatPropertyValue;
 
         set
         {
-            this.myHealthPropertyValue = value;
+            this.myHeartbeatPropertyValue = value;
             if (this.heartbeatManager != null)
             {
-                bool myPropIsHealthy = this.SomeTestForHealthStatus(this.myHealthPropertyValue);
-                this.heartbeatManager.SetHealthProperty(propertyName: "myHealthProperty", propertyValue: value, isHealthy: myPropIsHealthy);
+                bool myPropIsHealthy = this.SomeTestForHealthStatus(this.myHeartbeatPropertyValue);
+                this.heartbeatManager.SetHeartbeatProperty(propertyName: "myHeartbeatProperty", propertyValue: value, isHealthy: myPropIsHealthy);
             }
         }
     }
 
-Using the above example you can add and update properties in the Health Heartbeat for the
+Using the above example you can add and update properties in the Heartbeat for the
 duration of your application's life.
 
 > **Note:** You may also set values for the `HeartbeatInterval` value. This is discouraged, as
@@ -88,7 +88,7 @@ constructed in the Microsoft.ApplicationInsights.Web assembly, and can be review
 
 https://github.com/Microsoft/ApplicationInsights-dotnet-server/tree/dekeeler/sample-heartbeat-extension
 
-...specifically, you can see how we've provided extra properties to the health heartbeat in the
+...specifically, you can see how we've provided extra properties to the heartbeat in the
 FileDiagnosticsTelemetryModule here:
 
 https://github.com/Microsoft/ApplicationInsights-dotnet-server/blob/2089882ea10a32b88f8d4681eb4819f09a1471bd/Src/HostingStartup/HostingStartup.Net45/FileDiagnosticsTelemetryModule.cs#L134

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModule.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModule.cs
@@ -47,7 +47,7 @@
         }
 
         /// <summary>
-        /// Gets or sets a value indicating whether or not the Health Heartbeat feature is disabled.
+        /// Gets or sets a value indicating whether or not the Heartbeat feature is disabled.
         /// </summary>
         public bool IsHeartbeatEnabled
         {
@@ -81,7 +81,7 @@
         }
 
         /// <summary>
-        /// Gets a list of property names that are not to be sent with the health heartbeats. null/empty list means allow all default properties through.
+        /// Gets a list of property names that are not to be sent with the heartbeats. null/empty list means allow all default properties through.
         /// 
         /// <remarks>
         /// Default properties supplied by the Application Insights SDK:
@@ -199,46 +199,46 @@
         }
 
         /// <summary>
-        /// Add a new Health Heartbeat property to the payload sent with each heartbeat.
+        /// Add a new Heartbeat property to the payload sent with each heartbeat.
         /// 
-        /// To update the value of the property you are adding to the health heartbeat, 
-        /// <see cref="DiagnosticsTelemetryModule.SetHealthProperty"/>.
+        /// To update the value of the property you are adding to the heartbeat, 
+        /// <see cref="DiagnosticsTelemetryModule.SetHeartbeatProperty"/>.
         /// 
-        /// Note that you cannot add a HealthHeartbeatProperty with a name that already exists in the HealthHeartbeat
+        /// Note that you cannot add a HeartbeatProperty with a name that already exists in the Heartbeat
         /// payload, including (but not limited to) the name of SDK-default items.
         /// 
         /// </summary>
-        /// <param name="propertyName">Name of the health heartbeat value to add</param>
-        /// <param name="propertyValue">Current value of the health heartbeat value to add</param>
+        /// <param name="propertyName">Name of the heartbeat value to add</param>
+        /// <param name="propertyValue">Current value of the heartbeat value to add</param>
         /// <param name="isHealthy">Flag indicating whether or not the property represents a healthy value</param>
         /// <returns>True if the new payload item is successfully added, false otherwise.</returns>
-        public bool AddHealthProperty(string propertyName, string propertyValue, bool isHealthy)
+        public bool AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy)
         {
-            return this.HeartbeatProvider.AddHealthProperty(propertyName, propertyValue, isHealthy);
+            return this.HeartbeatProvider.AddHeartbeatProperty(propertyName, propertyValue, isHealthy);
         }
 
         /// <summary>
-        /// Set an updated value into an existing property of the health heartbeat. The propertyName must be non-null and non-empty
+        /// Set an updated value into an existing property of the heartbeat. The propertyName must be non-null and non-empty
         /// and at least one of the propertyValue and isHealthy parameters must be non-null.
         /// 
-        /// After the new HealthHeartbeatProperty has been added (<see cref="DiagnosticsTelemetryModule.AddHealthProperty"/>) to the 
+        /// After the new HeartbeatProperty has been added (<see cref="DiagnosticsTelemetryModule.AddHeartbeatProperty"/>) to the 
         /// heartbeat payload, the value represented by that item can be updated using this method at any time.
         /// 
         /// </summary>
-        /// <param name="propertyName">Name of the health heartbeat payload item property to set the value and/or health status of.</param>
-        /// <param name="propertyValue">Value of the health heartbeat payload item. If this is null, the current value in the item is left unchanged.</param>
-        /// <param name="isHealthy">Health status of the health heartbeat payload item. If this is set to null the health status is left unchanged.</param>
+        /// <param name="propertyName">Name of the heartbeat payload item property to set the value and/or its health status.</param>
+        /// <param name="propertyValue">Value of the heartbeat payload item. If this is null, the current value in the item is left unchanged.</param>
+        /// <param name="isHealthy">Health status of the heartbeat payload item. If this is set to null the health status is left unchanged.</param>
         /// <returns>True if the payload provider was added, false if it hasn't been added yet 
-        /// (<see cref="DiagnosticsTelemetryModule.AddHealthProperty"/>).</returns>
-        public bool SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null)
+        /// (<see cref="DiagnosticsTelemetryModule.AddHeartbeatProperty"/>).</returns>
+        public bool SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null)
         {
             if (!string.IsNullOrEmpty(propertyName) && (propertyValue != null || isHealthy != null))
             {
-                return this.HeartbeatProvider.SetHealthProperty(propertyName, propertyValue, isHealthy);
+                return this.HeartbeatProvider.SetHeartbeatProperty(propertyName, propertyValue, isHealthy);
             }
             else
             {
-                CoreEventSource.Log.LogVerbose("Did not set a valid health property. Ensure you set a valid propertyName and one or both of the propertyValue and isHealthy parameters.");
+                CoreEventSource.Log.LogVerbose("Did not set a valid heartbeat property. Ensure you set a valid propertyName and one or both of the propertyValue and isHealthy parameters.");
             }
 
             return false;

--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatDefaultPayload.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatDefaultPayload.cs
@@ -25,13 +25,13 @@
                     switch (fieldName)
                     {
                         case "runtimeFramework":
-                            provider.AddHealthProperty(fieldName, GetRuntimeFrameworkVer(), true);
+                            provider.AddHeartbeatProperty(fieldName, GetRuntimeFrameworkVer(), true);
                             break;
                         case "baseSdkTargetFramework":
-                            provider.AddHealthProperty(fieldName, GetBaseSdkTargetFramework(), true);
+                            provider.AddHeartbeatProperty(fieldName, GetBaseSdkTargetFramework(), true);
                             break;
                         default:
-                            provider.AddHealthProperty(fieldName, "UNDEFINED", false);
+                            provider.AddHeartbeatProperty(fieldName, "UNDEFINED", false);
                             break;
                     }
                 }

--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -11,7 +11,7 @@
     using Microsoft.ApplicationInsights.Extensibility;
 
     /// <summary>
-    /// Implementation of health heartbeat functionality.
+    /// Implementation of heartbeat functionality.
     /// </summary>
     internal class HeartbeatProvider : IDisposable, IHeartbeatProvider
     {
@@ -26,16 +26,16 @@
         public static readonly TimeSpan MinimumHeartbeatInterval = TimeSpan.FromSeconds(30.0);
 
         /// <summary>
-        /// The name of the health heartbeat metric item and operation context. 
+        /// The name of the heartbeat metric item and operation context. 
         /// </summary>
-        private static string heartbeatSyntheticMetricName = "HealthState";
+        private static string heartbeatSyntheticMetricName = "HeartbeatState";
 
         private readonly List<string> disabledDefaultFields = new List<string>(); // string containing fields that are not to be sent with the payload. Empty list means send everything available.
 
         private UInt64 heartbeatsSent; // counter of all heartbeats
 
         /// <summary>
-        /// The payload items to send out with each health heartbeat.
+        /// The payload items to send out with each heartbeat.
         /// </summary>
         private ConcurrentDictionary<string, HeartbeatPropertyPayload> heartbeatProperties;
 
@@ -139,48 +139,48 @@
             }
         }
 
-        public bool AddHealthProperty(string healthPropertyName, string healthPropertyValue, bool isHealthy)
+        public bool AddHeartbeatProperty(string heartbeatPropertyName, string heartbeatPropertyValue, bool isHealthy)
         {
             bool isAdded = false;
 
-            if (!string.IsNullOrEmpty(healthPropertyName))
+            if (!string.IsNullOrEmpty(heartbeatPropertyName))
             {
                 try
                 {
-                    var existingProp = this.heartbeatProperties.GetOrAdd(healthPropertyName, (key) =>
+                    var existingProp = this.heartbeatProperties.GetOrAdd(heartbeatPropertyName, (key) =>
                     {
                         isAdded = true;
                         return new HeartbeatPropertyPayload()
                         {
                             IsHealthy = isHealthy,
-                            PayloadValue = healthPropertyValue
+                            PayloadValue = heartbeatPropertyValue
                         };
                     });
                 }
                 catch (Exception e)
                 {
-                    CoreEventSource.Log.FailedToAddHeartbeatProperty(healthPropertyName, healthPropertyValue, e.ToString());
+                    CoreEventSource.Log.FailedToAddHeartbeatProperty(heartbeatPropertyName, heartbeatPropertyValue, e.ToString());
                 }
             }
             else
             {
-                CoreEventSource.Log.HeartbeatPropertyAddedWithoutAnyName(healthPropertyValue, isHealthy);
+                CoreEventSource.Log.HeartbeatPropertyAddedWithoutAnyName(heartbeatPropertyValue, isHealthy);
             }
 
             return isAdded;
         }
 
-        public bool SetHealthProperty(string healthPropertyName, string healthPropertyValue = null, bool? isHealthy = null)
+        public bool SetHeartbeatProperty(string heartbeatPropertyName, string heartbeatPropertyValue = null, bool? isHealthy = null)
         {
             bool setResult = false;
-            if (!string.IsNullOrEmpty(healthPropertyName)
-                && !HeartbeatDefaultPayload.DefaultFields.Contains(healthPropertyName))
+            if (!string.IsNullOrEmpty(heartbeatPropertyName)
+                && !HeartbeatDefaultPayload.DefaultFields.Contains(heartbeatPropertyName))
             {
                 try
                 {
-                    this.heartbeatProperties.AddOrUpdate(healthPropertyName, (key) =>
+                    this.heartbeatProperties.AddOrUpdate(heartbeatPropertyName, (key) =>
                     {
-                        throw new Exception("Cannot set a health property without adding it first.");
+                        throw new Exception("Cannot set a heartbeat property without adding it first.");
                     },
                     (key, property) =>
                     {
@@ -188,9 +188,9 @@
                         {
                             property.IsHealthy = isHealthy.Value;
                         }
-                        if (healthPropertyValue != null)
+                        if (heartbeatPropertyValue != null)
                         {
-                            property.PayloadValue = healthPropertyValue;
+                            property.PayloadValue = heartbeatPropertyValue;
                         }
 
                         return property;
@@ -199,12 +199,12 @@
                 }
                 catch (Exception e)
                 {
-                    CoreEventSource.Log.FailedToSetHeartbeatProperty(healthPropertyName, healthPropertyValue, isHealthy.HasValue, isHealthy.GetValueOrDefault(false), e.ToString());
+                    CoreEventSource.Log.FailedToSetHeartbeatProperty(heartbeatPropertyName, heartbeatPropertyValue, isHealthy.HasValue, isHealthy.GetValueOrDefault(false), e.ToString());
                 }
             }
             else
             {
-                CoreEventSource.Log.CannotSetHeartbeatPropertyWithNoNameOrDefaultName(healthPropertyName, healthPropertyValue, isHealthy.HasValue, isHealthy.GetValueOrDefault(false));
+                CoreEventSource.Log.CannotSetHeartbeatPropertyWithNoNameOrDefaultName(heartbeatPropertyName, heartbeatPropertyValue, isHealthy.HasValue, isHealthy.GetValueOrDefault(false));
             }
 
             return setResult;
@@ -305,7 +305,7 @@
             }
             else
             {
-                CoreEventSource.Log.LogError("Heartbeat pulse being sent without valid instance of HealthHeartbeatProvider as its state");
+                CoreEventSource.Log.LogError("Heartbeat pulse being sent without valid instance of HeartbeatProvider as its state");
             }
         }
     }

--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/IHeartbeatPropertyManager.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/IHeartbeatPropertyManager.cs
@@ -4,14 +4,14 @@
     using System.Collections.Generic;
 
     /// <summary>
-    /// Defines an implementation for management of the health heartbeat feature of the 
+    /// Defines an implementation for management of the heartbeat feature of the 
     /// Application Insights SDK. Add/Set properties, disable/enable the heartbeat, and set
     /// the interval between heartbeat pulses with classes that implement this interface.
     /// </summary>
     public interface IHeartbeatPropertyManager
     {
         /// <summary>
-        /// Gets or sets a value indicating whether or not the Health Heartbeat feature is disabled.
+        /// Gets or sets a value indicating whether or not the Heartbeat feature is disabled.
         /// </summary>
         bool IsHeartbeatEnabled { get; set; }
 
@@ -21,18 +21,18 @@
         TimeSpan HeartbeatInterval { get; set; }
 
         /// <summary>
-        /// Gets a list of property names that are not to be sent with the health heartbeats.
+        /// Gets a list of property names that are not to be sent with the heartbeats.
         /// </summary>
         IList<string> ExcludedHeartbeatProperties { get; }
 
         /// <summary>
-        /// Add a new Health Heartbeat property to the payload sent with each heartbeat.
+        /// Add a new Heartbeat property to the payload sent with each heartbeat.
         /// </summary>
-        bool AddHealthProperty(string propertyName, string propertyValue, bool isHealthy);
+        bool AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy);
 
         /// <summary>
-        /// Set an updated value into an existing property of the health heartbeat.
+        /// Set an updated value into an existing property of the heartbeat.
         /// </summary>
-        bool SetHealthProperty(string propertyName, string propertyValue = null, bool? isHealthy = null);
+        bool SetHeartbeatProperty(string propertyName, string propertyValue = null, bool? isHealthy = null);
     }
 }


### PR DESCRIPTION
Remove the term 'health' from heartbeat related API names

Fix Issue #665 .
We want the heartbeat functionality provided in the SDK to be as generic as possible, and *allow for* the tracking of health status as necessary. (See discussion within #636 for details/history). 

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #665 (follow up from discussions in #636)
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [x] Built & tested in CI