### PR TITLE
fix for failed build

### DIFF
--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -23,7 +23,8 @@
   </PropertyGroup>
   
   <PropertyGroup Condition="'$(PackageVersion)'==''">
-    <PackageVersion>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch)-$(PreReleaseMilestone)</PackageVersion>
+    <PackageVersion>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch)</PackageVersion>
+	<PackageVersion Condition="'$(PreReleaseMilestone)' != ''">$(PackageVersion)-$(PreReleaseMilestone)</PackageVersion>
     <PackageVersion Condition="'$(StableRelease)' != 'True'">$(PackageVersion)-build$(PreReleaseVersion)</PackageVersion>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Fix for failed builds.

"C:\Repos\SDK\ApplicationInsights-dotnet\dirs.proj" (default target) (1) ->
"C:\Repos\SDK\ApplicationInsights-dotnet\Microsoft.ApplicationInsights.sln" (Restore;Build target) (2) ->
(Restore target) ->
  C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.tar
gets(103,5): **error : '2.5.0-' is not a valid version string.** [C:\Repos\SDK\ApplicationInsights-dotnet\Microsoft.Applica
tionInsights.sln]
C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\Common7\IDE\CommonExtensions\Microsoft\NuGet\NuGet.targe
ts(103,5): error : Parameter name: value [C:\Repos\SDK\ApplicationInsights-dotnet\Microsoft.ApplicationInsights.sln]