### PR TITLE
fix for Context properties not being copied to telemetry items.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Finalize the architecture for adding default heartbeat properties (supporting proposal from Issue #636).](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/666).
 
 ## Version 2.5.1
-- Fix for missing TelemetryContext. Thank you to our community for discovering and reporting this issue!
+- Fix for missing TelemetryContext. Thank you to our community for discovering and reporting this issue! 
   [Logic bug within Initialize() in TelemetryContext](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/692),
   [Dependency correlation is broken after upgrade to .NET SDK 2.5](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/706),
   [Lost many context fields in 2.5.0](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/708)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ This changelog will be used to generate documentation on [release notes page](ht
 ## Version 2.6.0-beta1
 - [Added overload of TelemetryClientExtensions.StartOperation(Activity activity).] (https://github.com/Microsoft/ApplicationInsights-dotnet/issues/644)
 
+## Version 2.5.1
+- Fix for missing TelemetryContext. Thank you to our community for discovering and reporting this issue!
+  [Logic bug within Initialize() in TelemetryContext](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/692),
+  [Dependency correlation is broken after upgrade to .NET SDK 2.5](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/706),
+  [Lost many context fields in 2.5.0](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/708)
+
 ## Version 2.5.0-beta2
 - Remove calculation of sampling-score based on Context.User.Id [Issue #625](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/625)
 - New sdk-driven "heartbeat" functionality added which sends health status at pre-configured intervals. See [extending heartbeat properties doc for more information](./docs/ExtendingHeartbeatProperties.md)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryContextInitializeTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryContextInitializeTest.cs
@@ -1,0 +1,152 @@
+﻿namespace Microsoft.ApplicationInsights.DataContracts
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    /// <summary>
+    /// If a user sets the context on a TelemetryClient, it is expected that those values will propagate to individual TelemetryItems.
+    /// </summary>
+    [TestClass]
+    public class TelemetryContextInitializeTest
+    {
+        private TelemetryBuffer TelemetryBuffer;
+        private ITelemetryChannel TelemetryChannel;
+        private TelemetryClient TelemetryClient;
+
+        #region Telemetry Context Properties
+        private const string TestInstrumentationKey = "00000000-0000-0000-0000-000000000000";
+
+        private const string TestComponentVersion = "TestComponentVersion";
+
+        private const string TestDeviceType = "TestDeviceType";
+        private const string TestDeviceId = "TestDeviceId";
+        private const string TestDeviceOperatingSystem = "TestDeviceOperatingSystem";
+        private const string TestDeviceOemName = "TestDeviceOemName";
+        private const string TestDeviceModel = "TestDeviceModel";
+
+        private const string TestCloudRoleName = "TestCloudRoleName";
+        private const string TestCloudRoleInstance = "TestCloudRoleInstance";
+
+        private const string TestSessionId = "TestSessionId";
+        private const bool TestSessionIsFirst = true;
+
+        private const string TestUserId = "TestUserId";
+        private const string TestUserAccountId = "TestUserAccountId";
+        private const string TestUserUserAgent = "TestUserUserAgent";
+        private const string TestUserAuthenticatedUserId = "TestUserAuthenticatedUserId";
+
+        private const string TestOperationId = "TestOperationId";
+        private const string TestOperationParentId = "TestOperationParentId";
+        private const string TestOperationCorrelationVector = "TestOperationCorrelationVector";
+        private const string TestOperationSyntheticSource = "TestOperationSyntheticSource";
+        private const string TestOperationName = "TestOperationName";
+
+        private const string TestLocationIp = "TestLocationIp";
+
+        private const string TestInternalSdkVersion = "TestInternalSdkVersion";
+        private const string TestInternalAgentVersion = "TestInternalAgentVersion";
+        private const string TestInternalNodeName = "TestInternalNodeName";
+        #endregion
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            this.TelemetryBuffer = new TelemetryBuffer();
+            this.TelemetryChannel = new InMemoryChannel(this.TelemetryBuffer, new InMemoryTransmitter(this.TelemetryBuffer));
+            this.TelemetryClient = new TelemetryClient(new Extensibility.TelemetryConfiguration(instrumentationKey: TestInstrumentationKey, channel: this.TelemetryChannel));
+
+            this.TelemetryClient.Context.Component.Version = TestComponentVersion;
+
+            this.TelemetryClient.Context.Device.Type = TestDeviceType;
+            this.TelemetryClient.Context.Device.Id = TestDeviceId;
+            this.TelemetryClient.Context.Device.OperatingSystem = TestDeviceOperatingSystem;
+            this.TelemetryClient.Context.Device.OemName = TestDeviceOemName;
+            this.TelemetryClient.Context.Device.Model = TestDeviceModel;
+
+            this.TelemetryClient.Context.Cloud.RoleName = TestCloudRoleName;
+            this.TelemetryClient.Context.Cloud.RoleInstance = TestCloudRoleInstance;
+
+            this.TelemetryClient.Context.Session.Id = TestSessionId;
+            this.TelemetryClient.Context.Session.IsFirst = TestSessionIsFirst;
+
+            this.TelemetryClient.Context.User.Id = TestUserId;
+            this.TelemetryClient.Context.User.AccountId = TestUserAccountId;
+            this.TelemetryClient.Context.User.UserAgent = TestUserUserAgent;
+            this.TelemetryClient.Context.User.AuthenticatedUserId = TestUserAuthenticatedUserId;
+
+            this.TelemetryClient.Context.Operation.Id = TestOperationId;
+            this.TelemetryClient.Context.Operation.ParentId = TestOperationParentId;
+            this.TelemetryClient.Context.Operation.CorrelationVector = TestOperationCorrelationVector;
+            this.TelemetryClient.Context.Operation.SyntheticSource = TestOperationSyntheticSource;
+            this.TelemetryClient.Context.Operation.Name = TestOperationName;
+
+            this.TelemetryClient.Context.Location.Ip = TestLocationIp;
+
+            this.TelemetryClient.Context.Internal.SdkVersion = TestInternalSdkVersion;
+            this.TelemetryClient.Context.Internal.AgentVersion = TestInternalAgentVersion;
+            this.TelemetryClient.Context.Internal.NodeName = TestInternalNodeName;
+        }
+
+        [TestMethod]
+        public void VerifyContextPropertiesAreCopied()
+        {
+            var testDependencyName = "TestDependency";
+            var testCommandName = "TestCommand";
+            var testStartTime = DateTime.Parse("2000-01-01");
+            var testTimeSpan = new TimeSpan(0, 0, 5);
+            var testSuccess = true;
+
+            this.TelemetryClient.TrackDependency(dependencyName: testDependencyName, commandName: testCommandName, startTime: testStartTime, duration: testTimeSpan, success: testSuccess);
+
+            IEnumerable<ITelemetry> telemetryItems = this.TelemetryBuffer.Dequeue();
+            Assert.AreEqual(1, telemetryItems.Count());
+
+            var dependencyTelemetryItem = telemetryItems.First() as DependencyTelemetry;
+            Assert.AreEqual(testDependencyName, dependencyTelemetryItem.Name);
+            Assert.AreEqual(testCommandName, dependencyTelemetryItem.Data);
+            Assert.AreEqual(testSuccess, dependencyTelemetryItem.Success);
+
+            VerifyContext(dependencyTelemetryItem);
+        }
+
+        private void VerifyContext(ITelemetry telemetryItem)
+        {
+            Assert.AreEqual(TestInstrumentationKey, telemetryItem.Context.InstrumentationKey);
+
+            Assert.AreEqual(TestComponentVersion, telemetryItem.Context.Component.Version);
+            
+            Assert.AreEqual(TestDeviceType, telemetryItem.Context.Device.Type);
+            Assert.AreEqual(TestDeviceId, telemetryItem.Context.Device.Id);
+            Assert.AreEqual(TestDeviceOperatingSystem, telemetryItem.Context.Device.OperatingSystem);
+            Assert.AreEqual(TestDeviceOemName, telemetryItem.Context.Device.OemName);
+            Assert.AreEqual(TestDeviceModel, telemetryItem.Context.Device.Model);
+            
+            Assert.AreEqual(TestCloudRoleName, telemetryItem.Context.Cloud.RoleName);
+            Assert.AreEqual(TestCloudRoleInstance, telemetryItem.Context.Cloud.RoleInstance);
+            
+            Assert.AreEqual(TestSessionId, telemetryItem.Context.Session.Id);
+            Assert.AreEqual(TestSessionIsFirst, telemetryItem.Context.Session.IsFirst);
+            
+            Assert.AreEqual(TestUserId, telemetryItem.Context.User.Id);
+            Assert.AreEqual(TestUserAccountId, telemetryItem.Context.User.AccountId);
+            Assert.AreEqual(TestUserUserAgent, telemetryItem.Context.User.UserAgent);
+            Assert.AreEqual(TestUserAuthenticatedUserId, telemetryItem.Context.User.AuthenticatedUserId);
+            
+            Assert.AreEqual(TestOperationId, telemetryItem.Context.Operation.Id);
+            Assert.AreEqual(TestOperationParentId, telemetryItem.Context.Operation.ParentId);
+            Assert.AreEqual(TestOperationCorrelationVector, telemetryItem.Context.Operation.CorrelationVector);
+            Assert.AreEqual(TestOperationSyntheticSource, telemetryItem.Context.Operation.SyntheticSource);
+            Assert.AreEqual(TestOperationName, telemetryItem.Context.Operation.Name);
+            
+            Assert.AreEqual(TestLocationIp, telemetryItem.Context.Location.Ip);
+            
+            Assert.AreEqual(TestInternalSdkVersion, telemetryItem.Context.Internal.SdkVersion);
+            Assert.AreEqual(TestInternalAgentVersion, telemetryItem.Context.Internal.AgentVersion);
+            Assert.AreEqual(TestInternalNodeName, telemetryItem.Context.Internal.NodeName);
+        }
+    }
+}

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Microsoft.ApplicationInsights.Shared.Tests.projitems
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Microsoft.ApplicationInsights.Shared.Tests.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\DependencyTelemetryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\RequestTelemetryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\SessionStateTelemetryTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)DataContracts\TelemetryContextInitializeTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\TelemetryContextTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\TelemetryItemTestHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\TraceTelemetryTest.cs" />

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -152,18 +152,23 @@
             return other;
         }
 
+        /// <summary>
+        /// Initialize this instance's Context properties with the values from another TelemetryContext.
+        /// First check that source is not null, then copy to this instance.
+        /// Note that invoking the public getter instead of the private field will call the LazyInitializer.
+        /// </summary>
         internal void Initialize(TelemetryContext source, string instrumentationKey)
         {
             Property.Initialize(ref this.instrumentationKey, instrumentationKey);
-            
-            this.Component.CopyFrom(source);
-            this.Device.CopyFrom(source);
-            this.Cloud.CopyFrom(source);
-            this.Session.CopyFrom(source);
-            this.User.CopyFrom(source);
-            this.Operation.CopyFrom(source);
-            this.Location.CopyFrom(source);
-            this.Internal.CopyFrom(source);
-        }
+
+            source.component?.CopyTo(this.Component);
+            source.device?.CopyTo(this.Device);
+            source.cloud?.CopyTo(this.Cloud);
+            source.session?.CopyTo(this.Session);
+            source.user?.CopyTo(this.User);
+            source.operation?.CopyTo(this.Operation);
+            source.location?.CopyTo(this.Location);
+            source.Internal?.CopyTo(this.Internal);
     }
+}
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -168,7 +168,7 @@
             source.user?.CopyTo(this.User);
             source.operation?.CopyTo(this.Operation);
             source.location?.CopyTo(this.Location);
-            source.Internal?.CopyTo(this.Internal);
+            source.Internal.CopyTo(this.Internal);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -169,6 +169,6 @@
             source.operation?.CopyTo(this.Operation);
             source.location?.CopyTo(this.Location);
             source.Internal?.CopyTo(this.Internal);
+        }
     }
-}
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -132,13 +132,13 @@
             get
             {
                 var result = new Dictionary<string, string>();
-                this.Component?.UpdateTags(result);
-                this.Device?.UpdateTags(result);
-                this.Cloud?.UpdateTags(result);
-                this.Session?.UpdateTags(result);
-                this.User?.UpdateTags(result);
-                this.Operation?.UpdateTags(result);
-                this.Location?.UpdateTags(result);
+                this.Component.UpdateTags(result);
+                this.Device.UpdateTags(result);
+                this.Cloud.UpdateTags(result);
+                this.Session.UpdateTags(result);
+                this.User.UpdateTags(result);
+                this.Operation.UpdateTags(result);
+                this.Location.UpdateTags(result);
                 this.Internal.UpdateTags(result);
                 return result;
             }
@@ -156,13 +156,13 @@
         {
             Property.Initialize(ref this.instrumentationKey, instrumentationKey);
 
-            this.Component?.CopyFrom(source);
-            this.Device?.CopyFrom(source);
-            this.Cloud?.CopyFrom(source);
-            this.Session?.CopyFrom(source);
-            this.User?.CopyFrom(source);
-            this.Operation?.CopyFrom(source);
-            this.Location?.CopyFrom(source);
+            this.Component.CopyFrom(source);
+            this.Device.CopyFrom(source);
+            this.Cloud.CopyFrom(source);
+            this.Session.CopyFrom(source);
+            this.User.CopyFrom(source);
+            this.Operation.CopyFrom(source);
+            this.Location.CopyFrom(source);
             this.Internal.CopyFrom(source);
         }
     }

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -132,13 +132,13 @@
             get
             {
                 var result = new Dictionary<string, string>();
-                this.Component.UpdateTags(result);
-                this.Device.UpdateTags(result);
-                this.Cloud.UpdateTags(result);
-                this.Session.UpdateTags(result);
-                this.User.UpdateTags(result);
-                this.Operation.UpdateTags(result);
-                this.Location.UpdateTags(result);
+                this.component?.UpdateTags(result);
+                this.device?.UpdateTags(result);
+                this.cloud?.UpdateTags(result);
+                this.session?.UpdateTags(result);
+                this.user?.UpdateTags(result);
+                this.operation?.UpdateTags(result);
+                this.location?.UpdateTags(result);
                 this.Internal.UpdateTags(result);
                 return result;
             }
@@ -155,7 +155,7 @@
         internal void Initialize(TelemetryContext source, string instrumentationKey)
         {
             Property.Initialize(ref this.instrumentationKey, instrumentationKey);
-
+            
             this.Component.CopyFrom(source);
             this.Device.CopyFrom(source);
             this.Cloud.CopyFrom(source);

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -132,13 +132,13 @@
             get
             {
                 var result = new Dictionary<string, string>();
-                this.component?.UpdateTags(result);
-                this.device?.UpdateTags(result);
-                this.cloud?.UpdateTags(result);
-                this.session?.UpdateTags(result);
-                this.user?.UpdateTags(result);
-                this.operation?.UpdateTags(result);
-                this.location?.UpdateTags(result);
+                this.Component?.UpdateTags(result);
+                this.Device?.UpdateTags(result);
+                this.Cloud?.UpdateTags(result);
+                this.Session?.UpdateTags(result);
+                this.User?.UpdateTags(result);
+                this.Operation?.UpdateTags(result);
+                this.Location?.UpdateTags(result);
                 this.Internal.UpdateTags(result);
                 return result;
             }
@@ -156,13 +156,13 @@
         {
             Property.Initialize(ref this.instrumentationKey, instrumentationKey);
 
-            this.component?.CopyFrom(source);
-            this.device?.CopyFrom(source);
-            this.cloud?.CopyFrom(source);
-            this.session?.CopyFrom(source);
-            this.user?.CopyFrom(source);
-            this.operation?.CopyFrom(source);
-            this.location?.CopyFrom(source);
+            this.Component?.CopyFrom(source);
+            this.Device?.CopyFrom(source);
+            this.Cloud?.CopyFrom(source);
+            this.Session?.CopyFrom(source);
+            this.User?.CopyFrom(source);
+            this.Operation?.CopyFrom(source);
+            this.Location?.CopyFrom(source);
             this.Internal.CopyFrom(source);
         }
     }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/CloudContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/CloudContext.cs
@@ -39,12 +39,11 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.CloudRole, this.RoleName);
             tags.UpdateTagValue(ContextTagKeys.Keys.CloudRoleInstance, this.RoleInstance);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(CloudContext target)
         {
-            var source = telemetryContext.Cloud;
-            Tags.CopyTagValue(source.RoleName, ref this.roleName);
-            Tags.CopyTagValue(source.RoleInstance, ref this.roleInstance);
+            Tags.CopyTagValue(this.RoleName, ref target.roleName);
+            Tags.CopyTagValue(this.RoleInstance, ref target.roleInstance);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ComponentContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ComponentContext.cs
@@ -34,11 +34,10 @@
         {
             tags.UpdateTagValue(ContextTagKeys.Keys.ApplicationVersion, this.Version);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(ComponentContext target)
         {
-            var source = telemetryContext.Component;
-            Tags.CopyTagValue(source.Version, ref this.version);
+            Tags.CopyTagValue(this.Version, ref target.version);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ComponentContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ComponentContext.cs
@@ -37,8 +37,8 @@
 
         internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Component;
-            Tags.CopyTagValue(target.Version, ref this.version);
+            var source = telemetryContext.Component;
+            Tags.CopyTagValue(source.Version, ref this.version);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/DeviceContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/DeviceContext.cs
@@ -107,15 +107,14 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.DeviceOEMName, this.OemName);
             tags.UpdateTagValue(ContextTagKeys.Keys.DeviceModel, this.Model);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(DeviceContext target)
         {
-            var source = telemetryContext.Device;
-            Tags.CopyTagValue(source.Type, ref this.type);
-            Tags.CopyTagValue(source.Id, ref this.id);
-            Tags.CopyTagValue(source.OperatingSystem, ref this.operatingSystem);
-            Tags.CopyTagValue(source.OemName, ref this.oemName);
-            Tags.CopyTagValue(source.Model, ref this.model);
+            Tags.CopyTagValue(this.Type, ref target.type);
+            Tags.CopyTagValue(this.Id, ref target.id);
+            Tags.CopyTagValue(this.OperatingSystem, ref target.operatingSystem);
+            Tags.CopyTagValue(this.OemName, ref target.oemName);
+            Tags.CopyTagValue(this.Model, ref target.model);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/InternalContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/InternalContext.cs
@@ -56,10 +56,10 @@
 
         internal void CopyFrom(TelemetryContext telemetryContext)
         {
-            var target = telemetryContext.Internal;
-            Tags.CopyTagValue(target.SdkVersion, ref this.sdkVersion);
-            Tags.CopyTagValue(target.AgentVersion, ref this.agentVersion);
-            Tags.CopyTagValue(target.NodeName, ref this.nodeName);
+            var source = telemetryContext.Internal;
+            Tags.CopyTagValue(source.SdkVersion, ref this.sdkVersion);
+            Tags.CopyTagValue(source.AgentVersion, ref this.agentVersion);
+            Tags.CopyTagValue(source.NodeName, ref this.nodeName);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/InternalContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/InternalContext.cs
@@ -53,13 +53,12 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.InternalAgentVersion, this.AgentVersion);
             tags.UpdateTagValue(ContextTagKeys.Keys.InternalNodeName, this.NodeName);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(InternalContext target)
         {
-            var source = telemetryContext.Internal;
-            Tags.CopyTagValue(source.SdkVersion, ref this.sdkVersion);
-            Tags.CopyTagValue(source.AgentVersion, ref this.agentVersion);
-            Tags.CopyTagValue(source.NodeName, ref this.nodeName);
+            Tags.CopyTagValue(this.SdkVersion, ref target.sdkVersion);
+            Tags.CopyTagValue(this.AgentVersion, ref target.agentVersion);
+            Tags.CopyTagValue(this.NodeName, ref target.nodeName);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/LocationContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/LocationContext.cs
@@ -28,11 +28,10 @@
         {
             tags.UpdateTagValue(ContextTagKeys.Keys.LocationIp, this.Ip);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(LocationContext target)
         {
-            var source = telemetryContext.Location;
-            Tags.CopyTagValue(source.Ip, ref this.ip);
+            Tags.CopyTagValue(this.Ip, ref target.ip);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationContext.cs
@@ -75,14 +75,13 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.OperationSyntheticSource, this.SyntheticSource);
         }
 
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        internal void CopyTo(OperationContext target)
         {
-            var source = telemetryContext.Operation;
-            Tags.CopyTagValue(source.Id, ref this.id);
-            Tags.CopyTagValue(source.ParentId, ref this.parentId);
-            Tags.CopyTagValue(source.CorrelationVector, ref this.correlationVector);
-            Tags.CopyTagValue(source.Name, ref this.name);
-            Tags.CopyTagValue(source.SyntheticSource, ref this.syntheticSource);
+            Tags.CopyTagValue(this.Id, ref target.id);
+            Tags.CopyTagValue(this.ParentId, ref target.parentId);
+            Tags.CopyTagValue(this.CorrelationVector, ref target.correlationVector);
+            Tags.CopyTagValue(this.Name, ref target.name);
+            Tags.CopyTagValue(this.SyntheticSource, ref target.syntheticSource);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/SessionContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/SessionContext.cs
@@ -39,12 +39,11 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.SessionId, this.Id);
             tags.UpdateTagValue(ContextTagKeys.Keys.SessionIsFirst, this.IsFirst);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(SessionContext target)
         {
-            var source = telemetryContext.Session;
-            Tags.CopyTagValue(source.Id, ref this.id);
-            Tags.CopyTagValue(source.IsFirst, ref this.isFirst);
+            Tags.CopyTagValue(this.Id, ref target.id);
+            Tags.CopyTagValue(this.IsFirst, ref target.isFirst);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/UserContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/UserContext.cs
@@ -66,14 +66,13 @@
             tags.UpdateTagValue(ContextTagKeys.Keys.UserAgent, this.UserAgent);
             tags.UpdateTagValue(ContextTagKeys.Keys.UserAuthUserId, this.AuthenticatedUserId);
         }
-
-        internal void CopyFrom(TelemetryContext telemetryContext)
+        
+        internal void CopyTo(UserContext target)
         {
-            var source = telemetryContext.User;
-            Tags.CopyTagValue(source.Id, ref this.id);
-            Tags.CopyTagValue(source.AccountId, ref this.accountId);
-            Tags.CopyTagValue(source.UserAgent, ref this.userAgent);
-            Tags.CopyTagValue(source.AuthenticatedUserId, ref this.authenticatedUserId);
+            Tags.CopyTagValue(this.Id, ref target.id);
+            Tags.CopyTagValue(this.AccountId, ref target.accountId);
+            Tags.CopyTagValue(this.UserAgent, ref target.userAgent);
+            Tags.CopyTagValue(this.AuthenticatedUserId, ref target.authenticatedUserId);
         }
     }
 }


### PR DESCRIPTION
ensure that Context Properties are initialized.
add test to verify that Context Properties are copied to TelemetryItems.

Fix Issue #692.
Fix Issue #706.
Fix Issue #708.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
