### PR TITLE
Make TrackDependency harder to use incorrectly

### DIFF
--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
@@ -428,8 +428,9 @@ Microsoft.ApplicationInsights.TelemetryClient.Track(Microsoft.ApplicationInsight
 Microsoft.ApplicationInsights.TelemetryClient.TrackAvailability(Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry telemetry) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackAvailability(string name, System.DateTimeOffset timeStamp, System.TimeSpan duration, string runLocation, bool success, string message = null, System.Collections.Generic.IDictionary<string, string> properties = null, System.Collections.Generic.IDictionary<string, double> metrics = null) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry telemetry) -> void
-Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyName, string commandName, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
+Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyTypeName, string target, string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, string resultCode, bool success) -> void
+Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyTypeName, string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackEvent(Microsoft.ApplicationInsights.DataContracts.EventTelemetry telemetry) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackEvent(string eventName, System.Collections.Generic.IDictionary<string, string> properties = null, System.Collections.Generic.IDictionary<string, double> metrics = null) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackException(Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry telemetry) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
@@ -428,8 +428,9 @@ Microsoft.ApplicationInsights.TelemetryClient.Track(Microsoft.ApplicationInsight
 Microsoft.ApplicationInsights.TelemetryClient.TrackAvailability(Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry telemetry) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackAvailability(string name, System.DateTimeOffset timeStamp, System.TimeSpan duration, string runLocation, bool success, string message = null, System.Collections.Generic.IDictionary<string, string> properties = null, System.Collections.Generic.IDictionary<string, double> metrics = null) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry telemetry) -> void
-Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyName, string commandName, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
+Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyTypeName, string target, string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, string resultCode, bool success) -> void
+Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyTypeName, string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackEvent(Microsoft.ApplicationInsights.DataContracts.EventTelemetry telemetry) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackEvent(string eventName, System.Collections.Generic.IDictionary<string, string> properties = null, System.Collections.Generic.IDictionary<string, double> metrics = null) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackException(Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry telemetry) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
@@ -427,8 +427,9 @@ Microsoft.ApplicationInsights.TelemetryClient.Track(Microsoft.ApplicationInsight
 Microsoft.ApplicationInsights.TelemetryClient.TrackAvailability(Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry telemetry) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackAvailability(string name, System.DateTimeOffset timeStamp, System.TimeSpan duration, string runLocation, bool success, string message = null, System.Collections.Generic.IDictionary<string, string> properties = null, System.Collections.Generic.IDictionary<string, double> metrics = null) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry telemetry) -> void
-Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyName, string commandName, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
+Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyTypeName, string target, string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, string resultCode, bool success) -> void
+Microsoft.ApplicationInsights.TelemetryClient.TrackDependency(string dependencyTypeName, string dependencyName, string data, System.DateTimeOffset startTime, System.TimeSpan duration, bool success) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackEvent(Microsoft.ApplicationInsights.DataContracts.EventTelemetry telemetry) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackEvent(string eventName, System.Collections.Generic.IDictionary<string, string> properties = null, System.Collections.Generic.IDictionary<string, double> metrics = null) -> void
 Microsoft.ApplicationInsights.TelemetryClient.TrackException(Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry telemetry) -> void

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/AutocollectedMetricsExtractorTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/AutocollectedMetricsExtractorTest.cs
@@ -257,8 +257,11 @@
                 TelemetryClient client = new TelemetryClient(telemetryConfig);
                 
                 client.TrackRequest("Test Request", DateTimeOffset.Now, TimeSpan.FromMilliseconds(10), "200", success: true);
+#pragma warning disable CS0612 // Type or member is obsolete
                 client.TrackDependency("Test Dependency Call 1", "Test Command", DateTimeOffset.Now, TimeSpan.FromMilliseconds(10), success: true);
-                client.TrackDependency("Test Dependency Type", "Test Target", "Test Dependency Call 2", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(11), "201", success: true);
+#pragma warning restore CS0612 // Type or member is obsolete
+                client.TrackDependency("Test Dependency Type", "Test Dependency Call 2", "Test Command", DateTimeOffset.Now, TimeSpan.FromMilliseconds(10), true);
+                client.TrackDependency("Test Dependency Type", "Test Target", "Test Dependency Call 3", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(11), "201", success: true);
                 client.TrackEvent("Test Event");
             }
 
@@ -276,18 +279,24 @@
                          ((DependencyTelemetry) telemetrySentToChannel[1]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<DependencyTelemetry>(telemetrySentToChannel[2]);
-            Assert.AreEqual("Test Dependency Call 2", ((DependencyTelemetry) telemetrySentToChannel[2]).Name);
-            Assert.AreEqual(true, ((DependencyTelemetry) telemetrySentToChannel[2]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
+            Assert.AreEqual("Test Dependency Call 2", ((DependencyTelemetry)telemetrySentToChannel[2]).Name);
+            Assert.AreEqual(true, ((DependencyTelemetry)telemetrySentToChannel[2]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
             Assert.AreEqual("(Name:'Dependencies', Ver:'1.0')",
-                         ((DependencyTelemetry) telemetrySentToChannel[2]).Properties["_MS.ProcessedByMetricExtractors"]);
+                         ((DependencyTelemetry)telemetrySentToChannel[2]).Properties["_MS.ProcessedByMetricExtractors"]);
 
-            AssertEx.IsType<EventTelemetry>(telemetrySentToChannel[3]);
-            Assert.AreEqual("Test Event", ((EventTelemetry) telemetrySentToChannel[3]).Name);
-            Assert.AreEqual(false, ((EventTelemetry) telemetrySentToChannel[3]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
+            AssertEx.IsType<DependencyTelemetry>(telemetrySentToChannel[3]);
+            Assert.AreEqual("Test Dependency Call 3", ((DependencyTelemetry) telemetrySentToChannel[3]).Name);
+            Assert.AreEqual(true, ((DependencyTelemetry) telemetrySentToChannel[3]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
+            Assert.AreEqual("(Name:'Dependencies', Ver:'1.0')",
+                         ((DependencyTelemetry) telemetrySentToChannel[3]).Properties["_MS.ProcessedByMetricExtractors"]);
+
+            AssertEx.IsType<EventTelemetry>(telemetrySentToChannel[4]);
+            Assert.AreEqual("Test Event", ((EventTelemetry) telemetrySentToChannel[4]).Name);
+            Assert.AreEqual(false, ((EventTelemetry) telemetrySentToChannel[4]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
 
 
-            AssertEx.IsType<MetricTelemetry>(telemetrySentToChannel[4]);
             AssertEx.IsType<MetricTelemetry>(telemetrySentToChannel[5]);
+            AssertEx.IsType<MetricTelemetry>(telemetrySentToChannel[6]);
 
             Assert.AreEqual(1, telemetrySentToChannel.Where( (t) => "Server response time".Equals((t as MetricTelemetry)?.Name) ).Count());
             Assert.AreEqual(1, telemetrySentToChannel.Where( (t) => "Dependency duration".Equals((t as MetricTelemetry)?.Name) ).Count());
@@ -465,7 +474,7 @@
 
                 client.TrackDependency("", "Test Target", "Test Dependency Call", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(305), "201", success: true);
                 client.TrackDependency(null, "Test Target", "Test Dependency Call", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(310), "202", success: true);
-                client.TrackDependency("Test Dependency Call", "Test Command Name", DateTimeOffset.Now, TimeSpan.FromMilliseconds(315), success: true);
+                client.TrackDependency("", "Test Dependency Call", "Test Command Name", DateTimeOffset.Now, TimeSpan.FromMilliseconds(315), success: true);
 
                 client.TrackDependency("Test Type A", "Test Target", "Test Dependency Call", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(1070), "501", success: false);
                 client.TrackDependency("Test Type A", "Test Target", "Test Dependency Call", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(1180), "502", success: false);
@@ -488,7 +497,7 @@
 
                 client.TrackDependency("", "Test Target", "Test Dependency Call", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(4062), "201", success: false);
                 client.TrackDependency(null, "Test Target", "Test Dependency Call", "Test Data", DateTimeOffset.Now, TimeSpan.FromMilliseconds(4012), "202", success: false);
-                client.TrackDependency("Test Dependency Call", "Test Command Name", DateTimeOffset.Now, TimeSpan.FromMilliseconds(4039), success: false);
+                client.TrackDependency("", "Test Dependency Call", "Test Command Name", DateTimeOffset.Now, TimeSpan.FromMilliseconds(4039), success: false);
             }
 
             //// The following metric documents are expected:

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/AutocollectedMetricsExtractorTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/AutocollectedMetricsExtractorTest.cs
@@ -265,7 +265,7 @@
                 client.TrackEvent("Test Event");
             }
 
-            Assert.AreEqual(6, telemetrySentToChannel.Count);
+            Assert.AreEqual(7, telemetrySentToChannel.Count);
             
             AssertEx.IsType<RequestTelemetry>(telemetrySentToChannel[0]);
             Assert.AreEqual(true, ((RequestTelemetry) telemetrySentToChannel[0]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -427,16 +427,37 @@
         #region TrackDependency
 
         [TestMethod]
+        public void ObsoleteTrackDependencySendsDependencyTelemetryWithGivenNameCommandnameTimestampDurationAndSuccessToTelemetryChannel()
+        {
+            var sentTelemetry = new List<ITelemetry>();
+            TelemetryClient client = this.InitializeTelemetryClient(sentTelemetry);
+
+            var timestamp = DateTimeOffset.Now;
+#pragma warning disable CS0612 // Type or member is obsolete
+            client.TrackDependency("name", "command name", timestamp, TimeSpan.FromSeconds(42), false);
+#pragma warning restore CS0612 // Type or member is obsolete
+
+            var dependency = (DependencyTelemetry)sentTelemetry.Single();
+
+            Assert.AreEqual("name", dependency.Name);
+            Assert.AreEqual("command name", dependency.Data);
+            Assert.AreEqual(timestamp, dependency.Timestamp);
+            Assert.AreEqual(TimeSpan.FromSeconds(42), dependency.Duration);
+            Assert.AreEqual(false, dependency.Success);
+        }
+
+        [TestMethod]
         public void TrackDependencySendsDependencyTelemetryWithGivenNameCommandnameTimestampDurationAndSuccessToTelemetryChannel()
         {
             var sentTelemetry = new List<ITelemetry>();
             TelemetryClient client = this.InitializeTelemetryClient(sentTelemetry);
 
             var timestamp = DateTimeOffset.Now;
-            client.TrackDependency("name", "command name", timestamp, TimeSpan.FromSeconds(42), false);
+            client.TrackDependency("type name", "name", "command name", timestamp, TimeSpan.FromSeconds(42), false);
 
             var dependency = (DependencyTelemetry)sentTelemetry.Single();
 
+            Assert.AreEqual("type name", dependency.Type);
             Assert.AreEqual("name", dependency.Name);
             Assert.AreEqual("command name", dependency.Data);
             Assert.AreEqual(timestamp, dependency.Timestamp);

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -296,30 +296,48 @@
         }
 
         /// <summary>
-        /// Send information about external dependency call in the application.
+        /// Send information about an external dependency (outgoing call) in the application.
         /// </summary>
-        /// <param name="dependencyName">External dependency name.</param>
-        /// <param name="commandName">Dependency call command name.</param>
+        /// <param name="dependencyName">Name of the command initiated with this dependency call. Low cardinality value. Examples are stored procedure name and URL path template.</param>
+        /// <param name="data">Command initiated by this dependency call. Examples are SQL statement and HTTP URL's with all query parameters.</param>
         /// <param name="startTime">The time when the dependency was called.</param>
         /// <param name="duration">The time taken by the external dependency to handle the call.</param>
         /// <param name="success">True if the dependency call was handled successfully.</param>
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackdependency">Learn more</a>
         /// </remarks>
-        public void TrackDependency(string dependencyName, string commandName, DateTimeOffset startTime, TimeSpan duration, bool success)
+        [Obsolete]
+        public void TrackDependency(string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success)
         {
 #pragma warning disable 618
-            this.TrackDependency(new DependencyTelemetry(dependencyName, commandName, startTime, duration, success));
+            this.TrackDependency(new DependencyTelemetry(dependencyName, data, startTime, duration, success));
 #pragma warning restore 618
         }
 
         /// <summary>
-        /// Send information about external dependency call in the application.
+        /// Send information about an external dependency (outgoing call) in the application.
         /// </summary>
-        /// <param name="dependencyTypeName">External dependency type.</param>
+        /// <param name="dependencyTypeName">External dependency type. Very low cardinality value for logical grouping and interpretation of fields. Examples are SQL, Azure table, and HTTP.</param>
+        /// <param name="dependencyName">Name of the command initiated with this dependency call. Low cardinality value. Examples are stored procedure name and URL path template.</param>
+        /// <param name="data">Command initiated by this dependency call. Examples are SQL statement and HTTP URL's with all query parameters.</param>
+        /// <param name="startTime">The time when the dependency was called.</param>
+        /// <param name="duration">The time taken by the external dependency to handle the call.</param>
+        /// <param name="success">True if the dependency call was handled successfully.</param>
+        /// <remarks>
+        /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackdependency">Learn more</a>
+        /// </remarks>
+        public void TrackDependency(string dependencyTypeName, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success)
+        {
+            this.TrackDependency(new DependencyTelemetry(dependencyTypeName, null, dependencyName, data, startTime, duration, null, success));
+        }
+
+        /// <summary>
+        /// Send information about an external dependency (outgoing call) in the application.
+        /// </summary>
+        /// <param name="dependencyTypeName">External dependency type. Very low cardinality value for logical grouping and interpretation of fields. Examples are SQL, Azure table, and HTTP.</param>
         /// <param name="target">External dependency target.</param>
-        /// <param name="dependencyName">External dependency name.</param>
-        /// <param name="data">Dependency call command name.</param>
+        /// <param name="dependencyName">Name of the command initiated with this dependency call. Low cardinality value. Examples are stored procedure name and URL path template.</param>
+        /// <param name="data">Command initiated by this dependency call. Examples are SQL statement and HTTP URL's with all query parameters.</param>
         /// <param name="startTime">The time when the dependency was called.</param>
         /// <param name="duration">The time taken by the external dependency to handle the call.</param>
         /// <param name="resultCode">Result code of dependency call execution.</param>


### PR DESCRIPTION
Fix Issue #684 .
This makes the old shorthand TrackDependency call obsolete, adds a new shorthand with a parameter for setting the type name. It also updates the function intellisense documentation. It also adds/updates unit tests as appropriate.

- [X] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
