### PR TITLE
549 fix auto init modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.6.0-beta3
+- [Fix: TelemetryProcessor chain building should also initialize Modules.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/549)
+
 ## Version 2.6.0-beta2
 - [Changed signature of TelemetryClient.TrackDependency](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/684)
 - [Added overload of TelemetryClientExtensions.StartOperation(Activity activity).] (https://github.com/Microsoft/ApplicationInsights-dotnet/issues/644)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
@@ -103,17 +103,11 @@
 
         private class MockProcessorModule : ITelemetryProcessor, ITelemetryModule
         {
-            public bool ModuleInitialized = false;
+            public bool ModuleInitialized { get; private set; } = false;
 
-            public void Initialize(TelemetryConfiguration configuration)
-            {
-                this.ModuleInitialized = true;
-            }
+            public void Initialize(TelemetryConfiguration configuration) => this.ModuleInitialized = true;
 
-            public void Process(ITelemetry item)
-            {
-                throw new NotImplementedException();
-            }
+            public void Process(ITelemetry item) => throw new NotImplementedException();
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
@@ -10,7 +10,6 @@
 
     [TestClass]
     public class TelemetryProcessorChainBuilderTest
-
     {
         [TestMethod]
         public void NoExceptionOnReturningNullFromUse()
@@ -100,8 +99,6 @@
 
             Assert.IsTrue(tc1.TelemetryProcessors.Count == 2);
             Assert.IsTrue(((MockProcessorModule)tc1.TelemetryProcessors[0]).ModuleInitialized);
-
-            Assert.Inconclusive();
         }
 
         private class MockProcessorModule : ITelemetryProcessor, ITelemetryModule

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
@@ -1,9 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
-    using System;
-    using System.Diagnostics.Tracing;
     using System.Text;
-    using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -99,15 +96,6 @@
 
             Assert.AreEqual(2, tc1.TelemetryProcessors.Count); // Transmission is added by default
             Assert.IsTrue(((MockProcessorModule)tc1.TelemetryProcessors[0]).ModuleInitialized, "Module was not initialized.");
-        }
-
-        private class MockProcessorModule : ITelemetryProcessor, ITelemetryModule
-        {
-            public bool ModuleInitialized { get; private set; } = false;
-
-            public void Initialize(TelemetryConfiguration configuration) => this.ModuleInitialized = true;
-
-            public void Process(ITelemetry item) => throw new NotImplementedException();
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/TelemetryProcessorChainBuilderTest.cs
@@ -97,8 +97,8 @@
             builder1.Use((next) => new MockProcessorModule());
             builder1.Build();
 
-            Assert.IsTrue(tc1.TelemetryProcessors.Count == 2);
-            Assert.IsTrue(((MockProcessorModule)tc1.TelemetryProcessors[0]).ModuleInitialized);
+            Assert.AreEqual(2, tc1.TelemetryProcessors.Count); // Transmission is added by default
+            Assert.IsTrue(((MockProcessorModule)tc1.TelemetryProcessors[0]).ModuleInitialized, "Module was not initialized.");
         }
 
         private class MockProcessorModule : ITelemetryProcessor, ITelemetryModule

--- a/Test/TestFramework/Shared/MockProcessorModule.cs
+++ b/Test/TestFramework/Shared/MockProcessorModule.cs
@@ -1,0 +1,18 @@
+﻿namespace Microsoft.ApplicationInsights.TestFramework
+{
+    using System;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    /// <summary>
+    /// Mock class that implements both ITelemetryProcessor and ITelemetryModule.
+    /// </summary>
+    internal class MockProcessorModule : ITelemetryProcessor, ITelemetryModule
+    {
+        public bool ModuleInitialized { get; private set; } = false;
+
+        public void Initialize(TelemetryConfiguration configuration) => this.ModuleInitialized = true;
+
+        public void Process(ITelemetry item) => throw new NotImplementedException();
+    }
+}

--- a/Test/TestFramework/Shared/TestFramework.Shared.projitems
+++ b/Test/TestFramework/Shared/TestFramework.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AsyncTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeterministicTaskScheduler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventSourceTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)MockProcessorModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubSynchronizationContext.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubTelemetry.cs" />

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
@@ -97,11 +97,11 @@
             }
 
             // Check that all Processors that implement ITelemtryModule are also Initialized
-            var telemetryProcessors = this.telemetrySink == null ? this.configuration.TelemetryProcessors : this.telemetrySink.TelemetryProcessors;
-            foreach (var module in telemetryProcessors.OfType<ITelemetryModule>())
-            {
-                module.Initialize(this.configuration);
-            }
+            ////var telemetryProcessors = this.telemetrySink == null ? this.configuration.TelemetryProcessors : this.telemetrySink.TelemetryProcessors;
+            ////foreach (var module in telemetryProcessors.OfType<ITelemetryModule>())
+            ////{
+            ////    module.Initialize(this.configuration);
+            ////}
             
             // Save changes to the TelemetryProcessorChain
             var telemetryProcessorChain = new TelemetryProcessorChain(telemetryProcessorsList.AsEnumerable().Reverse());

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Shared.Extensibility.Implementation;
 
     /// <summary>
@@ -98,7 +99,14 @@
                 // If a Processor also implements ITelemtryModule, We should Initialize that Module
                 if (linkedTelemetryProcessor is ITelemetryModule telemetryModule)
                 {
-                    telemetryModule.Initialize(this.configuration);
+                    try
+                    {
+                        telemetryModule.Initialize(this.configuration);
+                    }
+                    catch (Exception ex)
+                    {
+                        CoreEventSource.Log.ComponentInitializationConfigurationError(telemetryModule.ToString(), ex.ToInvariantString());
+                    }
                 }
             }
             

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChainBuilder.cs
@@ -94,14 +94,13 @@
                 }
 
                 telemetryProcessorsList.Add(linkedTelemetryProcessor);
-            }
 
-            // Check that all Processors that implement ITelemtryModule are also Initialized
-            ////var telemetryProcessors = this.telemetrySink == null ? this.configuration.TelemetryProcessors : this.telemetrySink.TelemetryProcessors;
-            ////foreach (var module in telemetryProcessors.OfType<ITelemetryModule>())
-            ////{
-            ////    module.Initialize(this.configuration);
-            ////}
+                // If a Processor also implements ITelemtryModule, We should Initialize that Module
+                if (linkedTelemetryProcessor is ITelemetryModule telemetryModule)
+                {
+                    telemetryModule.Initialize(this.configuration);
+                }
+            }
             
             // Save changes to the TelemetryProcessorChain
             var telemetryProcessorChain = new TelemetryProcessorChain(telemetryProcessorsList.AsEnumerable().Reverse());


### PR DESCRIPTION
Fix Issue #549 .
When `TelemetryProcessorChainBuilder` rebuilds Processors, 
Processors that implement `ITelemetryModule` may not get initialized via this workflow.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
