### PR TITLE
New Config Property: Override ApplicationInsight's Service Endpoint Address

### DIFF
--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.ApplicationInsightsEndpointBaseAddress.set -> void
+Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.GetApplicationInsightsEndpointBaseUri() -> System.Uri
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatPropertyProviders.get -> System.Collections.Generic.IList<string>

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.ApplicationInsightsEndpointBaseAddress.set -> void
+Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.GetApplicationInsightsEndpointBaseUri() -> System.Uri
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatPropertyProviders.get -> System.Collections.Generic.IList<string>

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -1,3 +1,5 @@
+Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.ApplicationInsightsEndpointBaseAddress.set -> void
+Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.GetApplicationInsightsEndpointBaseUri() -> System.Uri
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.AddHeartbeatProperty(string propertyName, string propertyValue, bool isHealthy) -> bool
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatProperties.get -> System.Collections.Generic.IList<string>
 Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule.ExcludedHeartbeatPropertyProviders.get -> System.Collections.Generic.IList<string>

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetrySerializerTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/TelemetrySerializerTest.cs
@@ -32,14 +32,14 @@
             public void DefaultValuePointsToModernEndpointInProductionEnvironment()
             {
                 var serializer = new TelemetrySerializer(new StubTransmitter());
-                Assert.AreEqual("https://dc.services.visualstudio.com/v2/track", serializer.EndpointAddress.ToString());
+                Assert.AreEqual("https://dc.services.visualstudio.com/v2/track", serializer.ServerTelemetryChannelEndpointAddress.ToString());
             }
 
             [TestMethod]
             public void SetterThrowsArgumentNullExceptionToPreventUsageErrors()
             {
                 var serializer = new TelemetrySerializer(new StubTransmitter());
-                AssertEx.Throws<ArgumentNullException>(() => serializer.EndpointAddress = null);
+                AssertEx.Throws<ArgumentNullException>(() => serializer.ServerTelemetryChannelEndpointAddress = null);
             }
 
             [TestMethod]
@@ -47,8 +47,8 @@
             {
                 var serializer = new TelemetrySerializer(new StubTransmitter());
                 var expectedValue = new Uri("int://environment");
-                serializer.EndpointAddress = expectedValue;
-                Assert.AreEqual(expectedValue, serializer.EndpointAddress);
+                serializer.ServerTelemetryChannelEndpointAddress = expectedValue;
+                Assert.AreEqual(expectedValue, serializer.ServerTelemetryChannelEndpointAddress);
             }
         }
 
@@ -95,10 +95,10 @@
                     transmission = t;
                 };
         
-                var serializer = new TelemetrySerializer(transmitter) { EndpointAddress = new Uri("http://expected.uri") };
+                var serializer = new TelemetrySerializer(transmitter) { ServerTelemetryChannelEndpointAddress = new Uri("http://expected.uri") };
                 serializer.Serialize(new[] { new StubTelemetry() });
         
-                Assert.AreEqual(serializer.EndpointAddress, transmission.EndpointAddress);
+                Assert.AreEqual(serializer.ServerTelemetryChannelEndpointAddress, transmission.EndpointAddress);
                 Assert.AreEqual("application/x-json-stream", transmission.ContentType);
                 Assert.AreEqual("gzip", transmission.ContentEncoding);
                 Assert.AreEqual(string.Empty, Unzip(transmission.Content));

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelTest.cs
@@ -143,7 +143,7 @@
                 Uri expectedEndpoint = new Uri("http://abc.com");
                 channel.EndpointAddress = expectedEndpoint.AbsoluteUri;
                 
-                Assert.AreEqual(expectedEndpoint, channel.TelemetrySerializer.EndpointAddress);
+                Assert.AreEqual(expectedEndpoint, channel.TelemetrySerializer.ServerTelemetryChannelEndpointAddress);
             }
         }
 

--- a/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
+++ b/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
@@ -90,8 +90,8 @@
         /// </summary>
         public string EndpointAddress
         {
-            get { return this.transmitter.EndpointAddress.ToString(); }
-            set { this.transmitter.EndpointAddress = new Uri(value); }
+            get { return this.transmitter.InMemoryChannelEndpointAddress.ToString(); }
+            set { this.transmitter.InMemoryChannelEndpointAddress = new Uri(value); }
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Constants.cs
+++ b/src/Microsoft.ApplicationInsights/Constants.cs
@@ -2,8 +2,6 @@
 {
     internal class Constants
     {
-        internal const string TelemetryServiceEndpoint = "https://dc.services.visualstudio.com/v2/track";
-
         internal const string TelemetryNamePrefix = "Microsoft.ApplicationInsights.";
 
         internal const string DevModeTelemetryNamePrefix = "Microsoft.ApplicationInsights.Dev.";

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -31,6 +31,8 @@
         private TelemetryProcessorChainBuilder builder;
         private SnapshottingList<IMetricProcessor> metricProcessors = new SnapshottingList<IMetricProcessor>();
 
+        private Uri endpointProxyBaseUri = null;
+
         /// <summary>
         /// Indicates if this instance has been disposed of.
         /// </summary>
@@ -127,6 +129,23 @@
                 }
 
                 this.instrumentationKey = value;
+            }
+        }
+
+        /// <summary>
+        /// Sets an override to "https://dc.services.visualstudio.com".
+        /// All of our internal services will construct the full endpoint address starting with this base address.
+        /// </summary>
+        public string ApplicationInsightsEndpointBaseAddress
+        {
+            set
+            {
+                if (value == null)
+                {
+                    throw new ArgumentNullException("value");
+                }
+
+                this.endpointProxyBaseUri = new Uri(value);
             }
         }
 
@@ -296,6 +315,14 @@
             var configuration = new TelemetryConfiguration();
             TelemetryConfigurationFactory.Instance.Initialize(configuration, null, config);
             return configuration;
+        }
+
+        /// <summary>
+        /// Gets the endpoint that is to be used to get the application insights resource's profile (appId etc.).
+        /// </summary>
+        public Uri GetApplicationInsightsEndpointBaseUri()
+        {
+            return this.endpointProxyBaseUri;
         }
 
         /// <summary>

--- a/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
+++ b/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
@@ -113,8 +113,8 @@
         /// </summary>
         public string EndpointAddress
         {
-            get { return this.TelemetrySerializer.EndpointAddress.ToString(); }
-            set { this.TelemetrySerializer.EndpointAddress = new Uri(value); }
+            get { return this.TelemetrySerializer.ServerTelemetryChannelEndpointAddress.ToString(); }
+            set { this.TelemetrySerializer.ServerTelemetryChannelEndpointAddress = new Uri(value); }
         }
 
         /// <summary>


### PR DESCRIPTION
**Fix Issue**: https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/853

Currently, we do not offer users a friendly way to override both 
`dc.services.visualstudio.com/v2/track` and `dc.services.visualstudio.com/api/profiles`
Used by our classes `InMemoryTelemetryChannel`, `ServerTelemetryChannel`, and `CorrelationIdLookupHelper`.

Add new root level config property **"ApplicationInsightsEndpointBaseAddress"**
This new root level config will allow users to override the BASE ENDPOINT `dc.services.visualstudio.com`.
If this has been overridden, our classes will append their relative paths to this config value.
The theory is that users should not be expected to know every possible service call we could make and override those individually.

To protect backward compatibility, the `ITelemetryChannel.EndpointAddress` property will remain unchanged and take precedence over this root config value.

Order of precedence will be: Prop > Config > Default

To discourage 3rd party TelemetryChannels from using this property, this config property has been given an "ApplicationInsights" name.


These documents will need to be updated to address this new config property:

- [Microsoft Docs: "IP Addressed used by Application Insights"](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-ip-addresses)
- [Microsoft Docs: "Application Insights - Proxy"](https://docs.microsoft.com/en-us/azure/application-insights/app-insights-troubleshoot-faq#proxy)



----------

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
