### PR TITLE
Rename identifiers for v1 Metric Manager feature to avoid confusion with v2 Metric Manager features.

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/MetricManagerV1Test.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/MetricManagerV1Test.cs
@@ -11,7 +11,7 @@
     
 
     [TestClass]
-    public class MetricManagerTest
+    public class MetricManagerV1Test
     {
         [TestMethod]
         public void CanCreateMetricHavingNoDimensions()
@@ -20,10 +20,10 @@
             var sentTelemetry = new List<ITelemetry>();
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
                 // Act
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
                 metric.Track(42);
             }
 
@@ -47,10 +47,10 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
                 // Act
-                Metric metric = manager.CreateMetric("Test Metric", null);
+                MetricV1 metric = manager.CreateMetric("Test Metric", null);
                 metric.Track(42);
             }
 
@@ -79,10 +79,10 @@
                 { "Dim2", "Value2"}
             };
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
                 // Act
-                Metric metric = manager.CreateMetric("Test Metric", dimensions);
+                MetricV1 metric = manager.CreateMetric("Test Metric", dimensions);
                 metric.Track(42);
             }
 
@@ -108,9 +108,9 @@
             var sentTelemetry = new List<ITelemetry>();
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 metric.Track(42);
@@ -134,9 +134,9 @@
             var sentTelemetry = new List<ITelemetry>();
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 metric.Track(42);
@@ -162,10 +162,10 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
 
-            Metric metric1 = null;
-            Metric metric2 = null;
+            MetricV1 metric1 = null;
+            MetricV1 metric2 = null;
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
                 // note: on first go aggregators may be different because manager may
                 // snapshot after first got created but before the second
@@ -203,9 +203,9 @@
         [TestMethod]
         public void CanDisposeMetricManagerMultipleTimes()
         {
-            MetricManager manager = null;
+            MetricManagerV1 manager = null;
 
-            using (manager = new MetricManager()) { }
+            using (manager = new MetricManagerV1()) { }
 
             //Assert.DoesNotThrow
             manager.Dispose();
@@ -218,9 +218,9 @@
             var sentTelemetry = new List<ITelemetry>();
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 metric.Track(42);
 
@@ -242,9 +242,9 @@
             var sentTelemetry = new List<ITelemetry>();
 
             var client = this.InitializeTelemetryClient(sentTelemetry);
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 metric.Track(42);
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/MetricV1Test.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/MetricV1Test.cs
@@ -11,7 +11,7 @@
     
 
     [TestClass]
-    public class MetricTest
+    public class MetricV1Test
     {
         [TestMethod]
         public void MetricInvokesMetricProcessorsForEachValueTracked()
@@ -27,9 +27,9 @@
                 { "Dim2", "Value2"}
             };
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric", dimensions);
+                MetricV1 metric = manager.CreateMetric("Test Metric", dimensions);
 
                 // Act
                 metric.Track(42);
@@ -57,9 +57,9 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry, sentSamples);
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 for (int i = 0; i < testValues.Length; i++)
@@ -89,9 +89,9 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry, sentSamples);
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 for (int i = 0; i < testValues.Length; i++)
@@ -121,9 +121,9 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry, sentSamples);
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 for (int i = 0; i < testValues.Length; i++)
@@ -153,9 +153,9 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry, sentSamples);
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 for (int i = 0; i < testValues.Length; i++)
@@ -185,9 +185,9 @@
 
             var client = this.InitializeTelemetryClient(sentTelemetry, sentSamples);
 
-            using (MetricManager manager = new MetricManager(client))
+            using (MetricManagerV1 manager = new MetricManagerV1(client))
             {
-                Metric metric = manager.CreateMetric("Test Metric");
+                MetricV1 metric = manager.CreateMetric("Test Metric");
 
                 // Act
                 for (int i = 0; i < testValues.Length; i++)
@@ -228,9 +228,9 @@
         [TestMethod]
         public void MetricNeverEqualsNull()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric");
+                MetricV1 metric = manager.CreateMetric("My metric");
                 object other = null;
 
                 Assert.IsFalse(metric.Equals(other));
@@ -240,9 +240,9 @@
         [TestMethod]
         public void MetricEqualsItself()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric");
+                MetricV1 metric = manager.CreateMetric("My metric");
 
                 Assert.IsTrue(metric.Equals(metric));
             }
@@ -251,9 +251,9 @@
         [TestMethod]
         public void MetricNotEqualsOtherObject()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric");
+                MetricV1 metric = manager.CreateMetric("My metric");
                 var other = new object();
 
                 Assert.IsFalse(metric.Equals(other));
@@ -263,10 +263,10 @@
         [TestMethod]
         public void MetricsAreEqualForTheSameMetricNameWithoutDimensions()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric");
-                Metric other = manager.CreateMetric("My metric");
+                MetricV1 metric = manager.CreateMetric("My metric");
+                MetricV1 other = manager.CreateMetric("My metric");
 
                 Assert.IsTrue(metric.Equals(other));
             }
@@ -275,10 +275,10 @@
         [TestMethod]
         public void MetricNameIsCaseSensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric");
-                Metric other = manager.CreateMetric("My Metric");
+                MetricV1 metric = manager.CreateMetric("My metric");
+                MetricV1 other = manager.CreateMetric("My Metric");
 
                 Assert.IsFalse(metric.Equals(other));
             }
@@ -287,10 +287,10 @@
         [TestMethod]
         public void MetricNameIsAccentSensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric");
-                Metric other = manager.CreateMetric("My métric");
+                MetricV1 metric = manager.CreateMetric("My metric");
+                MetricV1 other = manager.CreateMetric("My métric");
 
                 Assert.IsFalse(metric.Equals(other));
             }
@@ -299,10 +299,10 @@
         [TestMethod]
         public void MetricsAreEqualIfDimensionsSetToNothingImplicitlyAndExplicitly()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric", null);
-                Metric other = manager.CreateMetric("My metric");
+                MetricV1 metric = manager.CreateMetric("My metric", null);
+                MetricV1 other = manager.CreateMetric("My metric");
 
                 Assert.IsTrue(metric.Equals(other));
             }
@@ -311,10 +311,10 @@
         [TestMethod]
         public void MetricsAreEqualIfDimensionsSetToNothingImplicitlyAndExplicitlyAsEmptySet()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
-                Metric metric = manager.CreateMetric("My metric", new Dictionary<string, string>());
-                Metric other = manager.CreateMetric("My metric");
+                MetricV1 metric = manager.CreateMetric("My metric", new Dictionary<string, string>());
+                MetricV1 other = manager.CreateMetric("My metric");
 
                 Assert.IsTrue(metric.Equals(other));
             }
@@ -323,7 +323,7 @@
         [TestMethod]
         public void DimensionsAreOrderInsensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
                 var dimensionSet1 = new Dictionary<string, string>() {
                     { "Dim1", "Value1"},
@@ -335,8 +335,8 @@
                     { "Dim1", "Value1"},
                 };
 
-                Metric metric = manager.CreateMetric("My metric", dimensionSet1);
-                Metric other = manager.CreateMetric("My metric", dimensionSet2);
+                MetricV1 metric = manager.CreateMetric("My metric", dimensionSet1);
+                MetricV1 other = manager.CreateMetric("My metric", dimensionSet2);
 
                 Assert.IsTrue(metric.Equals(other));
             }
@@ -345,13 +345,13 @@
         [TestMethod]
         public void DimensionNamesAreCaseSensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
                 var dimensionSet1 = new Dictionary<string, string>() { { "Dim1", "Value1" } };
                 var dimensionSet2 = new Dictionary<string, string>() { { "dim1", "Value1" } };
 
-                Metric metric = manager.CreateMetric("My metric", dimensionSet1);
-                Metric other = manager.CreateMetric("My metric", dimensionSet2);
+                MetricV1 metric = manager.CreateMetric("My metric", dimensionSet1);
+                MetricV1 other = manager.CreateMetric("My metric", dimensionSet2);
 
                 Assert.IsFalse(metric.Equals(other));
             }
@@ -360,13 +360,13 @@
         [TestMethod]
         public void DimensionNamesAreAccentSensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
                 var dimensionSet1 = new Dictionary<string, string>() { { "Dim1", "Value1" } };
                 var dimensionSet2 = new Dictionary<string, string>() { { "Dím1", "Value1" } };
 
-                Metric metric = manager.CreateMetric("My metric", dimensionSet1);
-                Metric other = manager.CreateMetric("My metric", dimensionSet2);
+                MetricV1 metric = manager.CreateMetric("My metric", dimensionSet1);
+                MetricV1 other = manager.CreateMetric("My metric", dimensionSet2);
 
                 Assert.IsFalse(metric.Equals(other));
             }
@@ -375,13 +375,13 @@
         [TestMethod]
         public void DimensionValuesAreCaseSensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
                 var dimensionSet1 = new Dictionary<string, string>() { { "Dim1", "Value1" } };
                 var dimensionSet2 = new Dictionary<string, string>() { { "Dim1", "value1" } };
 
-                Metric metric = manager.CreateMetric("My metric", dimensionSet1);
-                Metric other = manager.CreateMetric("My metric", dimensionSet2);
+                MetricV1 metric = manager.CreateMetric("My metric", dimensionSet1);
+                MetricV1 other = manager.CreateMetric("My metric", dimensionSet2);
 
                 Assert.IsFalse(metric.Equals(other));
             }
@@ -390,13 +390,13 @@
         [TestMethod]
         public void DimensionValuesAreAccentSensitive()
         {
-            using (var manager = new MetricManager())
+            using (var manager = new MetricManagerV1())
             {
                 var dimensionSet1 = new Dictionary<string, string>() { { "Dim1", "Value1" } };
                 var dimensionSet2 = new Dictionary<string, string>() { { "Dim1", "Válue1" } };
 
-                Metric metric = manager.CreateMetric("My metric", dimensionSet1);
-                Metric other = manager.CreateMetric("My metric", dimensionSet2);
+                MetricV1 metric = manager.CreateMetric("My metric", dimensionSet1);
+                MetricV1 other = manager.CreateMetric("My metric", dimensionSet2);
 
                 Assert.IsFalse(metric.Equals(other));
             }
@@ -409,7 +409,7 @@
             var channel = new StubTelemetryChannel { OnSend = t => sentTelemetry.Add(t) };
 
             var telemetryConfiguration = new TelemetryConfiguration(Guid.NewGuid().ToString(), channel);
-            telemetryConfiguration.MetricProcessors.Add(new StubMetricProcessor(sentSamples));
+            telemetryConfiguration.MetricProcessors.Add(new StubMetricProcessorV1(sentSamples));
 
             var client = new TelemetryClient(telemetryConfiguration);
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/StubMetricProcessorV1.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/StubMetricProcessorV1.cs
@@ -3,11 +3,11 @@
     using System;
     using System.Collections.Generic;
 
-    internal class StubMetricProcessor : IMetricProcessor
+    internal class StubMetricProcessorV1 : IMetricProcessorV1
     {
         private IList<MetricSample> sampleList;
 
-        public StubMetricProcessor(IList<MetricSample> sampleList)
+        public StubMetricProcessorV1(IList<MetricSample> sampleList)
         {
             if (sampleList == null)
             {
@@ -17,7 +17,7 @@
             this.sampleList = sampleList;
         }
 
-        public void Track(Metric metric, double value)
+        public void Track(MetricV1 metric, double value)
         {
             this.sampleList.Add(
                 new MetricSample()

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
@@ -348,7 +348,7 @@
         public void MetricPrcessorsReturnsThreadSafeList()
         {		
             var configuration = new TelemetryConfiguration();		
-            Assert.AreEqual(typeof(SnapshottingList<IMetricProcessor>), configuration.MetricProcessors.GetType());		
+            Assert.AreEqual(typeof(SnapshottingList<IMetricProcessorV1>), configuration.MetricProcessors.GetType());		
         }		
 		
         #endregion

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Microsoft.ApplicationInsights.Shared.Tests.projitems
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Microsoft.ApplicationInsights.Shared.Tests.projitems
@@ -36,9 +36,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\ExtensionsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\HeartbeatTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\Mocks\HeartbeatProviderMock.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\MetricManagerTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\MetricManagerV1Test.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\MetricSample.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\MetricTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\MetricV1Test.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\AutocollectedMetricsExtractorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\OperationCorrelationTelemetryInitializerTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\SequencePropertyInitializerTest.cs" />
@@ -75,7 +75,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Tracing\ThreadResourceLockTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\UserContextTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\WeakConcurrentRandomTests.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\StubMetricProcessor.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Extensibility\StubMetricProcessorV1.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TelemetryConfigurationFactoryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TelemetryConfigurationTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\TelemetrySinkTests.cs" />

--- a/src/Microsoft.ApplicationInsights/Extensibility/AutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/AutocollectedMetricsExtractor.cs
@@ -25,7 +25,7 @@
     /// they want from any kind of telemetry. 
     /// This extractor contains several implementations of the (internal) <c>ISpecificAutocollectedMetricsExtractor</c>-interface to which
     /// it delegates the aggregation of particular metrics. All those implementations share the
-    /// same <see cref="Microsoft.ApplicationInsights.Extensibility.MetricManager"/>-instance for metric aggregation.
+    /// same <see cref="Microsoft.ApplicationInsights.Extensibility.MetricManagerV1"/>-instance for metric aggregation.
     /// </summary>
     public sealed class AutocollectedMetricsExtractor : ITelemetryProcessor, ITelemetryModule, IDisposable
     {
@@ -43,11 +43,11 @@
         /// Gets the metric manager that owns all extracted metric data series.
         /// The <c>MetricManager</c> allows participating extractors to access the <c>Microsoft.ApplicationInsights.Extensibility.MetricManager</c> instance
         /// that aggregates all metrics to be extracted. Participants should call
-        /// <see cref="MetricManager.CreateMetric(string, System.Collections.Generic.IDictionary{string, string})"/> on
+        /// <see cref="MetricManagerV1.CreateMetric(string, System.Collections.Generic.IDictionary{string, string})"/> on
         /// this instance for construction of all data series to be extracted from telemetry. This will ensure that all metric documents are
         /// aggregated and tagged correctly and are processed using the <see cref="TelemetryConfiguration"/> instance used to initialize this extractor.
         /// </summary>
-        private MetricManager metricManager = null;
+        private MetricManagerV1 metricManager = null;
 
         /// <summary>
         /// The telemetry processor that will be called after this processor.
@@ -98,7 +98,7 @@
         /// This class implements the <see cref="ITelemetryModule"/> interface by defining this method.
         /// It will be called by the infrastructure when the telemetry pipeline is being built.
         /// This will ensure that the extractor is initialized using the same <see cref="TelemetryConfiguration"/> as the rest of the pipeline.
-        /// Specifically, this will also ensure that the <see cref="Microsoft.ApplicationInsights.Extensibility.MetricManager"/> and its
+        /// Specifically, this will also ensure that the <see cref="Microsoft.ApplicationInsights.Extensibility.MetricManagerV1"/> and its
         /// respective <see cref="TelemetryClient"/> used internally for sending extracted metrics use the same configuration.
         /// </summary>
         /// <param name="configuration">The telemetric configuration to be used by this extractor.</param>
@@ -113,7 +113,7 @@
                 telemetryClient.Context.Properties[MetricTerms.Autocollection.Moniker.Key] = MetricTerms.Autocollection.Moniker.Value;
             }
 
-            this.metricManager = new MetricManager(telemetryClient);
+            this.metricManager = new MetricManagerV1(telemetryClient);
             this.InitializeExtractors();
         }
 
@@ -216,7 +216,7 @@
         /// </summary>
         private void InitializeExtractors()
         {
-            MetricManager thisMetricManager = this.metricManager;
+            MetricManagerV1 thisMetricManager = this.metricManager;
 
             foreach (ExtractorWithInfo participant in this.extractors)
             {

--- a/src/Microsoft.ApplicationInsights/Extensibility/IMetricProcessorV1.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/IMetricProcessorV1.cs
@@ -3,13 +3,13 @@
     /// <summary>
     /// Provides functionality to process metric values prior to aggregation.
     /// </summary>
-    internal interface IMetricProcessor
+    internal interface IMetricProcessorV1
     {
         /// <summary>
         /// Process metric value.
         /// </summary>
         /// <param name="metric">Metric definition.</param>
         /// <param name="value">Metric value.</param>
-        void Track(Metric metric, double value);
+        void Track(MetricV1 metric, double value);
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/DependencyMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/DependencyMetricsExtractor.cs
@@ -40,7 +40,7 @@
         /// <summary>
         /// The <c>MetricManager</c> to be used for creating and sending the metrics by this extractor.
         /// </summary>
-        private MetricManager metricManager = null;
+        private MetricManagerV1 metricManager = null;
 
         /// <summary>
         /// Groups privates to ensure atomic updates via replacements.
@@ -97,7 +97,7 @@
         /// Initializes the internal metrics trackers based on settings.
         /// </summary>
         /// <param name="metricManager">The <c>MetricManager</c> to be used for creating and sending the metrics by this extractor.</param>
-        public void InitializeExtractor(MetricManager metricManager)
+        public void InitializeExtractor(MetricManagerV1 metricManager)
         {
             this.metricManager = metricManager;
             this.ReinitializeMetrics(this.metrics?.MaxDependencyTypesToDiscover ?? MaxDependenctTypesToDiscoverDefault);
@@ -118,7 +118,7 @@
                 return;
             }
 
-            MetricManager thisMetricManager = this.metricManager;
+            MetricManagerV1 thisMetricManager = this.metricManager;
             MetricsCache thisMetrics = this.metrics;
 
             //// If there is no MetricManager, then this extractor has not been properly initialized yet:
@@ -132,7 +132,7 @@
             bool dependencyFailed = (dependencyCall.Success != null) && (dependencyCall.Success == false);
 
             //// Now we need to determine which data series to use:
-            Metric metricToTrack = null;
+            MetricV1 metricToTrack = null;
 
             if (thisMetrics.MaxDependencyTypesToDiscover == 0)
             {
@@ -255,7 +255,7 @@
         /// <param name="maxDependencyTypesToDiscoverCount">Max number of Dependency Types to discover.</param>
         private void ReinitializeMetrics(int maxDependencyTypesToDiscoverCount)
         {
-            MetricManager thisMetricManager = this.metricManager;
+            MetricManagerV1 thisMetricManager = this.metricManager;
             if (thisMetricManager == null)
             {
                 MetricsCache newMetrics = new MetricsCache()
@@ -353,15 +353,15 @@
             {
             }
 
-            public SucceessAndFailureMetrics(Metric successMetric, Metric failureMetric)
+            public SucceessAndFailureMetrics(MetricV1 successMetric, MetricV1 failureMetric)
             {
                 this.Success = successMetric;
                 this.Failure = failureMetric;
             }
 
-            public Metric Success { get; private set; }
+            public MetricV1 Success { get; private set; }
 
-            public Metric Failure { get; private set; }
+            public MetricV1 Failure { get; private set; }
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/ISpecificAutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/ISpecificAutocollectedMetricsExtractor.cs
@@ -25,7 +25,7 @@
         /// Pre-initialize this extractor.
         /// </summary>
         /// <param name="metricManager">The manager to be used for aggregation.</param>
-        void InitializeExtractor(MetricManager metricManager);
+        void InitializeExtractor(MetricManagerV1 metricManager);
 
         /// <summary>
         /// Perform actual metric data point extraction from the specified item.

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/RequestMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/RequestMetricsExtractor.cs
@@ -13,8 +13,8 @@
     /// </summary>
     internal class RequestMetricsExtractor : ISpecificAutocollectedMetricsExtractor
     {
-        private Metric responseSuccessTimeMetric;
-        private Metric responseFailureTimeMetric;
+        private MetricV1 responseSuccessTimeMetric;
+        private MetricV1 responseFailureTimeMetric;
 
         public RequestMetricsExtractor()
         {
@@ -24,7 +24,7 @@
 
         public string ExtractorVersion { get; } = "1.0";
 
-        public void InitializeExtractor(MetricManager metricManager)
+        public void InitializeExtractor(MetricManagerV1 metricManager)
         {
             this.responseSuccessTimeMetric = metricManager.CreateMetric(
                     MetricTerms.Autocollection.Metric.RequestDuration.Name,
@@ -56,7 +56,7 @@
                                 ? (request.Success.Value == false)
                                 : false;
 
-            Metric metric = isFailed
+            MetricV1 metric = isFailed
                                 ? this.responseFailureTimeMetric
                                 : this.responseSuccessTimeMetric;
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/MetricManagerV1.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/MetricManagerV1.cs
@@ -18,7 +18,7 @@
     /// Metric factory and controller. Sends metrics to Application Insights service. Pre-aggregates metrics to reduce bandwidth.
     /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#send-metrics">Learn more</a>
     /// </summary>
-    internal sealed class MetricManager : IDisposable
+    internal sealed class MetricManagerV1 : IDisposable
     {
         /// <summary>
         /// Value of the property indicating 'app insights version' allowing to tell metric was built using metric manager.
@@ -48,25 +48,25 @@
         /// <summary>
         /// A dictionary of all metrics instantiated via this manager.
         /// </summary>
-        private ConcurrentDictionary<Metric, SimpleMetricStatisticsAggregator> metricDictionary;
+        private ConcurrentDictionary<MetricV1, SimpleMetricStatisticsAggregator> metricDictionary;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MetricManager"/> class.
+        /// Initializes a new instance of the <see cref="MetricManagerV1"/> class.
         /// </summary>
-        public MetricManager()
+        public MetricManagerV1()
             : this(new TelemetryClient())
         {
         }
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="MetricManager"/> class.
+        /// Initializes a new instance of the <see cref="MetricManagerV1"/> class.
         /// </summary>
         /// <param name="client">Telemetry client to use to output aggregated metric data.</param>
-        public MetricManager(TelemetryClient client)
+        public MetricManagerV1(TelemetryClient client)
         {
             this.telemetryClient = client ?? new TelemetryClient();
 
-            this.metricDictionary = new ConcurrentDictionary<Metric, SimpleMetricStatisticsAggregator>();
+            this.metricDictionary = new ConcurrentDictionary<MetricV1, SimpleMetricStatisticsAggregator>();
 
             this.lastSnapshotStartDateTime = DateTimeOffset.UtcNow;
 
@@ -76,9 +76,9 @@
 
         /// <summary>
         /// Gets a list of metric processors associated
-        /// with this instance of <see cref="MetricManager"/>.
+        /// with this instance of <see cref="MetricManagerV1"/>.
         /// </summary>
-        internal IList<IMetricProcessor> MetricProcessors
+        internal IList<IMetricProcessorV1> MetricProcessors
         {
             get
             {
@@ -97,9 +97,9 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#send-metrics">Learn more</a>
         /// </remarks>
-        public Metric CreateMetric(string name, IDictionary<string, string> dimensions = null)
+        public MetricV1 CreateMetric(string name, IDictionary<string, string> dimensions = null)
         {
-            return new Metric(this, name, dimensions);
+            return new MetricV1(this, name, dimensions);
         }
 
         /// <summary>
@@ -127,7 +127,7 @@
             this.Flush();
         }
 
-        internal SimpleMetricStatisticsAggregator GetStatisticsAggregator(Metric metric)
+        internal SimpleMetricStatisticsAggregator GetStatisticsAggregator(MetricV1 metric)
         {
             return this.metricDictionary.GetOrAdd(metric, (m) => { return new SimpleMetricStatisticsAggregator(); });
         }
@@ -161,7 +161,7 @@
         /// <param name="metric">Metric definition.</param>
         /// <param name="statistics">Metric aggregator statistics calculated for a period of time.</param>
         /// <returns>Metric telemetry object resulting from aggregation.</returns>
-        private static MetricTelemetry CreateAggregatedMetricTelemetry(Metric metric, SimpleMetricStatisticsAggregator statistics)
+        private static MetricTelemetry CreateAggregatedMetricTelemetry(MetricV1 metric, SimpleMetricStatisticsAggregator statistics)
         {
             var telemetry = new MetricTelemetry(
                 metric.Name,
@@ -216,8 +216,8 @@
         /// </summary>
         private void Snapshot()
         {
-            ConcurrentDictionary<Metric, SimpleMetricStatisticsAggregator> aggregatorSnapshot =
-                Interlocked.Exchange(ref this.metricDictionary, new ConcurrentDictionary<Metric, SimpleMetricStatisticsAggregator>());
+            ConcurrentDictionary<MetricV1, SimpleMetricStatisticsAggregator> aggregatorSnapshot =
+                Interlocked.Exchange(ref this.metricDictionary, new ConcurrentDictionary<MetricV1, SimpleMetricStatisticsAggregator>());
 
             // calculate aggregation interval duration interval
             TimeSpan aggregationIntervalDuation = DateTimeOffset.UtcNow - this.lastSnapshotStartDateTime;
@@ -239,7 +239,7 @@
 
             if (aggregatorSnapshot.Count > 0)
             {
-                foreach (KeyValuePair<Metric, SimpleMetricStatisticsAggregator> aggregatorWithStats in aggregatorSnapshot)
+                foreach (KeyValuePair<MetricV1, SimpleMetricStatisticsAggregator> aggregatorWithStats in aggregatorSnapshot)
                 {
                     if (aggregatorWithStats.Value.Count > 0)
                     { 

--- a/src/Microsoft.ApplicationInsights/Extensibility/MetricV1.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/MetricV1.cs
@@ -12,12 +12,12 @@
     /// <summary>
     /// Represents aggregator for a single time series of a given metric.
     /// </summary>
-    internal class Metric : IEquatable<Metric>
+    internal class MetricV1 : IEquatable<MetricV1>
     {
         /// <summary>
         /// Aggregator manager for the aggregator.
         /// </summary>
-        private readonly MetricManager manager;
+        private readonly MetricManagerV1 manager;
 
         /// <summary>
         /// Metric aggregator id to look for in the aggregator dictionary.
@@ -30,13 +30,13 @@
         private readonly int hashCode;
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="Metric"/> class.
+        /// Initializes a new instance of the <see cref="MetricV1"/> class.
         /// </summary>
         /// <param name="manager">Aggregator manager handling this instance.</param>
         /// <param name="name">Metric name.</param>
         /// <param name="dimensions">Metric dimensions.</param>
-        internal Metric(
-            MetricManager manager,
+        internal MetricV1(
+            MetricManagerV1 manager,
             string name, 
             IDictionary<string, string> dimensions = null)
         {
@@ -49,7 +49,7 @@
             this.Name = name;
             this.Dimensions = dimensions;
 
-            this.aggregatorId = Metric.GetAggregatorId(name, dimensions);
+            this.aggregatorId = MetricV1.GetAggregatorId(name, dimensions);
             this.hashCode = this.aggregatorId.GetHashCode();
         }
 
@@ -89,7 +89,7 @@
         /// </summary>
         /// <param name="other">The object to compare with the current object. </param>
         /// <returns>True if the specified object is equal to the current object; otherwise, false.</returns>
-        public bool Equals(Metric other)
+        public bool Equals(MetricV1 other)
         {
             if (other == null)
             {
@@ -116,7 +116,7 @@
                 return true;
             }
 
-            return this.Equals(obj as Metric);
+            return this.Equals(obj as MetricV1);
         }
 
         /// <summary>
@@ -150,7 +150,7 @@
         {
             // create a local reference to metric processor collection
             // if collection changes after that - it will be copied not affecting local reference
-            IList<IMetricProcessor> metricProcessors = this.manager.MetricProcessors;
+            IList<IMetricProcessorV1> metricProcessors = this.manager.MetricProcessors;
 
             if (metricProcessors != null)
             {
@@ -158,7 +158,7 @@
 
                 for (int i = 0; i < processorCount; i++)
                 {
-                    IMetricProcessor processor = metricProcessors[i];
+                    IMetricProcessorV1 processor = metricProcessors[i];
 
                     try
                     {

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -29,7 +29,7 @@
         private string instrumentationKey = string.Empty;
         private bool disableTelemetry = false;
         private TelemetryProcessorChainBuilder builder;
-        private SnapshottingList<IMetricProcessor> metricProcessors = new SnapshottingList<IMetricProcessor>();
+        private SnapshottingList<IMetricProcessorV1> metricProcessors = new SnapshottingList<IMetricProcessorV1>();
 
         /// <summary>
         /// Indicates if this instance has been disposed of.
@@ -234,10 +234,10 @@
         public TelemetrySink DefaultTelemetrySink => this.telemetrySinks.DefaultSink;
 
         /// <summary>
-        /// Gets the list of <see cref="IMetricProcessor"/> objects used for custom metric data processing        
+        /// Gets the list of <see cref="IMetricProcessorV1"/> objects used for custom metric data processing        
         /// before client-side metric aggregation process.
         /// </summary>
-        internal IList<IMetricProcessor> MetricProcessors
+        internal IList<IMetricProcessorV1> MetricProcessors
         {
             get { return this.metricProcessors; }
         }


### PR DESCRIPTION
Initially, this change was part of the big pre-aggs PR.
https://github.com/Microsoft/ApplicationInsights-dotnet/pull/735

@SergeyKanzhelev asked me to move this out, so here we go. :)