### PR TITLE
Listen to Microsoft.AspNet.TelemetryCorrelation event source

### DIFF
--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
@@ -42,7 +42,8 @@
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if (eventSource.Name.StartsWith("Microsoft-ApplicationInsights-", StringComparison.Ordinal))
+            if (eventSource.Name.StartsWith("Microsoft-ApplicationInsights-", StringComparison.Ordinal) ||
+                eventSource.Name.Equals("Microsoft-AspNet-Telemetry-Correlation", StringComparison.Ordinal))
             {
                 this.EnableEvents(eventSource, this.logLevel, (EventKeywords)AllKeyword);
             }


### PR DESCRIPTION
We use [Microsoft.AspNet.TelemetryCorrelation package](https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/) to enables request tracking and correlation for the Web SDK.
While the package is owned by the AspNet team, ApplicationInsights is the biggest contributor and ~~single~~ main user.
Errors in this module result in requests not being tracked or correlated. It's extremely useful to report all [event source errors](https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/blob/master/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs) to the backend and track them as AI internal errors.

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.