### PR TITLE
Metrics: Add Obsolete attribute on the "bad" TrackMetric overload.

### DIFF
--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -224,6 +224,7 @@
         /// <param name="name">Metric name.</param>
         /// <param name="value">Metric value.</param>
         /// <param name="properties">Named string values you can use to classify and filter metrics.</param>
+        [Obsolete("Use GetMetric(..) to use SDK pre-aggregation capabilities or Track(ITelemetry metricTelemetry) if you performed your own local aggregation.")]
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void TrackMetric(string name, double value, IDictionary<string, string> properties = null)
         {


### PR DESCRIPTION
We just added a feature to allow metrics pre-aggregation by the SDK.
The central focus of the metrics feature work is metrics are always (pre-) aggregated once they leave the location where they are measured. In use cases that require sending an separate telemetry item at every occasion without aggregation across time, event telemetry, not metric telemetry should be used.

We need to deprecate the `TrackMetric(..)` overload that encourages the incorrect usage of metrics by tracking non-preaggregated data. In the future we will evaluate whether other `TrackMetric(..)` overloads should also me deprecated or not.

Additional discussion:

The recommended new API for metrics is now `.GetMetric(..).TrackValue(..)`. The old `TrackMetric(..)` API is discouraged because it promotes incorrect coding behavior by sending non-aggregated metric telemetry. 

The old `TrackMetric(..)` API can be used in 2 cases:

A) "Einstein" users who have implemented their own pre-aggregation. These few very advanced users can be expected to realize that `TrackMetric(MetricTelemetry item)` is just a thin wrapper around `Track(ITelemetty item)` and that the latter can be used to send the results of their custom pre-aggregation.

B) Users who want to send a single (non-pre-aggregated) measurement. As described, such data is not a correct use of AppInsights' data model. Customers should be using Events when aggregation is explicitly not required or `.GetMetric(..).TrackValue(..)` for metrics.

For additional discussion, see this thread:
https://github.com/Microsoft/ApplicationInsights-dotnet/pull/735/files/1f151e21907f4408a8eb783fc0c1a05553fff20e#diff-a4553125b36a87ff02a1256a752265fc