### PR TITLE
fix for DependencyTelemetry schema change

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -12,6 +12,17 @@
     [TestClass]
     public class DependencyTelemetryTest
     {
+        /// <summary>
+        /// The SDKs (and our customers) expect specific default values.
+        /// This test is to verify that changes to the schema don't unexpectedly change our public api.
+        /// </summary>
+        [TestMethod]
+        public void VerifyExpectedDefaultValue()
+        {
+            var defaultDependencyTelemetry = new DependencyTelemetry();
+            Assert.AreEqual(true, defaultDependencyTelemetry.Success, "Success is expected to be true");
+        }
+
         [TestMethod]
         public void RemoteDependencyTelemetrySerializesToJson()
         {

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -30,6 +30,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         public DependencyTelemetry()
         {
             this.InternalData = new RemoteDependencyData();
+            this.successFieldSet = true;
             this.context = new TelemetryContext(this.InternalData.properties);
             this.GenerateId();
         }


### PR DESCRIPTION
This amends a change introduced in #715 .

The DependencyTelemetry schema changed the base type of the Success property from a `Nullable<bool>` to a `bool`.
https://github.com/Microsoft/ApplicationInsights-dotnet/blob/da86c509f487ae04d1621616b25ca50e9f0a601c/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_types.cs#L65

The `DependencyTelemetry` class made a change on how that base value was handled, wrapping it with an `isSet` flag.
https://github.com/Microsoft/ApplicationInsights-dotnet/blob/da86c509f487ae04d1621616b25ca50e9f0a601c/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs#L201-L211


This changed the effective default value of `DependenyTelemetry.Success` from `true` to `null`.
I am amending that change by adding `this.successFieldSet = true` to the constructor.
Doing this because the public api should not have been affected.


- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [x] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
