### PR TITLE
enable parsed stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.6.0-beta4
+- [Enable ExceptionTelemetry.SetParsedStack for .Net Standard](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/763)
+
 ## Version 2.6.0-beta3
 - [Report internal errors from Microsoft.AspNet.TelemteryCorrelation module](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/744)
 - [Fix: Telemetry tracked with StartOperation is tracked outside of corresponding activity's scope](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/864)

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -267,3 +267,4 @@ static Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DefaultMetricNames
 static Microsoft.ApplicationInsights.Metrics.TelemetryConfigurationExtensions.GetMetricManager(this Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration telemetryPipeline) -> Microsoft.ApplicationInsights.Metrics.MetricManager
 static readonly Microsoft.ApplicationInsights.MetricConfigurations.Common -> Microsoft.ApplicationInsights.MetricConfigurations
 virtual Microsoft.ApplicationInsights.Metrics.MetricConfiguration.Equals(Microsoft.ApplicationInsights.Metrics.MetricConfiguration other) -> bool
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SetParsedStack(System.Diagnostics.StackFrame[] frames) -> void

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -3,11 +3,9 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
-    using System.Threading;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Platform;
 
     /// <summary>
     /// Telemetry type used to track exceptions.
@@ -213,7 +211,6 @@
             return new ExceptionTelemetry(this);
         }
 
-#if !NETSTANDARD1_3
         /// <summary>
         /// Set parsedStack from an array of StackFrame objects.
         /// </summary>
@@ -247,7 +244,6 @@
                 }
             }
         }
-#endif
 
         /// <summary>
         /// Sanitizes the properties based on constraints.


### PR DESCRIPTION
Fix Issue #763 .
Enable SetParsedStack method for NetStandard

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
