### PR TITLE
fix changed namespace SamplingPercentageEstimatorSettings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.6.0
+ -[Fix: changed namespace SamplingPercentageEstimatorSettings](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/727)
+
+
 ## Version 2.6.0-beta4
 - [New: Enable ExceptionTelemetry.SetParsedStack for .Net Standard](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/763)
 - [Fix: TelemetryClient throws NullReferenceException on Flush if the underlying configuration was disposed](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/755)

--- a/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation.SamplingPercentageEstimatorSettings

--- a/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.AI.ServerTelemetryChannel.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -36,3 +36,4 @@ Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChan
 Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel.ServerTelemetryChannel() -> void
 Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel.StorageFolder.get -> string
 Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel.StorageFolder.set -> void
+Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation.SamplingPercentageEstimatorSettings

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingPercentageEstimatorSettingsTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingPercentageEstimatorSettingsTest.cs
@@ -1,14 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation
 {
     using System;
-    using System.Collections.Generic;
-    using System.Globalization;
-
-    using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
-    
-
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 
     [TestClass]
     public class SamplingPercentageEstimatorSettingsTest

--- a/src/ServerTelemetryChannel/BackwardsCompatability/SamplingPercentageEstimatorSettings.cs
+++ b/src/ServerTelemetryChannel/BackwardsCompatability/SamplingPercentageEstimatorSettings.cs
@@ -1,0 +1,17 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation
+{
+    using System;
+
+    /// <summary>
+    /// Container for all the settings applicable to the process of dynamically estimating 
+    /// application telemetry sampling percentage.
+    /// </summary>
+    /// <remarks>
+    /// This class exists to resolve a backwards compatibility issue introduced in 2.5.0.
+    /// TODO: REMOVE THIS CLASS WHEN WE RELEASE NEW MAJOR VERSION: 3.0.0
+    /// For more information see: https://github.com/Microsoft/ApplicationInsights-dotnet/issues/727
+    /// </remarks>
+    public class SamplingPercentageEstimatorSettings : Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.SamplingPercentageEstimatorSettings
+    {
+    }
+}

--- a/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -60,7 +60,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj"/>
+    <ProjectReference Include="..\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net45'" />
     <Reference Include="System.Web.Extensions" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>
@@ -88,7 +88,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
-    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0"/>
+    <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.3.0" />
     <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
     <PackageReference Include="System.Net.Requests" Version="4.3.0" />


### PR DESCRIPTION
Fix Issue #727.
`SamplingPercentageEstimatorSettings`'s namespace was changed 
- from: Microsoft.ApplicationInsights.WindowsServer.**Channel**.Implementation.
- to: Microsoft.ApplicationInsights.WindowsServer.**TelemetryChannel**.Implementation

(Channel -> TelemetryChannel)


Fixing this by adding a proxy class to support former public api, but refer to new class.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
