### PR TITLE
Add a heartbeat-specific version property to the metrics sent as hear…

### DIFF
--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -29,7 +29,7 @@
         /// <summary>
         /// Value for property indicating 'app insights version' related specifically to heartbeats.
         /// </summary>
-        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbeat:");
+        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hb:");
 
         /// <summary>
         /// The name of the heartbeat metric item and operation context. 

--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -29,7 +29,7 @@
         /// <summary>
         /// Value for property indicating 'app insights version' related specifically to heartbeats.
         /// </summary>
-        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hb:");
+        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbnet:");
 
         /// <summary>
         /// The name of the heartbeat metric item and operation context. 

--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -27,6 +27,11 @@
         public static readonly TimeSpan MinimumHeartbeatInterval = TimeSpan.FromSeconds(30.0);
 
         /// <summary>
+        /// Value for property indicating 'app insights version' related specifically to heartbeats.
+        /// </summary>
+        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbeat:");
+
+        /// <summary>
         /// The name of the heartbeat metric item and operation context. 
         /// </summary>
         private static string heartbeatSyntheticMetricName = "HeartbeatState";
@@ -300,6 +305,7 @@
             var eventData = (MetricTelemetry)this.GatherData();
 
             eventData.Context.Operation.SyntheticSource = heartbeatSyntheticMetricName;
+            eventData.Context.GetInternalContext().SdkVersion = sdkVersionPropertyValue;
 
             this.telemetryClient.Track(eventData);
         }


### PR DESCRIPTION
Add a heartbeat-specific version string to the properties of the metrics sent as heartbeats.

- [x] Design discussion (none needed - issue raised in informal discussions)
- [x] Changes in public surface reviewed
    - no change to public API
- [x] CHANGELOG.md
    - probably unnecessary for this small change, let me know if you still want it in there!
