### PR TITLE
Metrics: Autocollected Metric Extraction now uses new aggregation APIs

### DIFF
--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -137,6 +137,7 @@ Microsoft.ApplicationInsights.Metrics.MetricConfiguration.SeriesCountLimit.get -
 Microsoft.ApplicationInsights.Metrics.MetricConfiguration.GetValuesPerDimensionLimit(int dimensionNumber) -> int
 Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement
 Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement.MetricConfigurationForMeasurement(int seriesCountLimit, int valuesPerDimensionLimit, Microsoft.ApplicationInsights.Metrics.MetricSeriesConfigurationForMeasurement seriesConfig) -> void
+Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement.MetricConfigurationForMeasurement(int seriesCountLimit, System.Collections.Generic.IEnumerable<int> valuesPerDimensionLimits, Microsoft.ApplicationInsights.Metrics.MetricSeriesConfigurationForMeasurement seriesConfig) -> void
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DimensionsCount.get -> int
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(Microsoft.ApplicationInsights.Metrics.MetricIdentifier otherMetricIdentifier) -> bool

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -137,6 +137,7 @@ Microsoft.ApplicationInsights.Metrics.MetricConfiguration.SeriesCountLimit.get -
 Microsoft.ApplicationInsights.Metrics.MetricConfiguration.GetValuesPerDimensionLimit(int dimensionNumber) -> int
 Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement
 Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement.MetricConfigurationForMeasurement(int seriesCountLimit, int valuesPerDimensionLimit, Microsoft.ApplicationInsights.Metrics.MetricSeriesConfigurationForMeasurement seriesConfig) -> void
+Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement.MetricConfigurationForMeasurement(int seriesCountLimit, System.Collections.Generic.IEnumerable<int> valuesPerDimensionLimits, Microsoft.ApplicationInsights.Metrics.MetricSeriesConfigurationForMeasurement seriesConfig) -> void
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DimensionsCount.get -> int
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(Microsoft.ApplicationInsights.Metrics.MetricIdentifier otherMetricIdentifier) -> bool

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -137,6 +137,7 @@ Microsoft.ApplicationInsights.Metrics.MetricConfiguration.SeriesCountLimit.get -
 Microsoft.ApplicationInsights.Metrics.MetricConfiguration.GetValuesPerDimensionLimit(int dimensionNumber) -> int
 Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement
 Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement.MetricConfigurationForMeasurement(int seriesCountLimit, int valuesPerDimensionLimit, Microsoft.ApplicationInsights.Metrics.MetricSeriesConfigurationForMeasurement seriesConfig) -> void
+Microsoft.ApplicationInsights.Metrics.MetricConfigurationForMeasurement.MetricConfigurationForMeasurement(int seriesCountLimit, System.Collections.Generic.IEnumerable<int> valuesPerDimensionLimits, Microsoft.ApplicationInsights.Metrics.MetricSeriesConfigurationForMeasurement seriesConfig) -> void
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DimensionsCount.get -> int
 Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(Microsoft.ApplicationInsights.Metrics.MetricIdentifier otherMetricIdentifier) -> bool

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/AutocollectedMetricsExtractorTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/AutocollectedMetricsExtractorTest.cs
@@ -76,13 +76,13 @@
             AssertEx.IsType<RequestTelemetry>(telemetrySentToChannel[1]);
             Assert.AreEqual("Test Request 1", ((RequestTelemetry) telemetrySentToChannel[1]).Name);
             Assert.AreEqual(true, ((RequestTelemetry) telemetrySentToChannel[1]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
-            Assert.AreEqual("(Name:'Requests', Ver:'1.0')",
+            Assert.AreEqual("(Name:'Requests', Ver:'1.1')",
                          ((RequestTelemetry) telemetrySentToChannel[1]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<RequestTelemetry>(telemetrySentToChannel[2]);
             Assert.AreEqual("Test Request 2", ((RequestTelemetry) telemetrySentToChannel[2]).Name);
             Assert.AreEqual(true, ((RequestTelemetry) telemetrySentToChannel[2]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
-            Assert.AreEqual("(Name:'Requests', Ver:'1.0')",
+            Assert.AreEqual("(Name:'Requests', Ver:'1.1')",
                          ((RequestTelemetry) telemetrySentToChannel[2]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<MetricTelemetry>(telemetrySentToChannel[3]);
@@ -269,25 +269,25 @@
             
             AssertEx.IsType<RequestTelemetry>(telemetrySentToChannel[0]);
             Assert.AreEqual(true, ((RequestTelemetry) telemetrySentToChannel[0]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
-            Assert.AreEqual("(Name:'Requests', Ver:'1.0')",
+            Assert.AreEqual("(Name:'Requests', Ver:'1.1')",
                          ((RequestTelemetry) telemetrySentToChannel[0]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<DependencyTelemetry>(telemetrySentToChannel[1]);
             Assert.AreEqual("Test Dependency Call 1", ((DependencyTelemetry) telemetrySentToChannel[1]).Name);
             Assert.AreEqual(true, ((DependencyTelemetry) telemetrySentToChannel[1]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
-            Assert.AreEqual("(Name:'Dependencies', Ver:'1.0')",
+            Assert.AreEqual("(Name:'Dependencies', Ver:'1.1')",
                          ((DependencyTelemetry) telemetrySentToChannel[1]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<DependencyTelemetry>(telemetrySentToChannel[2]);
             Assert.AreEqual("Test Dependency Call 2", ((DependencyTelemetry)telemetrySentToChannel[2]).Name);
             Assert.AreEqual(true, ((DependencyTelemetry)telemetrySentToChannel[2]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
-            Assert.AreEqual("(Name:'Dependencies', Ver:'1.0')",
+            Assert.AreEqual("(Name:'Dependencies', Ver:'1.1')",
                          ((DependencyTelemetry)telemetrySentToChannel[2]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<DependencyTelemetry>(telemetrySentToChannel[3]);
             Assert.AreEqual("Test Dependency Call 3", ((DependencyTelemetry) telemetrySentToChannel[3]).Name);
             Assert.AreEqual(true, ((DependencyTelemetry) telemetrySentToChannel[3]).Properties.ContainsKey("_MS.ProcessedByMetricExtractors"));
-            Assert.AreEqual("(Name:'Dependencies', Ver:'1.0')",
+            Assert.AreEqual("(Name:'Dependencies', Ver:'1.1')",
                          ((DependencyTelemetry) telemetrySentToChannel[3]).Properties["_MS.ProcessedByMetricExtractors"]);
 
             AssertEx.IsType<EventTelemetry>(telemetrySentToChannel[4]);
@@ -423,7 +423,7 @@
             Assert.AreEqual(true, Math.Abs(metricT.StandardDeviation.Value - 5.590169943749474) < 0.0000001);
             Assert.AreEqual(50, metricT.Sum);
 
-            Assert.AreEqual(4, metricT.Properties.Count);
+            Assert.AreEqual(5, metricT.Properties.Count);
             Assert.IsTrue(metricT.Properties.ContainsKey("_MS.AggregationIntervalMs"));
             Assert.IsTrue(metricT.Properties.ContainsKey("_MS.IsAutocollected"));
             Assert.AreEqual("True", metricT.Properties["_MS.IsAutocollected"]);
@@ -431,6 +431,8 @@
             Assert.AreEqual("dependencies/duration", metricT.Properties["_MS.MetricId"]);
             Assert.AreEqual(true, metricT.Properties.ContainsKey("Dependency.Success"));
             Assert.AreEqual(Boolean.TrueString, metricT.Properties["Dependency.Success"]);
+            Assert.AreEqual(true, metricT.Properties.ContainsKey("Dependency.Type"));
+            Assert.AreEqual("Other", metricT.Properties["Dependency.Type"]);
 
             Assert.AreEqual("Dependency duration", metricF.Name);
             Assert.AreEqual(3, metricF.Count);
@@ -439,7 +441,7 @@
             Assert.AreEqual(true, Math.Abs(metricF.StandardDeviation.Value - 40.8248290) < 0.0000001);
             Assert.AreEqual(300, metricF.Sum);
 
-            Assert.AreEqual(4, metricF.Properties.Count);
+            Assert.AreEqual(5, metricF.Properties.Count);
             Assert.IsTrue(metricF.Properties.ContainsKey("_MS.AggregationIntervalMs"));
             Assert.IsTrue(metricF.Properties.ContainsKey("_MS.IsAutocollected"));
             Assert.AreEqual("True", metricF.Properties["_MS.IsAutocollected"]);
@@ -447,6 +449,8 @@
             Assert.AreEqual("dependencies/duration", metricF.Properties["_MS.MetricId"]);
             Assert.AreEqual(true, metricF.Properties.ContainsKey("Dependency.Success"));
             Assert.AreEqual(Boolean.FalseString, metricF.Properties["Dependency.Success"]);
+            Assert.AreEqual(true, metricT.Properties.ContainsKey("Dependency.Type"));
+            Assert.AreEqual("Other", metricT.Properties["Dependency.Type"]);
         }
 
         [TestMethod]
@@ -513,7 +517,6 @@
             //// 6)* E, true ==> Other, true: +1 = 3
             //// 7)  E, false ==> Other, false: 1
             //// 8)  Unknown, false: 3
-
 
             Assert.AreEqual(27 + 8, telemetrySentToChannel.Count);
             for (int i = 0; i < 35; i++)

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/ISpecificAutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Metrics/ISpecificAutocollectedMetricsExtractor.cs
@@ -24,8 +24,8 @@
         /// <summary>
         /// Pre-initialize this extractor.
         /// </summary>
-        /// <param name="metricManager">The manager to be used for aggregation.</param>
-        void InitializeExtractor(MetricManagerV1 metricManager);
+        /// <param name="metricTelemetryClient">The <c>TelemetryClient</c> to be used for sending extracted metrics.</param>
+        void InitializeExtractor(TelemetryClient metricTelemetryClient);
 
         /// <summary>
         /// Perform actual metric data point extraction from the specified item.

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -254,33 +254,6 @@
             get { return this.metricProcessors; }
         }
 
-        internal MetricManager MetricManager
-        {
-            get
-            {
-                MetricManager manager = this.metricManager;
-                if (manager == null)
-                {
-                    var pipelineAdapter = new ApplicationInsightsTelemetryPipeline(this);
-                    MetricManager newManager = new MetricManager(pipelineAdapter);
-                    MetricManager prevManager = Interlocked.CompareExchange(ref this.metricManager, newManager, null);
-
-                    if (prevManager == null)
-                    {
-                        manager = newManager;
-                    }
-                    else
-                    {
-                        // We just created a new manager that we are not using. Stop is before discarding.
-                        Task fireAndForget = newManager.StopDefaultAggregationCycleAsync();
-                        manager = prevManager;
-                    }
-                }
-
-                return manager;
-            }
-        }
-
         /// <summary>
         /// Gets or sets the chain of processors.
         /// </summary>
@@ -346,6 +319,30 @@
             GC.SuppressFinalize(this);
         }
 
+        internal MetricManager GetMetricManager(bool createIfNotExists)
+        {
+            MetricManager manager = this.metricManager;
+            if (manager == null && createIfNotExists)
+            {
+                var pipelineAdapter = new ApplicationInsightsTelemetryPipeline(this);
+                MetricManager newManager = new MetricManager(pipelineAdapter);
+                MetricManager prevManager = Interlocked.CompareExchange(ref this.metricManager, newManager, null);
+
+                if (prevManager == null)
+                {
+                    manager = newManager;
+                }
+                else
+                {
+                    // We just created a new manager that we are not using. Stop is before discarding.
+                    Task fireAndForget = newManager.StopDefaultAggregationCycleAsync();
+                    manager = prevManager;
+                }
+            }
+
+            return manager;
+        }
+
         /// <summary>
         /// Disposes of resources.
         /// </summary>
@@ -356,6 +353,11 @@
             {
                 this.isDisposed = true;
                 Interlocked.CompareExchange(ref active, null, this);
+
+                // I think we should be flushing this.telemetrySinks.DefaultSink.TelemetryChannel at this point.
+                // Filed https://github.com/Microsoft/ApplicationInsights-dotnet/issues/823 to track.
+                // For now just flushing the metrics:
+                this.metricManager?.Flush();
 
                 if (this.telemetryProcessorChain != null)
                 {
@@ -371,14 +373,6 @@
                         this.telemetrySinks.Remove(sink);
                     }
                 }
-            }
-        }
-
-        private void EnsureNotDisposed()
-        {
-            if (this.isDisposed)
-            {
-                throw new ObjectDisposedException(nameof(TelemetryConfiguration));
             }
         }
     }

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/TelemetryClientExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/TelemetryClientExtensions.cs
@@ -38,6 +38,24 @@
             }
         }
 
+        internal static bool TryGetMetricManager(this TelemetryClient telemetryClient, out MetricManager metricManager)
+        {
+            if (telemetryClient == null)
+            {
+                metricManager = null;
+                return false;
+            }
+
+            ConditionalWeakTable<TelemetryClient, MetricManager> metricManagers = metricManagersForTelemetryClients;
+            if (metricManagers == null)
+            {
+                metricManager = null;
+                return false;
+            }
+
+            return metricManagers.TryGetValue(telemetryClient, out metricManager);
+        }
+
         private static MetricManager GetOrCreateMetricManager(TelemetryClient telemetryClient)
         {
             ConditionalWeakTable<TelemetryClient, MetricManager> metricManagers = metricManagersForTelemetryClients;

--- a/src/Microsoft.ApplicationInsights/Metrics/MetricConfigurationForMeasurement.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/MetricConfigurationForMeasurement.cs
@@ -1,16 +1,38 @@
 ﻿namespace Microsoft.ApplicationInsights.Metrics
 {
     using System;
+    using System.Collections.Generic;
 
     /// <summary>@ToDo: Complete documentation before stable release. {218}</summary>
     public sealed class MetricConfigurationForMeasurement : MetricConfiguration
     {
-        /// <summary>@ToDo: Complete documentation before stable release. {928}</summary>
-        /// <param name="seriesCountLimit">@ToDo: Complete documentation before stable release. {466}</param>
-        /// <param name="valuesPerDimensionLimit">@ToDo: Complete documentation before stable release. {730}</param>
-        /// <param name="seriesConfig">@ToDo: Complete documentation before stable release. {977}</param>
+        /// <summary>Creates a new instance of <c>MetricConfigurationForMeasurement</c>.</summary>
+        /// <param name="seriesCountLimit">How many data time series a metric can contain as a maximum.
+        /// Once this limit is reached, calls to <c>TryTrackValue(..)</c>, <c>TryGetDataSeries(..)</c> and similar
+        /// that would normally result in new series will return <c>false</c>.</param>
+        /// <param name="valuesPerDimensionLimit">How many different values each of the dimensions of a metric can
+        /// have as a maximum.
+        /// Once this limit is reached, calls to <c>TryTrackValue(..)</c>, <c>TryGetDataSeries(..)</c> and similar
+        /// that would normally result in new series will return <c>false</c>.</param>
+        /// <param name="seriesConfig">The configuration for how each series of this metric should be aggregated.</param>
         public MetricConfigurationForMeasurement(int seriesCountLimit, int valuesPerDimensionLimit, MetricSeriesConfigurationForMeasurement seriesConfig)
             : base(seriesCountLimit, valuesPerDimensionLimit, seriesConfig)
+        {
+        }
+
+        /// <summary>Creates a new instance of <c>MetricConfiguration</c>.</summary>
+        /// <param name="seriesCountLimit">How many data time series a metric can contain as a maximum.
+        /// Once this limit is reached, calls to <c>TryTrackValue(..)</c>, <c>TryGetDataSeries(..)</c> and similar
+        /// that would normally result in new series will return <c>false</c>.</param>
+        /// <param name="valuesPerDimensionLimits">How many different values each of the dimensions of a metric can
+        /// have as a maximum. If this enumeration contains less elements than the number of supported dimensions,
+        /// then the last specified element is replicated for subsequent dimensions. If this enumeration contains
+        /// too many elements, superflous elements are ignored.
+        /// Once this limit is reached, calls to <c>TryTrackValue(..)</c>, <c>TryGetDataSeries(..)</c> and similar
+        /// that would normally result in new series will return <c>false</c>.</param>
+        /// <param name="seriesConfig">The configuration for how each series of this metric should be aggregated.</param>
+        public MetricConfigurationForMeasurement(int seriesCountLimit, IEnumerable<int> valuesPerDimensionLimits, MetricSeriesConfigurationForMeasurement seriesConfig)
+            : base(seriesCountLimit, valuesPerDimensionLimits, seriesConfig)
         {
         }
     }

--- a/src/Microsoft.ApplicationInsights/Metrics/MetricManager.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/MetricManager.cs
@@ -117,9 +117,14 @@
         /// <summary>@ToDo: Complete documentation before stable release. {134}</summary>
         public void Flush()
         {
+            this.Flush(flushDownstreamPipeline: true);
+        }
+
+        internal void Flush(bool flushDownstreamPipeline)
+        {
             DateTimeOffset now = DateTimeOffset.Now;
             AggregationPeriodSummary aggregates = this.aggregationManager.StartOrCycleAggregators(MetricAggregationCycleKind.Default, futureFilter: null, tactTimestamp: now);
-            this.TrackMetricAggregates(aggregates, flush: true);
+            this.TrackMetricAggregates(aggregates, flushDownstreamPipeline);
         }
 
         internal void TrackMetricAggregates(AggregationPeriodSummary aggregates, bool flush)

--- a/src/Microsoft.ApplicationInsights/Metrics/TelemetryConfigurationExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/TelemetryConfigurationExtensions.cs
@@ -11,7 +11,7 @@
         /// <returns>@ToDo: Complete documentation before stable release. {580}</returns>
         public static MetricManager GetMetricManager(this TelemetryConfiguration telemetryPipeline)
         {
-            return telemetryPipeline?.MetricManager;
+            return telemetryPipeline?.GetMetricManager(createIfNotExists: true);
         }
     }
 }


### PR DESCRIPTION
This is PR number 2 that addresses https://github.com/Microsoft/ApplicationInsights-dotnet/issues/806

One last PR is coming to remove the no longer used internal APIs.