### PR TITLE
Fix: NullReferenceException in ExceptionConverter.GetStackFrame if StackFrame.GetMethod() is null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.7.0-beta2
-
+- [Fix: NullReferenceException in ExceptionConverter.GetStackFrame if StackFrame.GetMethod() is null](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/819)
 
 ## Version 2.7.0-beta1 
 - [Extend the Beta period for Metrics Pre-Aggregation features shipped in 2.6.0-beta3.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/785)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/ExceptionConverterTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/ExceptionConverterTest.cs
@@ -8,7 +8,7 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.ApplicationInsights.TestFramework;
-
+    using Moq;
 
     /// <summary>
     /// Tests of exception stack serialization.
@@ -59,6 +59,29 @@
             // We should keep top of stack, and end of stack hence CreateException function should be present
             Assert.AreEqual("Microsoft.ApplicationInsights.Extensibility.Implementation.ExceptionConverterTest.FailedFunction", expDetails.parsedStack[0].method);
             Assert.AreEqual("Microsoft.ApplicationInsights.Extensibility.Implementation.ExceptionConverterTest.CreateException", expDetails.parsedStack[expDetails.parsedStack.Count - 1].method);
+        }
+
+        [TestMethod]
+        public void TestNullMethodInfoInStack()
+        {
+            var frameMock = new Mock<System.Diagnostics.StackFrame>(null, 0, 0);
+            frameMock.Setup(x => x.GetMethod()).Returns((MethodBase)null);
+
+            External.StackFrame stackFrame = null;
+
+            try
+            {
+                stackFrame = ExceptionConverter.GetStackFrame(frameMock.Object, 0);
+            }
+            catch (Exception e)
+            {
+                Assert.Fail("GetStackFrame threw " + e);
+            }
+
+            Assert.AreEqual("unknown", stackFrame.assembly);
+            Assert.AreEqual(null, stackFrame.fileName);
+            Assert.AreEqual("unknown", stackFrame.method);
+            Assert.AreEqual(0, stackFrame.line);
         }
 
 #if !NETCOREAPP1_1

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
@@ -151,17 +151,18 @@
                 const int spikeProductionFrequencyMs = 3000;
 
                 using (var regularProductionTimer = new Timer(
-                            (state) =>
-                            {
-                                for (int i = 0; i < 2; i++)
-                                {
-                                    tc.TelemetryProcessorChain.Process(new RequestTelemetry());
-                                    Interlocked.Increment(ref itemsProduced);
-                                }
-                            },
-                            null,
-                            0,
-                            regularProductionFrequencyMs))
+                    (state) =>
+                    {
+                        for (int i = 0; i < 2; i++)
+                        {
+                            tc.TelemetryProcessorChain.Process(new RequestTelemetry());
+                            Interlocked.Increment(ref itemsProduced);
+                        }
+                    },
+                    null,
+                    0,
+                    regularProductionFrequencyMs))
+
                 using (var spikeProductionTimer = new Timer(
                             (state) =>
                             {
@@ -176,6 +177,8 @@
                             spikeProductionFrequencyMs))
                 {
                     Thread.Sleep(30000);
+                    spikeProductionTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                    Thread.Sleep(1000);
                 }
             }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
@@ -42,17 +42,28 @@
 
             var methodInfo = stackFrame.GetMethod();
             string fullName;
-            if (methodInfo.DeclaringType != null)
+            string assemblyName;
+
+            if (methodInfo == null)
             {
-                fullName = methodInfo.DeclaringType.FullName + "." + methodInfo.Name;
+                fullName = "unknown";
+                assemblyName = "unknown";
             }
             else
             {
-                fullName = methodInfo.Name;
+                assemblyName = methodInfo.Module.Assembly.FullName;
+                if (methodInfo.DeclaringType != null)
+                {
+                    fullName = methodInfo.DeclaringType.FullName + "." + methodInfo.Name;
+                }
+                else
+                {
+                    fullName = methodInfo.Name;
+                }
             }
 
             convertedStackFrame.method = fullName;
-            convertedStackFrame.assembly = methodInfo.Module.Assembly.FullName;
+            convertedStackFrame.assembly = assemblyName;
             convertedStackFrame.fileName = stackFrame.GetFileName();
 
             // 0 means it is unavailable


### PR DESCRIPTION
Fix Issue #819.


- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.


/cc @pharring