### PR TITLE
Fix SamplingPercentageAdjustsAccordingToConstantHighProductionRate flaky test

### DIFF
--- a/Test/ServerTelemetryChannel.Test/NetCore.Tests/TelemetryChannel.netcoreapp11.Tests.csproj
+++ b/Test/ServerTelemetryChannel.Test/NetCore.Tests/TelemetryChannel.netcoreapp11.Tests.csproj
@@ -14,7 +14,7 @@
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.NetCore.Tests</AssemblyName>
     <DebugType>pdbonly</DebugType> 
     <DebugSymbols>true</DebugSymbols> 
-    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP1_1</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
@@ -14,9 +14,6 @@
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
-    using Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation;
-
     [TestClass]
     public class AdaptiveSamplingTelemetryProcessorTest
     {
@@ -46,14 +43,20 @@
 
                 const int productionFrequencyMs = 1000;
 
-                using (var productionTimer = new Timer(
-                            (state) => { tc.TelemetryProcessorChain.Process(new RequestTelemetry()); itemsProduced++; },
-                            null,
-                            productionFrequencyMs,
-                            productionFrequencyMs))
-                {
-                    Thread.Sleep(25000);
-                }
+                var productionTimer = new Timer(
+                    (state) =>
+                    {
+                        tc.TelemetryProcessorChain.Process(new RequestTelemetry());
+                        itemsProduced++;
+                    },
+                    null,
+                    productionFrequencyMs,
+                    productionFrequencyMs);
+
+                Thread.Sleep(25000);
+                
+                // dispose timer and wait for callbacks to complete
+                DisposeTimer(productionTimer);
             }
 
             Assert.AreEqual(itemsProduced, sentTelemetry.Count);
@@ -85,23 +88,23 @@
 
                 const int productionFrequencyMs = 100;
 
-                using (var productionTimer = new Timer(
-                            (state) =>
-                            {
-                                for (int i = 0; i < 2; i++)
-                                {
-                                    tc.TelemetryProcessorChain.Process(new RequestTelemetry());
-                                    itemsProduced++;
-                                }
-                            },
-                            null,
-                            0,
-                            productionFrequencyMs))
-                {
-                    Thread.Sleep(25000);
-                    productionTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-                    Thread.Sleep(1000);
-                }
+                var productionTimer = new Timer(
+                    (state) =>
+                    {
+                        for (int i = 0; i < 2; i++)
+                        {
+                            tc.TelemetryProcessorChain.Process(new RequestTelemetry());
+                            itemsProduced++;
+                        }
+                    },
+                    null,
+                    0,
+                    productionFrequencyMs);
+
+                Thread.Sleep(25000);
+                
+                // dispose timer and wait for callbacks to complete
+                DisposeTimer(productionTimer);
             }
 
             // number of items produced should be close to target of 5/second
@@ -152,7 +155,7 @@
                 const int regularProductionFrequencyMs = 100;
                 const int spikeProductionFrequencyMs = 3000;
 
-                using (var regularProductionTimer = new Timer(
+                var regularProductionTimer = new Timer(
                     (state) =>
                     {
                         for (int i = 0; i < 2; i++)
@@ -163,25 +166,26 @@
                     },
                     null,
                     0,
-                    regularProductionFrequencyMs))
+                    regularProductionFrequencyMs);
 
-                using (var spikeProductionTimer = new Timer(
-                            (state) =>
-                            {
-                                for (int i = 0; i < 200; i++)
-                                {
-                                    tc.TelemetryProcessorChain.Process(new RequestTelemetry());
-                                    Interlocked.Increment(ref itemsProduced);
-                                }
-                            },
-                            null,
-                            0,
-                            spikeProductionFrequencyMs))
-                {
-                    Thread.Sleep(30000);
-                    spikeProductionTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-                    Thread.Sleep(1000);
-                }
+                var spikeProductionTimer = new Timer(
+                    (state) =>
+                    {
+                        for (int i = 0; i < 200; i++)
+                        {
+                            tc.TelemetryProcessorChain.Process(new RequestTelemetry());
+                            Interlocked.Increment(ref itemsProduced);
+                        }
+                    },
+                    null,
+                    0,
+                    spikeProductionFrequencyMs);
+
+                Thread.Sleep(30000);
+
+                // dispose timers and wait for callbacks to complete
+                DisposeTimer(regularProductionTimer);
+                DisposeTimer(spikeProductionTimer);
             }
 
             // number of items produced should be close to target of 5/second
@@ -305,6 +309,24 @@
                 currentSamplingPercentage,
                 newSamplingPercentage,
                 isSamplingPercentageChanged));
+        }
+
+
+        private void DisposeTimer(Timer timer)
+        {
+            // Regular Dispose() does not wait for all callbacks to complete
+            // so TelemetryConfiguration could be disposed while callback still runs
+
+#if NETCOREAPP1_1
+            timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+            timer.Dispose();
+            Thread.Sleep(1000);
+#else
+            AutoResetEvent allDone = new AutoResetEvent(false);
+            timer.Dispose(allDone);
+            // this will wait for all callbacks to complete
+            allDone.WaitOne();
+#endif
         }
     }
 }

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
@@ -99,6 +99,8 @@
                             productionFrequencyMs))
                 {
                     Thread.Sleep(25000);
+                    productionTimer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
+                    Thread.Sleep(1000);
                 }
             }
 


### PR DESCRIPTION
TelemteryConfiguration could disposed while timer call back still runs. 

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
