### PR TITLE
Add new GlobalProperties on TelemetryContext and mark Properties obsolete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.7.0-beta3
+- [Add a new distict properties collection, GlobalProperties, on TelemetryContext, and obsolete the Properties on TelememetryContext.](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/820)
+
 ## Version 2.7.0-beta2
 - [Fix: NullReferenceException if telemtery is tracked after TelemetryConfiguration is disposed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/928)
 - [Move the implementation of the extraction of auto-collected (aka standard) metrics from internal legacy APIs to the recently shipped metric aggregation APIs.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/806)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/en-us/documentation/articles/app-insights-release-notes-dotnet/).
 
-## Version 2.7.0-beta2 
+## Version 2.7.0-beta2
+- [Fix: NullReferenceException if telemtery is tracked after TelemetryConfiguration is disposed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/928)
 - [Move the implementation of the extraction of auto-collected (aka standard) metrics from internal legacy APIs to the recently shipped metric aggregation APIs.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/806)
 - [Fix: NullReferenceException in ExceptionConverter.GetStackFrame if StackFrame.GetMethod() is null](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/819)
 

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
@@ -244,6 +244,7 @@ Microsoft.ApplicationInsights.DataContracts.TelemetryContext.InstrumentationKey.
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Location.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.LocationContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Operation.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.OperationContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Properties.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.ApplicationInsights.DataContracts.TelemetryContext.GlobalProperties.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Session.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.SessionContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.TelemetryContext() -> void
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.User.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.UserContext

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
@@ -244,6 +244,7 @@ Microsoft.ApplicationInsights.DataContracts.TelemetryContext.InstrumentationKey.
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Location.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.LocationContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Operation.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.OperationContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Properties.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.ApplicationInsights.DataContracts.TelemetryContext.GlobalProperties.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Session.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.SessionContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.TelemetryContext() -> void
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.User.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.UserContext

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
@@ -243,6 +243,7 @@ Microsoft.ApplicationInsights.DataContracts.TelemetryContext.InstrumentationKey.
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Location.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.LocationContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Operation.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.OperationContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Properties.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.ApplicationInsights.DataContracts.TelemetryContext.GlobalProperties.get -> System.Collections.Generic.IDictionary<string, string>
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Session.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.SessionContext
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.TelemetryContext() -> void
 Microsoft.ApplicationInsights.DataContracts.TelemetryContext.User.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.UserContext

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/ITelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/ITelemetryTest.cs
@@ -155,7 +155,7 @@
             var expected = new TTelemetry { Timestamp = DateTimeOffset.UtcNow };
             expected.Sanitize();
 
-            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TTelemetry, TEndpointData>(expected);
+            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TEndpointData>(expected);
 
 
             Assert.AreEqual<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(actual.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
@@ -166,7 +166,7 @@
             var expected = new TTelemetry { Sequence = "4:2" };
             expected.Sanitize();
             
-            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TTelemetry, TEndpointData>(expected);
+            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TEndpointData>(expected);
             
             Assert.AreEqual(expected.Sequence, actual.seq);
         }
@@ -177,7 +177,7 @@
             expected.Context.InstrumentationKey = Guid.NewGuid().ToString();
             expected.Sanitize();
 
-            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TTelemetry, TEndpointData>(expected);
+            TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TEndpointData>(expected);
             
             Assert.AreEqual(expected.Context.InstrumentationKey, actual.iKey);
         }
@@ -187,7 +187,7 @@
             var telemetry = new TTelemetry();
             telemetry.Sanitize();
 
-            TelemetryItem<TEndpointData> envelope = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TTelemetry, TEndpointData>(telemetry);
+            TelemetryItem<TEndpointData> envelope = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TEndpointData>(telemetry);
 
             string expectedBaseType = ExtractTelemetryNameFromType(typeof(TTelemetry)) + "Data";
             Assert.AreEqual(expectedBaseType, envelope.data.baseType);
@@ -200,7 +200,7 @@
             expected.Sanitize();
 
             TelemetryItem<TEndpointData> actual = TelemetryItemTestHelper
-                .SerializeDeserializeTelemetryItem<TTelemetry, TEndpointData>(expected);
+                .SerializeDeserializeTelemetryItem<TEndpointData>(expected);
 
             Assert.AreEqual(
                 Constants.TelemetryNamePrefix + "312cbd799dbb4c48a7da3cc2a931cb71." + this.ExtractTelemetryNameFromType(typeof(TTelemetry)),

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
@@ -15,10 +15,31 @@
     public class AvailabilityTelemetryTest
     {
         [TestMethod]
+        public void AvailabilityTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = CreateAvailabilityTelemetry();
+
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("TestPropertyGlobal"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.AvailabilityData>(expected);
+
+            // Items added to both availability.Properties, and availability.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestPropertyGlobal"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
+        }
+
+        [TestMethod]
         public void AvailabilityTelemetrySerializesToJson()
         {
             AvailabilityTelemetry expected = this.CreateAvailabilityTelemetry();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AvailabilityTelemetry, AI.AvailabilityData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.AvailabilityData>(expected);
 
             Assert.AreEqual<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(item.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
             Assert.AreEqual(expected.Sequence, item.seq);
@@ -138,6 +159,7 @@
             };
             item.Context.InstrumentationKey = Guid.NewGuid().ToString();
             item.Properties.Add("TestProperty", "TestValue");
+            item.Context.GlobalProperties.Add("TestPropertyGlobal", "TestValue");
             item.Sequence = "12";
 
             return item;

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -24,10 +24,31 @@
         }
 
         [TestMethod]
+        public void DependencyTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = CreateRemoteDependencyTelemetry();
+
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("TestPropertyGlobal"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.AvailabilityData>(expected);
+
+            // Items added to both dependency.Properties, and dependency.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestPropertyGlobal"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
+        }
+
+        [TestMethod]
         public void RemoteDependencyTelemetrySerializesToJson()
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
 
             Assert.AreEqual<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(item.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
             Assert.AreEqual(expected.Sequence, item.seq);
@@ -54,7 +75,7 @@
             original.Type = null;
             original.Success = null;
             ((ITelemetry)original).Sanitize();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
         }
@@ -64,7 +85,7 @@
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry();
             expected.Context.InstrumentationKey = "AIC-" + expected.Context.InstrumentationKey;
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
 
             Assert.AreEqual(expected.Context.InstrumentationKey, item.iKey);
         }
@@ -73,7 +94,7 @@
         public void RemoteDependencyTelemetrySerializeCommandNameToJson()
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry("Select * from Customers where CustomerID=@1");
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
             AI.RemoteDependencyData dp = item.data.baseData;
             Assert.AreEqual(expected.Data, dp.data);
         }
@@ -82,7 +103,7 @@
         public void RemoteDependencyTelemetrySerializeNullCommandNameToJson()
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry(null);
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
             AI.RemoteDependencyData dp = item.data.baseData;
             Assert.IsTrue(string.IsNullOrEmpty(dp.data));
         }
@@ -91,7 +112,7 @@
         public void RemoteDependencyTelemetrySerializeEmptyCommandNameToJson()
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry(string.Empty);
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
             AI.RemoteDependencyData dp = item.data.baseData;
             Assert.IsTrue(string.IsNullOrEmpty(dp.data));
         }
@@ -162,7 +183,7 @@
             var telemetry = this.CreateRemoteDependencyTelemetry("mycommand");
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<DependencyTelemetry, AI.RemoteDependencyData>(telemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(telemetry);
 
             Assert.AreEqual(10, item.sampleRate);
         }
@@ -227,6 +248,7 @@
                                             };
             item.Context.InstrumentationKey = Guid.NewGuid().ToString();
             item.Properties.Add("TestProperty", "TestValue");
+            item.Context.GlobalProperties.Add("TestPropertyGlobal", "TestValue");
 
             return item;
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/EventTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/EventTelemetryTest.cs
@@ -56,7 +56,7 @@
             expected.Properties["Test Property"] = "Test Value";
             expected.Metrics["Test Property"] = 4.2;
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<EventTelemetry, AI.EventData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.EventData>(expected);
 
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(AI.ItemType.Event, item.name);
@@ -73,9 +73,31 @@
             EventTelemetry original = new EventTelemetry();
             original.Name = null;
             ((ITelemetry)original).Sanitize();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<EventTelemetry, AI.EventData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.EventData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
+        }
+
+        [TestMethod]
+        public void EventTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = new EventTelemetry();
+            expected.Context.GlobalProperties.Add("TestPropertyGlobal", "contextpropvalue");
+            expected.Properties.Add("TestProperty", "TestPropertyValue");
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("TestPropertyGlobal"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.EventData>(expected);
+
+            // Items added to both event.Properties, and event.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestPropertyGlobal"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
         }
 
         [TestMethod]
@@ -145,7 +167,7 @@
             var telemetry = new EventTelemetry("my event");
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<EventTelemetry, AI.EventData>(telemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.EventData>(telemetry);
 
             Assert.AreEqual(10, item.sampleRate);
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -98,7 +98,7 @@
             ExceptionTelemetry original = new ExceptionTelemetry();
             original.Exception = null;
             original.SeverityLevel = null;
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
         }
@@ -107,7 +107,7 @@
         public void SerializeWritesItemVersionAsExpectedByEndpoint()
         {
             ExceptionTelemetry original = CreateExceptionTelemetry();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
         }
@@ -116,7 +116,7 @@
         public void SerializeUsesExceptionMessageIfTelemetryMessageNotProvided()
         {
             ExceptionTelemetry original = CreateExceptionTelemetry(new ArgumentException("Test"));
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual("Test", item.data.baseData.exceptions[0].message);
         }
@@ -126,7 +126,7 @@
         {
             ExceptionTelemetry original = CreateExceptionTelemetry(new ArgumentException("Test"));
             original.Message = "Custom";
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual("Custom", item.data.baseData.exceptions[0].message);
         }
@@ -138,7 +138,7 @@
             ExceptionTelemetry original = CreateExceptionTelemetry(outerException);
 
             original.Message = "Custom";
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual("Custom", item.data.baseData.exceptions[0].message);
             Assert.AreEqual("Inner", item.data.baseData.exceptions[1].message);
@@ -155,7 +155,7 @@
             ExceptionTelemetry original = CreateExceptionTelemetry(aggregateException);
 
             original.Message = "Custom";
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual("Custom", item.data.baseData.exceptions[0].message);
             Assert.AreEqual("Inner1", item.data.baseData.exceptions[1].message);
@@ -167,7 +167,7 @@
         {
             ExceptionTelemetry original = CreateExceptionTelemetry();
             original.SeverityLevel = SeverityLevel.Information;
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual(AI.SeverityLevel.Information, item.data.baseData.severityLevel.Value);
         }
@@ -177,7 +177,7 @@
         {
             var exception = new Exception();
             ExceptionTelemetry original = CreateExceptionTelemetry(exception);
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual(exception.GetType().FullName, item.data.baseData.exceptions[0].typeName);
         }
@@ -187,7 +187,7 @@
         {
             var exception = new Exception("Test Message");
             ExceptionTelemetry original = CreateExceptionTelemetry(exception);
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
 
             Assert.AreEqual(exception.Message, item.data.baseData.exceptions[0].message);
         }
@@ -196,7 +196,7 @@
         public void SerializeWritesDataBaseTypeAsExpectedByEndpoint()
         {
             ExceptionTelemetry original = CreateExceptionTelemetry();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
             Assert.AreEqual(typeof(AI.ExceptionData).Name, item.data.baseType);
         }
 
@@ -221,7 +221,7 @@
             var exception = new Exception("Root Message", innerException);
             ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             Assert.AreEqual(innerException.Message, item.data.baseData.exceptions[1].message);
         }
@@ -233,7 +233,7 @@
             var exception = new Exception("Test Exception", innerException);
             ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             Assert.AreEqual(exception.GetHashCode(), item.data.baseData.exceptions[1].outerId);
         }
@@ -244,7 +244,7 @@
             var exception = new AggregateException();
             ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             Assert.AreEqual(1, item.data.baseData.exceptions.Count);
         }
@@ -255,7 +255,7 @@
             var exception = new AggregateException("Test Exception", new[] { new Exception(), new Exception() });
             ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             Assert.AreEqual(exception.GetHashCode(), item.data.baseData.exceptions[1].outerId);
             Assert.AreEqual(exception.GetHashCode(), item.data.baseData.exceptions[2].outerId);
@@ -269,7 +269,7 @@
                 var exception = CreateExceptionWithStackTrace();
                 ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
 
-                var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+                var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
                 Assert.IsTrue(item.data.baseData.exceptions[0].hasFullStack);
             }
@@ -281,7 +281,7 @@
             var exception = new AggregateException("Test Exception", new Exception());
 
             ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             Assert.AreEqual(2, item.data.baseData.exceptions.Count);
         }
@@ -289,10 +289,9 @@
         [TestMethod]
         public void SerializeWritesPropertiesAsExpectedByEndpoint()
         {
-            ExceptionTelemetry expected = CreateExceptionTelemetry();
-            expected.Properties.Add("TestProperty", "TestValue");
+            ExceptionTelemetry expected = CreateExceptionTelemetry();            
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             AssertEx.AreEqual(expected.Properties.ToArray(), item.data.baseData.properties.ToArray());
         }
@@ -303,7 +302,7 @@
             ExceptionTelemetry expected = CreateExceptionTelemetry();
             expected.Metrics.Add("TestMetric", 4.2);
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
             AssertEx.AreEqual(expected.Metrics.ToArray(), item.data.baseData.measurements.ToArray());
         }
@@ -313,7 +312,7 @@
         {
             var exceptionTelemetry = new ExceptionTelemetry();
             exceptionTelemetry.Context.InstrumentationKey = Guid.NewGuid().ToString();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(exceptionTelemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(exceptionTelemetry);
 
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.IsNotNull(item.data.baseData.exceptions);
@@ -449,7 +448,7 @@
             var telemetry = new ExceptionTelemetry();
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<ExceptionTelemetry, AI.ExceptionData>(telemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(telemetry);
 
             Assert.AreEqual(10, item.sampleRate);
         }
@@ -464,6 +463,26 @@
 
             var result = deepComparator.Compare(telemetry, other);
             Assert.IsTrue(result.AreEqual, result.DifferencesString);
+        }
+
+        [TestMethod]
+        public void ExceptionTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = CreateExceptionTelemetry();
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("TestPropertyGlobal"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
+
+            // Items added to both Exception.Properties, and Exception.Context.Properties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestPropertyGlobal"));
         }
 
         private static Exception CreateExceptionWithStackTrace()
@@ -486,7 +505,9 @@
             }
 
             ExceptionTelemetry output = new ExceptionTelemetry(exception) { Timestamp = DateTimeOffset.UtcNow };
+            output.Context.GlobalProperties.Add("TestPropertyGlobal", "contextpropvalue");
             output.Context.InstrumentationKey = "required";
+            output.Properties.Add("TestProperty", "TestPropertyValue");
             return output;
         }
     }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/MetricTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/MetricTelemetryTest.cs
@@ -62,6 +62,30 @@
         }
 
         [TestMethod]
+        public void MetricTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = new MetricTelemetry();
+            expected.Name = "TestMetric";
+            expected.Context.GlobalProperties.Add("TestPropertyGlobal", "contextpropvalue");
+            expected.Properties.Add("TestProperty", "TestPropertyValue");
+
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("TestPropertyGlobal"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(expected);
+
+            // Items added to both Metric.Properties, and Metric.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestPropertyGlobal"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
+        }
+
+        [TestMethod]
         public void AggregateMetricTelemetrySerializesToJsonCorrectlyWithNamespace()
         {
             var expected = new MetricTelemetry();
@@ -77,7 +101,7 @@
             expected.StandardDeviation = 0.5;
             expected.Properties.Add("Property1", "Value1");
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<MetricTelemetry, AI.MetricData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(expected);
 
             Assert.AreEqual(typeof(AI.MetricData).Name, item.data.baseType);
 
@@ -112,7 +136,7 @@
             expected.StandardDeviation = 0.5;
             expected.Properties.Add("Property1", "Value1");
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<MetricTelemetry, AI.MetricData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(expected);
 
             Assert.AreEqual(typeof(AI.MetricData).Name, item.data.baseType);
 
@@ -182,7 +206,7 @@
             metricTelemetry.Context.InstrumentationKey = "AIC-" + Guid.NewGuid().ToString();
             ((ITelemetry)metricTelemetry).Sanitize();
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<MetricTelemetry, AI.MetricData>(metricTelemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(metricTelemetry);
 
             Assert.AreEqual(metricTelemetry.Context.InstrumentationKey, item.iKey);
         }
@@ -230,7 +254,7 @@
             original.Count = null;
             original.StandardDeviation = null;
             ((ITelemetry)original).Sanitize();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<MetricTelemetry, AI.MetricData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PageViewTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PageViewTelemetryTest.cs
@@ -60,7 +60,7 @@
             expected.Metrics.Add("Metric1", 30);
             expected.Properties.Add("Property1", "Value1");
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<PageViewTelemetry, AI.PageViewData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.PageViewData>(expected);
 
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.PageView);
@@ -72,6 +72,28 @@
             Assert.AreEqual(expected.Url.ToString(), item.data.baseData.url);
 
             AssertEx.AreEqual(expected.Properties.ToArray(), item.data.baseData.properties.ToArray());
+        }
+
+        [TestMethod]
+        public void PageViewTelemetryTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = new PageViewTelemetry();
+            expected.Context.GlobalProperties.Add("TestPropertyGlobal", "contextpropvalue");
+            expected.Properties.Add("TestProperty", "TestPropertyValue");
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("TestPropertyGlobal"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.PageViewData>(expected);
+
+            // Items added to both PageViewTelemetry.Properties, and PageViewTelemetry.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestPropertyGlobal"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
         }
 
         [TestMethod]
@@ -129,7 +151,7 @@
             var telemetry = new PageViewTelemetry("my page view");
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<PageViewTelemetry, AI.PageViewData>(telemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.PageViewData>(telemetry);
 
             Assert.AreEqual(10, item.sampleRate);
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PerformanceCounterTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PerformanceCounterTelemetryTest.cs
@@ -19,7 +19,7 @@
             original.CounterName = null;
             original.InstanceName = null;
             ((ITelemetry)original).Sanitize();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<PerformanceCounterTelemetry, AI.MetricData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -77,9 +77,30 @@
             original.ResponseCode = null;
             original.Url = null;
             ((ITelemetry)original).Sanitize();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, AI.RequestData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RequestData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
+        }
+
+        [TestMethod]
+        public void RequestTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = CreateTestTelemetry();
+
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("itempropkey"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("contextpropkey"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RequestData>(expected);
+
+            // Items added to both request.Properties, and request.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("contextpropkey"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("itempropkey"));
         }
 
         [TestMethod]
@@ -89,7 +110,7 @@
 
             ((ITelemetry)expected).Sanitize();
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, AI.RequestData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RequestData>(expected);
 
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.Request);
@@ -117,7 +138,7 @@
                 var requestTelemetry = new RequestTelemetry();
                 requestTelemetry.Context.InstrumentationKey = Guid.NewGuid().ToString();
                 ((ITelemetry)requestTelemetry).Sanitize();
-                var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, AI.RequestData>(requestTelemetry);
+                var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RequestData>(requestTelemetry);
 
                 Assert.AreEqual(2, item.data.baseData.ver);
                 Assert.IsNotNull(item.data.baseData.id);
@@ -189,7 +210,7 @@
   
             ((ITelemetry)telemetry).Sanitize();  
   
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, AI.RequestData>(telemetry);  
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RequestData>(telemetry);  
   
             // RequestTelemetry.Id is deprecated and you cannot access it. Method above will validate that all required fields would be populated  
             // AssertEx.Contains("id", telemetry.Id, StringComparison.OrdinalIgnoreCase);  
@@ -211,7 +232,7 @@
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
             ((ITelemetry)telemetry).Sanitize();
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<RequestTelemetry, AI.RequestData>(telemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RequestData>(telemetry);
 
             Assert.AreEqual(10, item.sampleRate);
         }
@@ -241,7 +262,8 @@
             request.Success = true;
             request.Url = new Uri("http://localhost/myapp/MyPage.aspx");
             request.Metrics.Add("Metric1", 30);
-            request.Properties.Add("userHostAddress", "::1");
+            request.Properties.Add("itempropkey", "::1");
+            request.Context.GlobalProperties.Add("contextpropkey", "contextpropvalue");
             return request;
         }
     }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/SessionStateTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/SessionStateTelemetryTest.cs
@@ -50,7 +50,7 @@
         public void SerializeWritesStateAsExpectedByEndpoint()
         {
             var telemetry = new SessionStateTelemetry { State = SessionState.End };
-            TelemetryItem<EventData> envelope = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<SessionStateTelemetry, EventData>(telemetry);
+            TelemetryItem<EventData> envelope = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<EventData>(telemetry);
             Assert.AreEqual("Session ended", envelope.data.baseData.name);
             Assert.AreEqual(2, envelope.data.baseData.ver);
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryContextTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryContextTest.cs
@@ -9,6 +9,7 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Microsoft.ApplicationInsights.TestFramework;
+    using System.Collections.Generic;
 
     [TestClass]
     public class TelemetryContextTest
@@ -173,6 +174,24 @@
             context.Session.Id = "Test Value";
             string json = CopyAndSerialize(context);
             AssertEx.Contains("\"" + ContextTagKeys.Keys.SessionId + "\":\"Test Value\"", json, StringComparison.OrdinalIgnoreCase);
+        }
+
+        [TestMethod]
+        public void TestSanitizeGlobalProperties()
+        {
+            var addedKeyWithSizeAboveLimit = new string('K', Property.MaxDictionaryNameLength + 1);
+            var addedValueWithSizeAboveLimit = new string('V', Property.MaxValueLength + 1);
+
+            var expectedKeyWithSizeWithinLimit = new string('K', Property.MaxDictionaryNameLength);
+            var expectedValueWithSizeWithinLimit = new string('V', Property.MaxValueLength);
+
+            var context = new TelemetryContext();
+            context.GlobalProperties.Add(addedKeyWithSizeAboveLimit, addedValueWithSizeAboveLimit);
+            context.SanitizeGlobalProperties();
+
+            Assert.IsTrue(context.GlobalProperties.ContainsKey(expectedKeyWithSizeWithinLimit));
+            var value = context.GlobalProperties[expectedKeyWithSizeWithinLimit];
+            Assert.AreEqual(expectedValueWithSizeWithinLimit, value);
         }
 
         private static string CopyAndSerialize(TelemetryContext source)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryItemTestHelper.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryItemTestHelper.cs
@@ -15,7 +15,7 @@
         /// <summary>
         /// Serializes and deserializes the telemetry item and returns the results.
         /// </summary>
-        internal static AI.TelemetryItem<TelemetryDataType> SerializeDeserializeTelemetryItem<TODO_DELETEME, TelemetryDataType>(ITelemetry telemetry)
+        internal static AI.TelemetryItem<TelemetryDataType> SerializeDeserializeTelemetryItem<TelemetryDataType>(ITelemetry telemetry)
         {
             byte[] b = JsonSerializer.Serialize(telemetry, compress: false);
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TraceTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TraceTelemetryTest.cs
@@ -64,7 +64,7 @@
             expected.Message = "My Test";
             expected.Properties.Add("Property2", "Value2");
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TraceTelemetry, AI.MessageData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MessageData>(expected);
 
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.Message);
@@ -80,7 +80,7 @@
             var expected = new TraceTelemetry { SeverityLevel = SeverityLevel.Information };
             ((ITelemetry)expected).Sanitize();
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TraceTelemetry, AI.MessageData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MessageData>(expected);
 
             Assert.AreEqual(AI.SeverityLevel.Information, item.data.baseData.severityLevel.Value);
         }
@@ -92,7 +92,7 @@
             original.Message = null;
             original.SeverityLevel = null;
             ((ITelemetry)original).Sanitize();
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TraceTelemetry, AI.MessageData>(original);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MessageData>(original);
 
             Assert.AreEqual(2, item.data.baseData.ver);
         }
@@ -141,7 +141,7 @@
             var telemetry = new TraceTelemetry("my trace");
             ((ISupportSampling)telemetry).SamplingPercentage = 10;
 
-            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<TraceTelemetry, AI.MessageData>(telemetry);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MessageData>(telemetry);
 
             Assert.AreEqual(10, item.sampleRate);
         }
@@ -161,6 +161,28 @@
             var result = deepComparator.Compare(trace, other);
 
             Assert.IsTrue(result.AreEqual, result.DifferencesString);
+        }
+
+        [TestMethod]
+        public void TraceTelemetryPropertiesFromContextAndItemSerializesToPropertiesInJson()
+        {
+            var expected = new TraceTelemetry();
+            expected.Context.GlobalProperties.Add("contextpropkey", "contextpropvalue");
+            expected.Properties.Add("TestProperty", "TestPropertyValue");
+            ((ITelemetry)expected).Sanitize();
+
+            Assert.AreEqual(1, expected.Properties.Count);
+            Assert.AreEqual(1, expected.Context.GlobalProperties.Count);
+
+            Assert.IsTrue(expected.Properties.ContainsKey("TestProperty"));
+            Assert.IsTrue(expected.Context.GlobalProperties.ContainsKey("contextpropkey"));
+
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MessageData>(expected);
+
+            // Items added to both MessageData.Properties, and MessageData.Context.GlobalProperties are serialized to properties.
+            Assert.AreEqual(2, item.data.baseData.properties.Count);
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("contextpropkey"));
+            Assert.IsTrue(item.data.baseData.properties.ContainsKey("TestProperty"));
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/JsonSerializerTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/JsonSerializerTest.cs
@@ -41,6 +41,23 @@
         }
 
         [TestMethod]
+        public void SanitizesTelemetryContextGlobalProperties()
+        {
+            var addedValueWithSizeAboveLimit = new string('V', Property.MaxValueLength + 1);
+            var expectedValueWithSizeWithinLimit = new string('V', Property.MaxValueLength);
+
+            EventTelemetry t = new EventTelemetry("myevent");
+            t.Context.GlobalProperties.Add("mykey", addedValueWithSizeAboveLimit);
+
+            string exceptionAsJson = JsonSerializer.SerializeAsString(t);
+
+            JObject obj = JsonConvert.DeserializeObject<JObject>(exceptionAsJson);
+
+            Assert.AreEqual(expectedValueWithSizeWithinLimit, obj["data"]["baseData"]["properties"]["mykey"]);
+            
+        }
+
+        [TestMethod]
         public void SanitizesTimestampInIsoFormat()
         {
             EventTelemetry t = new EventTelemetry();

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -275,6 +275,8 @@
                     listener.EnableEvents(RichPayloadEventSource.Log.EventSourceInternal, EventLevel.Verbose, keywords);
 
                     item.Context.Properties.Add("property1", "value1");
+                    (item as ISupportProperties)?.Properties.Add("itemprop1","itemvalue1");
+                    item.Context.GlobalProperties.Add("globalproperty1", "globalvalue1");
                     item.Context.User.Id = "testUserId";
                     item.Context.Operation.Id = Guid.NewGuid().ToString();
 
@@ -310,6 +312,25 @@
 
                     Assert.AreEqual(2, keysFound);
                     Assert.IsNotNull(actualEvent.Payload[2]);
+
+                    if(item is ISupportProperties)
+                    {
+                        object[] properties = (object[])((IDictionary<string, object>)actualEvent.Payload[2])["properties"];                        
+                        if(!(item is PerformanceCounterTelemetry))
+                        {
+                            // There should be 3 entries in properties
+                            // 1. from item's ISupportProperties.Properties
+                            // 2. from item context.GlobalProperties
+                            // 3. from item context.Properties                            
+                            Assert.AreEqual(3, properties.Length);                                                        
+                        }
+                        else
+                        {
+                            // There should be 4 entries in properties                            
+                            // 4. PerfCounter name is a custom property.
+                            Assert.AreEqual(4, properties.Length);
+                        }
+                    }
 
                     var expectedProperties = dataType.GetProperties().AsEnumerable();
                     var actualPropertiesPayload = (IDictionary<string, object>)actualEvent.Payload[2];

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -274,7 +274,9 @@
                 {
                     listener.EnableEvents(RichPayloadEventSource.Log.EventSourceInternal, EventLevel.Verbose, keywords);
 
+#pragma warning disable CS0618 // Type or member is obsolete
                     item.Context.Properties.Add("property1", "value1");
+#pragma warning restore CS0618 // Type or member is obsolete
                     (item as ISupportProperties)?.Properties.Add("itemprop1","itemvalue1");
                     item.Context.GlobalProperties.Add("globalproperty1", "globalvalue1");
                     item.Context.User.Id = "testUserId";
@@ -315,8 +317,10 @@
 
                     if(item is ISupportProperties)
                     {
-                        object[] properties = (object[])((IDictionary<string, object>)actualEvent.Payload[2])["properties"];                        
-                        if(!(item is PerformanceCounterTelemetry))
+                        object[] properties = (object[])((IDictionary<string, object>)actualEvent.Payload[2])["properties"];
+#pragma warning disable CS0618 // Type or member is obsolete
+                        if (!(item is PerformanceCounterTelemetry))
+#pragma warning restore CS0618 // Type or member is obsolete
                         {
                             // There should be 3 entries in properties
                             // 1. from item's ISupportProperties.Properties

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -122,8 +122,8 @@
             Assert.IsTrue(telemetry.Context.Operation.ParentId.StartsWith("|activityRoot."));
 
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual(1, telemetry.Context.Properties.Count);
-            Assert.AreEqual("v1", telemetry.Context.Properties["k1"]);
+            Assert.AreEqual(1, telemetry.Properties.Count);
+            Assert.AreEqual("v1", telemetry.Properties["k1"]);
             currentActivity.Stop();
         }
 
@@ -145,7 +145,7 @@
             Assert.AreEqual("rootId", telemetry.Context.Operation.Id);
             Assert.IsNull(telemetry.Context.Operation.ParentId);
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual(0, telemetry.Context.Properties.Count);
+            Assert.AreEqual(0, telemetry.Properties.Count);
             currentActivity.Stop();
         }
 
@@ -166,8 +166,8 @@
             Assert.AreEqual("activityRoot", telemetry.Context.Operation.Id);
             Assert.AreEqual("parentId", telemetry.Context.Operation.ParentId);
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
-            Assert.AreEqual(1, telemetry.Context.Properties.Count);
-            Assert.AreEqual("v1", telemetry.Context.Properties["k1"]);
+            Assert.AreEqual(1, telemetry.Properties.Count);
+            Assert.AreEqual("v1", telemetry.Properties["k1"]);
             currentActivity.Stop();
         }
     }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -99,9 +99,11 @@
             Assert.IsTrue(telemetry.Context.Operation.ParentId.StartsWith("|parent."));
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
 
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.AreEqual(2, telemetry.Context.Properties.Count);
             Assert.AreEqual("v1", telemetry.Context.Properties["k1"]);
             Assert.AreEqual("v2", telemetry.Context.Properties["k2"]);
+#pragma warning restore CS0618 // Type or member is obsolete
             currentActivity.Stop();
         }
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetrySinkTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetrySinkTests.cs
@@ -33,13 +33,13 @@
             chainBuilder.Use((next) =>
             {
                 var first = new StubTelemetryProcessor(next);
-                first.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenByFirst", "true");
+                first.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenByFirst", "true");
                 return first;
             });
             chainBuilder.Use((next) =>
             {
                 var second = new StubTelemetryProcessor(next);
-                second.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenBySecond", "true");
+                second.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenBySecond", "true");
                 return second;
             });
 
@@ -47,8 +47,8 @@
             client.TrackTrace("t1");
 
             Assert.AreEqual(1, sentTelemetry.Count);
-            Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey("SeenByFirst"));
-            Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey("SeenBySecond"));
+            Assert.IsTrue(sentTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByFirst"));
+            Assert.IsTrue(sentTelemetry[0].Context.GlobalProperties.ContainsKey("SeenBySecond"));
         }
 
         [TestMethod]
@@ -66,13 +66,13 @@
             chainBuilder.Use((next) =>
             {
                 var first = new StubTelemetryProcessor(next);
-                first.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenByFirst", "true");
+                first.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenByFirst", "true");
                 return first;
             });
             chainBuilder.Use((next) =>
             {
                 var second = new StubTelemetryProcessor(next);
-                second.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenBySecond", "true");
+                second.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenBySecond", "true");
                 return second;
             });
 
@@ -81,8 +81,8 @@
 
             Assert.IsFalse(configuration.TelemetryProcessors.OfType<StubTelemetryProcessor>().Any()); // Both processors belong to the sink, not to the common chain.
             Assert.AreEqual(1, sentTelemetry.Count);
-            Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey("SeenByFirst"));
-            Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey("SeenBySecond"));
+            Assert.IsTrue(sentTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByFirst"));
+            Assert.IsTrue(sentTelemetry[0].Context.GlobalProperties.ContainsKey("SeenBySecond"));
         }
 
         [TestMethod]
@@ -100,7 +100,7 @@
             commonChainBuilder.Use((next) =>
             {
                 var commonProcessor = new StubTelemetryProcessor(next);
-                commonProcessor.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenByCommonProcessor", "true");
+                commonProcessor.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenByCommonProcessor", "true");
                 return commonProcessor;
             });
 
@@ -109,7 +109,7 @@
             sinkChainBuilder.Use((next) =>
             {
                 var sinkProcessor = new StubTelemetryProcessor(next);
-                sinkProcessor.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenBySinkProcessor", "true");
+                sinkProcessor.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenBySinkProcessor", "true");
                 return sinkProcessor;
             });
 
@@ -117,8 +117,8 @@
             client.TrackTrace("t1");
 
             Assert.AreEqual(1, sentTelemetry.Count);
-            Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey("SeenByCommonProcessor"));
-            Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey("SeenBySinkProcessor"));
+            Assert.IsTrue(sentTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByCommonProcessor"));
+            Assert.IsTrue(sentTelemetry[0].Context.GlobalProperties.ContainsKey("SeenBySinkProcessor"));
         }
 
         [TestMethod]
@@ -192,7 +192,7 @@
             commonChainBuilder.Use((next) =>
             {
                 var commonProcessor = new StubTelemetryProcessor(next);
-                commonProcessor.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenByCommonProcessor", "true");
+                commonProcessor.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenByCommonProcessor", "true");
                 return commonProcessor;
             });
 
@@ -205,7 +205,7 @@
             firstSinkChainBuilder.Use((next) =>
             {
                 var firstSinkTelemetryProcessor = new StubTelemetryProcessor(next);
-                firstSinkTelemetryProcessor.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenByFirstSinkProcessor", "true");
+                firstSinkTelemetryProcessor.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenByFirstSinkProcessor", "true");
                 return firstSinkTelemetryProcessor;
             });
             configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder = firstSinkChainBuilder;
@@ -220,7 +220,7 @@
             secondSinkChainBuilder.Use((next) =>
             {
                 var secondSinkTelemetryProcessor = new StubTelemetryProcessor(next);
-                secondSinkTelemetryProcessor.OnProcess = (telemetry) => telemetry.Context.Properties.Add("SeenBySecondSinkProcessor", "true");
+                secondSinkTelemetryProcessor.OnProcess = (telemetry) => telemetry.Context.GlobalProperties.Add("SeenBySecondSinkProcessor", "true");
                 return secondSinkTelemetryProcessor;
             });
             secondSink.TelemetryProcessorChainBuilder = secondSinkChainBuilder;
@@ -229,14 +229,14 @@
             client.TrackTrace("t1");
 
             Assert.AreEqual(1, firstChannelTelemetry.Count);
-            Assert.IsTrue(firstChannelTelemetry[0].Context.Properties.ContainsKey("SeenByCommonProcessor"));
-            Assert.IsTrue(firstChannelTelemetry[0].Context.Properties.ContainsKey("SeenByFirstSinkProcessor"));
-            Assert.IsFalse(firstChannelTelemetry[0].Context.Properties.ContainsKey("SeenBySecondSinkProcessor"));
+            Assert.IsTrue(firstChannelTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByCommonProcessor"));
+            Assert.IsTrue(firstChannelTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByFirstSinkProcessor"));
+            Assert.IsFalse(firstChannelTelemetry[0].Context.GlobalProperties.ContainsKey("SeenBySecondSinkProcessor"));
 
             Assert.AreEqual(1, secondChannelTelemetry.Count);
-            Assert.IsTrue(secondChannelTelemetry[0].Context.Properties.ContainsKey("SeenByCommonProcessor"));
-            Assert.IsFalse(secondChannelTelemetry[0].Context.Properties.ContainsKey("SeenByFirstSinkProcessor"));
-            Assert.IsTrue(secondChannelTelemetry[0].Context.Properties.ContainsKey("SeenBySecondSinkProcessor"));
+            Assert.IsTrue(secondChannelTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByCommonProcessor"));
+            Assert.IsFalse(secondChannelTelemetry[0].Context.GlobalProperties.ContainsKey("SeenByFirstSinkProcessor"));
+            Assert.IsTrue(secondChannelTelemetry[0].Context.GlobalProperties.ContainsKey("SeenBySecondSinkProcessor"));
         }
 
         [TestMethod]

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetrySinkTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetrySinkTests.cs
@@ -284,6 +284,16 @@
             Assert.IsTrue(secondSinkTelemetryProcessorDisposed);
             Assert.IsFalse(firstChannelDisposed);
             Assert.IsFalse(secondChannelDisposed);
+
+            // does not throw
+            try
+            {
+                client.TrackTrace("t2");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.ToString());
+            }
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Extensibility/ApplicationInsightsTelemetryPipelineTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Extensibility/ApplicationInsightsTelemetryPipelineTests.cs
@@ -247,8 +247,8 @@ namespace Microsoft.ApplicationInsights.Metrics.Extensibility
                         TestUtil.ValidateNumericAggregateValues(metricTelemetry, "NS", "mid-foobar", expectedCount, sum: 0, max: 0, min: 0, stdDev: 0);
                     
                         Assert.AreEqual(1, metricTelemetry.Properties.Count);
-                        Assert.IsTrue(metricTelemetry.Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                        Assert.AreEqual("0", metricTelemetry.Context.Properties[TestUtil.AggregationIntervalMonikerPropertyKey]);
+                        Assert.IsTrue(metricTelemetry.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                        Assert.AreEqual("0", metricTelemetry.Properties[TestUtil.AggregationIntervalMonikerPropertyKey]);
                         Assert.IsTrue((metricTelemetry.Timestamp - DateTimeOffset.Now).Duration() < TimeSpan.FromMilliseconds(100));
 
                         Assert.AreEqual(mockInstrumentationKey, metricTelemetry.Context.InstrumentationKey);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Implementation/UtilTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Implementation/UtilTests.cs
@@ -98,9 +98,15 @@ namespace Microsoft.ApplicationInsights.Metrics
                 source.User.Id = "U";
                 source.User.UserAgent = "V";
 #pragma warning restore 618
+#pragma warning disable CS0618 // Type or member is obsolete
                 source.Properties["Dim 1"] = "W";
                 source.Properties["Dim 2"] = "X";
                 source.Properties["Dim 3"] = "Y";
+#pragma warning restore CS0618 // Type or member is obsolete
+
+                source.GlobalProperties["Dim 1G"] = "W";
+                source.GlobalProperties["Dim 2G"] = "X";
+                source.GlobalProperties["Dim 3G"] = "Y";
 
                 Util.CopyTelemetryContext(source, target);
 
@@ -130,6 +136,7 @@ namespace Microsoft.ApplicationInsights.Metrics
                 Assert.AreEqual("V", target.User.UserAgent);
 #pragma warning restore 618
 
+#pragma warning disable CS0618 // Type or member is obsolete
                 Assert.IsTrue(target.Properties.ContainsKey("Dim 1"));
                 Assert.AreEqual("W", target.Properties["Dim 1"]);
 
@@ -138,6 +145,15 @@ namespace Microsoft.ApplicationInsights.Metrics
 
                 Assert.IsTrue(target.Properties.ContainsKey("Dim 3"));
                 Assert.AreEqual("Y", target.Properties["Dim 3"]);
+#pragma warning restore CS0618 // Type or member is obsolete
+                Assert.IsTrue(target.GlobalProperties.ContainsKey("Dim 1G"));
+                Assert.AreEqual("W", target.GlobalProperties["Dim 1G"]);
+
+                Assert.IsTrue(target.GlobalProperties.ContainsKey("Dim 2G"));
+                Assert.AreEqual("X", target.GlobalProperties["Dim 2G"]);
+
+                Assert.IsTrue(target.GlobalProperties.ContainsKey("Dim 3G"));
+                Assert.AreEqual("Y", target.GlobalProperties["Dim 3G"]);
             }
         }
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientExtensionTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientExtensionTests.cs
@@ -298,7 +298,11 @@
 
                 foreach (var tag in Activity.Current.Tags)
                 {
-                    telemetry.Context.Properties[tag.Key] = tag.Value;
+                    var telProp = telemetry as ISupportProperties;
+                    if(telProp != null)
+                    {
+                        telProp.Properties[tag.Key] = tag.Value;
+                    }                        
                 }
             }
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -1055,7 +1055,7 @@
             // ChuckNorrisTeamUnitTests resource in Prototypes1
             var config = new TelemetryConfiguration("687218b9-2250-4eaa-8946-2dd5cc35eff8");
             var telemetryClient = new TelemetryClient(config);
-            telemetryClient.Context.Properties.Add(unicodeString, unicodeString);
+            telemetryClient.Context.GlobalProperties.Add(unicodeString, unicodeString);
             
             telemetryClient.Initialize(telemetry1);
             telemetryClient.Initialize(telemetry2);
@@ -1125,8 +1125,8 @@
                 telemetryPipeline.GetMetricManager().Flush();
                 Assert.AreEqual(1, sentTelemetry.Count);
                 TestUtil.ValidateNumericAggregateValues(sentTelemetry[0], "", "CowsSold", 2, 1.1, 0.6, 0.5, 0.05);
-                Assert.AreEqual(1, sentTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual(1, ((MetricTelemetry)sentTelemetry[0]).Properties.Count);                
+                Assert.IsTrue(((MetricTelemetry)sentTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
                 sentTelemetry.Clear();
 
                 metric.TrackValue(0.7);
@@ -1135,8 +1135,8 @@
                 telemetryPipeline.GetMetricManager().Flush();
                 Assert.AreEqual(1, sentTelemetry.Count);
                 TestUtil.ValidateNumericAggregateValues(sentTelemetry[0], "", "CowsSold", 2, 1.5, 0.8, 0.7, 0.05);
-                Assert.AreEqual(1, sentTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual(1, ((MetricTelemetry)sentTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)sentTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
                 sentTelemetry.Clear();
             }
             {
@@ -1154,9 +1154,9 @@
                 telemetryPipeline.GetMetricManager().Flush();
                 Assert.AreEqual(1, sentTelemetry.Count);
                 TestUtil.ValidateNumericAggregateValues(sentTelemetry[0], "", "CowsSold", 2, 1.1, 0.6, 0.5, 0.05);
-                Assert.AreEqual(2, sentTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("Purple", sentTelemetry[0].Context.Properties["Color"]);
+                Assert.AreEqual(2, ((MetricTelemetry)sentTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)sentTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("Purple", ((MetricTelemetry)sentTelemetry[0]).Properties["Color"]);
                 sentTelemetry.Clear();
 
                 metric.TryTrackValue(0.7, "Purple");
@@ -1165,9 +1165,9 @@
                 telemetryPipeline.GetMetricManager().Flush();
                 Assert.AreEqual(1, sentTelemetry.Count);
                 TestUtil.ValidateNumericAggregateValues(sentTelemetry[0], String.Empty, "CowsSold", 2, 1.5, 0.8, 0.7, 0.05);
-                Assert.AreEqual(2, sentTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(sentTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("Purple", sentTelemetry[0].Context.Properties["Color"]);
+                Assert.AreEqual(2, ((MetricTelemetry)sentTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)sentTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("Purple", ((MetricTelemetry)sentTelemetry[0]).Properties["Color"]);
                 sentTelemetry.Clear();
             }
             {
@@ -1190,10 +1190,10 @@
                                                         .ToArray();
 
                 TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], String.Empty, "CowsSold", 2, 1.1, 0.6, 0.5, 0.05);
-                Assert.AreEqual(3, orderedTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("Purple", orderedTelemetry[0].Context.Properties["Color"]);
-                Assert.AreEqual("Large", orderedTelemetry[0].Context.Properties["Size"]);
+                Assert.AreEqual(3, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("Purple", ((MetricTelemetry)orderedTelemetry[0]).Properties["Color"]);
+                Assert.AreEqual("Large", ((MetricTelemetry)orderedTelemetry[0]).Properties["Size"]);
                 sentTelemetry.Clear();
 
                 metric.TryTrackValue(0.7, "Purple", "Large");
@@ -1208,16 +1208,16 @@
                                             .ToArray();
 
                 TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], String.Empty, "CowsSold", 1, 0.8, 0.8, 0.8, 0);
-                Assert.AreEqual(3, orderedTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("Purple", orderedTelemetry[0].Context.Properties["Color"]);
-                Assert.AreEqual("Small", orderedTelemetry[0].Context.Properties["Size"]);
+                Assert.AreEqual(3, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("Purple", ((MetricTelemetry)orderedTelemetry[0]).Properties["Color"]);
+                Assert.AreEqual("Small", ((MetricTelemetry)orderedTelemetry[0]).Properties["Size"]);
 
                 TestUtil.ValidateNumericAggregateValues(orderedTelemetry[1], String.Empty, "CowsSold", 1, 0.7, 0.7, 0.7, 0);
-                Assert.AreEqual(3, orderedTelemetry[1].Context.Properties.Count);
-                Assert.IsTrue(orderedTelemetry[1].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("Purple", orderedTelemetry[1].Context.Properties["Color"]);
-                Assert.AreEqual("Large", orderedTelemetry[1].Context.Properties["Size"]);
+                Assert.AreEqual(3, ((MetricTelemetry)orderedTelemetry[1]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[1]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("Purple", ((MetricTelemetry)orderedTelemetry[1]).Properties["Color"]);
+                Assert.AreEqual("Large", ((MetricTelemetry)orderedTelemetry[1]).Properties["Size"]);
 
                 sentTelemetry.Clear();
             }
@@ -1265,18 +1265,18 @@
                                         .ToArray();
 
                 TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], "Test MetricNamespace", "Test MetricId", 2, 1.1, 0.6, 0.5, 0.05);
-                Assert.AreEqual(11, orderedTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("DV1", orderedTelemetry[0].Context.Properties["Dim 1"]);
-                Assert.AreEqual("DV2", orderedTelemetry[0].Context.Properties["Dim 2"]);
-                Assert.AreEqual("DV3", orderedTelemetry[0].Context.Properties["Dim 3"]);
-                Assert.AreEqual("DV4", orderedTelemetry[0].Context.Properties["Dim 4"]);
-                Assert.AreEqual("DV5", orderedTelemetry[0].Context.Properties["Dim 5"]);
-                Assert.AreEqual("DV6", orderedTelemetry[0].Context.Properties["Dim 6"]);
-                Assert.AreEqual("DV7", orderedTelemetry[0].Context.Properties["Dim 7"]);
-                Assert.AreEqual("DV8", orderedTelemetry[0].Context.Properties["Dim 8"]);
-                Assert.AreEqual("DV9", orderedTelemetry[0].Context.Properties["Dim 9"]);
-                Assert.AreEqual("DV10", orderedTelemetry[0].Context.Properties["Dim 10"]);
+                Assert.AreEqual(11, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("DV1", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 1"]);
+                Assert.AreEqual("DV2", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 2"]);
+                Assert.AreEqual("DV3", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 3"]);
+                Assert.AreEqual("DV4", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 4"]);
+                Assert.AreEqual("DV5", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 5"]);
+                Assert.AreEqual("DV6", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 6"]);
+                Assert.AreEqual("DV7", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 7"]);
+                Assert.AreEqual("DV8", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 8"]);
+                Assert.AreEqual("DV9", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 9"]);
+                Assert.AreEqual("DV10", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 10"]);
                 sentTelemetry.Clear();
 
                 metric.TryTrackValue(0.7, "DV1", "DV2", "DV3", "DV4", "DV5", "DV6", "DV7", "DV8", "DV9", "DV10");
@@ -1291,32 +1291,32 @@
                                         .ToArray();
 
                 TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], "Test MetricNamespace", "Test MetricId", 1, 0.8, 0.8, 0.8, 0);
-                Assert.AreEqual(11, orderedTelemetry[0].Context.Properties.Count);
-                Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("DV1", orderedTelemetry[0].Context.Properties["Dim 1"]);
-                Assert.AreEqual("DV2", orderedTelemetry[0].Context.Properties["Dim 2"]);
-                Assert.AreEqual("DV3", orderedTelemetry[0].Context.Properties["Dim 3"]);
-                Assert.AreEqual("DV4", orderedTelemetry[0].Context.Properties["Dim 4"]);
-                Assert.AreEqual("DV5", orderedTelemetry[0].Context.Properties["Dim 5"]);
-                Assert.AreEqual("DV6a", orderedTelemetry[0].Context.Properties["Dim 6"]);
-                Assert.AreEqual("DV7", orderedTelemetry[0].Context.Properties["Dim 7"]);
-                Assert.AreEqual("DV8", orderedTelemetry[0].Context.Properties["Dim 8"]);
-                Assert.AreEqual("DV9", orderedTelemetry[0].Context.Properties["Dim 9"]);
-                Assert.AreEqual("DV10", orderedTelemetry[0].Context.Properties["Dim 10"]);
+                Assert.AreEqual(11, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("DV1", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 1"]);
+                Assert.AreEqual("DV2", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 2"]);
+                Assert.AreEqual("DV3", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 3"]);
+                Assert.AreEqual("DV4", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 4"]);
+                Assert.AreEqual("DV5", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 5"]);
+                Assert.AreEqual("DV6a", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 6"]);
+                Assert.AreEqual("DV7", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 7"]);
+                Assert.AreEqual("DV8", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 8"]);
+                Assert.AreEqual("DV9", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 9"]);
+                Assert.AreEqual("DV10", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 10"]);
 
                 TestUtil.ValidateNumericAggregateValues(orderedTelemetry[1], "Test MetricNamespace", "Test MetricId", 1, 0.7, 0.7, 0.7, 0);
-                Assert.AreEqual(11, orderedTelemetry[1].Context.Properties.Count);
-                Assert.IsTrue(orderedTelemetry[1].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-                Assert.AreEqual("DV1", orderedTelemetry[1].Context.Properties["Dim 1"]);
-                Assert.AreEqual("DV2", orderedTelemetry[1].Context.Properties["Dim 2"]);
-                Assert.AreEqual("DV3", orderedTelemetry[1].Context.Properties["Dim 3"]);
-                Assert.AreEqual("DV4", orderedTelemetry[1].Context.Properties["Dim 4"]);
-                Assert.AreEqual("DV5", orderedTelemetry[1].Context.Properties["Dim 5"]);
-                Assert.AreEqual("DV6", orderedTelemetry[1].Context.Properties["Dim 6"]);
-                Assert.AreEqual("DV7", orderedTelemetry[1].Context.Properties["Dim 7"]);
-                Assert.AreEqual("DV8", orderedTelemetry[1].Context.Properties["Dim 8"]);
-                Assert.AreEqual("DV9", orderedTelemetry[1].Context.Properties["Dim 9"]);
-                Assert.AreEqual("DV10", orderedTelemetry[1].Context.Properties["Dim 10"]);
+                Assert.AreEqual(11, ((MetricTelemetry)orderedTelemetry[1]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[1]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("DV1", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 1"]);
+                Assert.AreEqual("DV2", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 2"]);
+                Assert.AreEqual("DV3", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 3"]);
+                Assert.AreEqual("DV4", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 4"]);
+                Assert.AreEqual("DV5", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 5"]);
+                Assert.AreEqual("DV6", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 6"]);
+                Assert.AreEqual("DV7", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 7"]);
+                Assert.AreEqual("DV8", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 8"]);
+                Assert.AreEqual("DV9", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 9"]);
+                Assert.AreEqual("DV10", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 10"]);
 
                 sentTelemetry.Clear();
             }
@@ -1814,31 +1814,31 @@
                                                         .ToArray();
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], String.Empty, "Metric A", 8, 916, 118, 111, 2.29128784747792);
-            Assert.AreEqual(2, orderedTelemetry[0].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Val", orderedTelemetry[0].Context.Properties["Dim1"]);
+            Assert.AreEqual(2, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Val", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim1"]);
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[1], String.Empty, "Metric A", 8, 836, 108, 101, 2.29128784747792);
-            Assert.AreEqual(1, orderedTelemetry[1].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[1].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual(1, ((MetricTelemetry)orderedTelemetry[1]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[1]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[2], String.Empty, "Metric A", 4, 1250, 314, 311, 1.11803398874989);
-            Assert.AreEqual(2, orderedTelemetry[2].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[2].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Val", orderedTelemetry[2].Context.Properties["Dim1"]);
+            Assert.AreEqual(2, ((MetricTelemetry)orderedTelemetry[2]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[2]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Val", ((MetricTelemetry)orderedTelemetry[2]).Properties["Dim1"]);
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[3], String.Empty, "Metric A", 4, 1210, 304, 301, 1.11803398874989);
-            Assert.AreEqual(1, orderedTelemetry[3].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[3].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual(1, ((MetricTelemetry)orderedTelemetry[3]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[3]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[4], String.Empty, "Metric A", 2, 631, 316, 315, 0.5);
-            Assert.AreEqual(2, orderedTelemetry[4].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[4].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Val", orderedTelemetry[4].Context.Properties["Dim1"]);
+            Assert.AreEqual(2, ((MetricTelemetry)orderedTelemetry[4]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[4]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Val", ((MetricTelemetry)orderedTelemetry[4]).Properties["Dim1"]);
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[5], String.Empty, "Metric A", 2, 611, 306, 305, 0.5);
-            Assert.AreEqual(1, orderedTelemetry[5].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[5].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual(1, ((MetricTelemetry)orderedTelemetry[5]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[5]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
 
             orderedTelemetry = sentTelemetry2
                                         .OrderByDescending((t) => ((MetricTelemetry) t).Count * 10000 + ((MetricTelemetry) t).Sum)
@@ -1846,13 +1846,13 @@
                                         .ToArray();
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], String.Empty, "Metric A", 2, 423, 212, 211, 0.5);
-            Assert.AreEqual(2, orderedTelemetry[0].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Val", orderedTelemetry[0].Context.Properties["Dim1"]);
+            Assert.AreEqual(2, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Val", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim1"]);
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[1], String.Empty, "Metric A", 2, 403, 202, 201, 0.5);
-            Assert.AreEqual(1, orderedTelemetry[1].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[1].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual(1, ((MetricTelemetry)orderedTelemetry[1]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[1]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
 
 
             Metric metricB21c1 = client21.GetMetric("Metric B", MetricConfigurations.Common.Measurement(), MetricAggregationScope.TelemetryClient);
@@ -1919,7 +1919,9 @@
 
             client.Context.InstrumentationKey = "3A3C34B6-CA2D-4372-B772-3B015E1E83DC";
             client.Context.Device.Model = "Super-Fancy";
+#pragma warning disable CS0618 // Type or member is obsolete
             client.Context.Properties["MyTag"] = "MyValue";
+#pragma warning restore CS0618 // Type or member is obsolete
 
             animalsSold.TryTrackValue(30, "Cow");
             animalsSold.TryTrackValue(40, "Cow");
@@ -1935,25 +1937,25 @@
                                                         .ToArray();
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], String.Empty, "AnimalsSold", 4, 1000, 400, 100, 111.803398874989);
-            Assert.AreEqual(3, orderedTelemetry[0].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[0].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Rabbit", orderedTelemetry[0].Context.Properties["Species"]);
-            Assert.AreEqual("MyValue", orderedTelemetry[0].Context.Properties["MyTag"]);
+            Assert.AreEqual(3, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Rabbit", ((MetricTelemetry)orderedTelemetry[0]).Properties["Species"]);
+            Assert.AreEqual("MyValue", ((MetricTelemetry)orderedTelemetry[0]).Properties["MyTag"]);            
             Assert.AreEqual("Super-Fancy", orderedTelemetry[0].Context.Device.Model);
             Assert.AreEqual("3A3C34B6-CA2D-4372-B772-3B015E1E83DC", orderedTelemetry[0].Context.InstrumentationKey);
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[1], String.Empty, "AnimalsSold", 2, 70, 40, 30, 5);
-            Assert.AreEqual(3, orderedTelemetry[1].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[1].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Cow", orderedTelemetry[1].Context.Properties["Species"]);
-            Assert.AreEqual("MyValue", orderedTelemetry[1].Context.Properties["MyTag"]);
+            Assert.AreEqual(3, ((MetricTelemetry)orderedTelemetry[1]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[1]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Cow", ((MetricTelemetry)orderedTelemetry[1]).Properties["Species"]);
+            Assert.AreEqual("MyValue", ((MetricTelemetry)orderedTelemetry[1]).Properties["MyTag"]);
             Assert.AreEqual("Super-Fancy", orderedTelemetry[1].Context.Device.Model);
             Assert.AreEqual("3A3C34B6-CA2D-4372-B772-3B015E1E83DC", orderedTelemetry[1].Context.InstrumentationKey);
 
             TestUtil.ValidateNumericAggregateValues(orderedTelemetry[2], String.Empty, "AnimalsSold", 2, 30, 20, 10, 5);
-            Assert.AreEqual(2, orderedTelemetry[2].Context.Properties.Count);
-            Assert.IsTrue(orderedTelemetry[2].Context.Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
-            Assert.AreEqual("Cow", orderedTelemetry[2].Context.Properties["Species"]);
+            Assert.AreEqual(2, ((MetricTelemetry)orderedTelemetry[2]).Properties.Count);
+            Assert.IsTrue(((MetricTelemetry)orderedTelemetry[2]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+            Assert.AreEqual("Cow", ((MetricTelemetry)orderedTelemetry[2]).Properties["Species"]);
             Assert.IsNull(orderedTelemetry[2].Context.Device.Model);
             Assert.AreEqual("754DD89F-61D6-4539-90C7-D886449E12BC", orderedTelemetry[2].Context.InstrumentationKey);
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -54,6 +54,25 @@
             }
         }
 
+        [TestMethod]
+        public void TrackDoesNotThrowIfConfigurationIsDisposed()
+        {
+            var channel = new InMemoryChannel();
+            var configuration = new TelemetryConfiguration { TelemetryChannel = channel };
+            var client = new TelemetryClient(configuration);
+
+            configuration.Dispose();
+
+            try
+            {
+                client.TrackTrace("trace");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail(ex.ToString());
+            }
+        }
+
         #region TrackEvent
 
         [TestMethod]

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -54,25 +54,6 @@
             }
         }
 
-        [TestMethod]
-        public void TrackDoesNotThrowIfConfigurationIsDisposed()
-        {
-            var channel = new InMemoryChannel();
-            var configuration = new TelemetryConfiguration { TelemetryChannel = channel };
-            var client = new TelemetryClient(configuration);
-
-            configuration.Dispose();
-
-            try
-            {
-                client.TrackTrace("trace");
-            }
-            catch (Exception ex)
-            {
-                Assert.Fail(ex.ToString());
-            }
-        }
-
         #region TrackEvent
 
         [TestMethod]
@@ -916,12 +897,14 @@
             var configuration = new TelemetryConfiguration(string.Empty, new StubTelemetryChannel());
             var client = new TelemetryClient(configuration);
             client.Context.Properties["TestProperty"] = "TestValue";
+            client.Context.GlobalProperties["TestGlobalProperty"] = "TestGlobalValue";
             client.Context.InstrumentationKey = "Test Key";
 
             var telemetry = new StubTelemetry();
             client.Track(telemetry);
 
-            AssertEx.AreEqual(client.Context.Properties.ToArray(), telemetry.Properties.ToArray());
+            AssertEx.AreEqual(client.Context.Properties.ToArray(), telemetry.Context.Properties.ToArray());
+            AssertEx.AreEqual(client.Context.GlobalProperties.ToArray(), telemetry.Context.GlobalProperties.ToArray());
         }
 
         [TestMethod]
@@ -930,6 +913,7 @@
             var configuration = new TelemetryConfiguration(string.Empty, new StubTelemetryChannel());
             var client = new TelemetryClient(configuration);
             client.Context.Properties["TestProperty"] = "ClientValue";
+            client.Context.GlobalProperties["TestProperty"] = "ClientValue";
             client.Context.InstrumentationKey = "Test Key";
 
             var telemetry = new StubTelemetry { Properties = { { "TestProperty", "TelemetryValue" } } };
@@ -942,20 +926,29 @@
         public void TrackCopiesPropertiesFromClientToTelemetryBeforeInvokingInitializersBecauseExplicitlySetValuesTakePrecedence()
         {
             const string PropertyName = "TestProperty";
+            const string PropertyNameGlobal = "TestGlobalProperty";
 
             string valueInInitializer = null;
+            string globalValueInInitializer = null;
             var initializer = new StubTelemetryInitializer();
-            initializer.OnInitialize = telemetry => valueInInitializer = ((ISupportProperties)telemetry).Properties[PropertyName];
+            initializer.OnInitialize =
+                (telemetry) =>
+                {
+                    valueInInitializer = ((ISupportProperties)telemetry).Properties[PropertyName];
+                    globalValueInInitializer = ((ISupportProperties)telemetry).Properties[PropertyNameGlobal];
+                };
 
             var configuration = new TelemetryConfiguration(string.Empty, new StubTelemetryChannel()) { TelemetryInitializers = { initializer } };
 
             var client = new TelemetryClient(configuration);
             client.Context.Properties[PropertyName] = "ClientValue";
+            client.Context.Properties[PropertyNameGlobal] = "ClientValue";
             client.Context.InstrumentationKey = "Test Key";
 
             client.Track(new StubTelemetry());
 
             Assert.AreEqual(client.Context.Properties[PropertyName], valueInInitializer);
+            Assert.AreEqual(client.Context.Properties[PropertyNameGlobal], globalValueInInitializer);
         }
 
 #if !NETCOREAPP1_1

--- a/Test/TestFramework/Shared/StubTelemetry.cs
+++ b/Test/TestFramework/Shared/StubTelemetry.cs
@@ -13,9 +13,9 @@
         public Action<object> OnSendEvent = eventSourceWriter => { };
 
         public StubTelemetry()
-        {
-            this.Context = new TelemetryContext();
+        {            
             this.Properties = new Dictionary<string, string>();
+            this.Context = new TelemetryContext(this.Properties);
         }
 
         public DateTimeOffset Timestamp { get; set; }

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -139,7 +139,7 @@
         /// Future SDK versions could serialize this separately from the item level properties.
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#properties">Learn more</a>
         /// </summary>
-        internal IDictionary<string, string> GlobalProperties
+        public IDictionary<string, string> GlobalProperties
         {
             get { return this.globalProperties; }
         }

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -44,8 +44,8 @@
 
         internal TelemetryContext(IDictionary<string, string> properties, IDictionary<string, string> globalProperties)
         {
-            Debug.Assert(properties != null, "properties");
-            Debug.Assert(properties != null, "globalProperties");
+            Debug.Assert(properties != null, nameof(properties));
+            Debug.Assert(globalProperties != null, nameof(globalProperties));
             this.properties = properties;
             this.globalProperties = globalProperties;
         }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -312,6 +312,7 @@
                     streamWriter.Write(Environment.NewLine);
                 }
 
+                telemetryItem.Context.SanitizeGlobalProperties();
                 telemetryItem.Sanitize();
                 SerializeTelemetryItem(telemetryItem, jsonWriter);
             }
@@ -337,8 +338,8 @@
                     writer.WriteProperty("ver", eventTelemetry.Data.ver);
                     writer.WriteProperty("name", eventTelemetry.Data.name);
                     writer.WriteProperty("measurements", eventTelemetry.Data.measurements);
-                    writer.WriteProperty("properties", eventTelemetry.Data.properties);
-
+                    Utils.CopyDictionary(eventTelemetry.Context.GlobalProperties, eventTelemetry.Data.properties);
+                    writer.WriteProperty("properties", eventTelemetry.Data.properties);                    
                     writer.WriteEndObject();
                 }
 
@@ -365,6 +366,7 @@
 
                     writer.WriteProperty("ver", exceptionTelemetry.Data.ver);
                     writer.WriteProperty("problemId", exceptionTelemetry.Data.problemId);
+                    Utils.CopyDictionary(exceptionTelemetry.Context.GlobalProperties, exceptionTelemetry.Data.properties);
                     writer.WriteProperty("properties", exceptionTelemetry.Data.properties);
                     writer.WriteProperty("measurements", exceptionTelemetry.Data.measurements);
                     writer.WritePropertyName("exceptions");
@@ -429,6 +431,7 @@
                         writer.WriteEndArray();
                     }
 
+                    Utils.CopyDictionary(metricTelemetry.Context.GlobalProperties, metricTelemetry.Data.properties);
                     writer.WriteProperty("properties", metricTelemetry.Data.properties);
 
                     writer.WriteEndObject();
@@ -461,6 +464,7 @@
                     writer.WriteProperty("url", pageViewTelemetry.Data.url);
                     writer.WriteProperty("duration", pageViewTelemetry.Data.duration);
                     writer.WriteProperty("measurements", pageViewTelemetry.Data.measurements);
+                    Utils.CopyDictionary(pageViewTelemetry.Context.GlobalProperties, pageViewTelemetry.Data.properties);
                     writer.WriteProperty("properties", pageViewTelemetry.Data.properties);
 
                     writer.WriteEndObject();
@@ -496,7 +500,7 @@
                     writer.WriteProperty("success", dependencyTelemetry.InternalData.success);
                     writer.WriteProperty("type", dependencyTelemetry.InternalData.type);
                     writer.WriteProperty("target", dependencyTelemetry.InternalData.target);
-
+                    Utils.CopyDictionary(dependencyTelemetry.Context.GlobalProperties, dependencyTelemetry.InternalData.properties);
                     writer.WriteProperty("properties", dependencyTelemetry.InternalData.properties);
                     writer.WriteProperty("measurements", dependencyTelemetry.InternalData.measurements);
                     writer.WriteEndObject();
@@ -532,6 +536,7 @@
                     jsonWriter.WriteProperty("responseCode", requestTelemetry.Data.responseCode);
                     jsonWriter.WriteProperty("url", requestTelemetry.Data.url);
                     jsonWriter.WriteProperty("measurements", requestTelemetry.Data.measurements);
+                    Utils.CopyDictionary(requestTelemetry.Context.GlobalProperties, requestTelemetry.Data.properties);
                     jsonWriter.WriteProperty("properties", requestTelemetry.Data.properties);
 
                     jsonWriter.WriteEndObject();
@@ -567,6 +572,7 @@
                         writer.WriteProperty("severityLevel", traceTelemetry.SeverityLevel.Value.ToString());
                     }
 
+                    Utils.CopyDictionary(traceTelemetry.Context.GlobalProperties, traceTelemetry.Data.properties);
                     writer.WriteProperty("properties", traceTelemetry.Properties); // TODO: handle case where the property dictionary doesn't need to be instantiated.
 
                     writer.WriteEndObject();
@@ -603,7 +609,7 @@
                     writer.WriteProperty("success", availabilityTelemetry.Data.success);
                     writer.WriteProperty("runLocation", availabilityTelemetry.Data.runLocation);
                     writer.WriteProperty("message", availabilityTelemetry.Data.message);
-                    writer.WriteProperty("properties", availabilityTelemetry.Data.properties);
+                    Utils.CopyDictionary(availabilityTelemetry.Context.GlobalProperties, availabilityTelemetry.Data.properties);
                     writer.WriteProperty("properties", availabilityTelemetry.Data.properties);
                     writer.WriteProperty("measurements", availabilityTelemetry.Data.measurements);
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/PassThroughProcessor.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/PassThroughProcessor.cs
@@ -9,8 +9,6 @@
     /// </summary>
     internal class PassThroughProcessor : ITelemetryProcessor
     {
-        private TelemetrySink sink;
-
         public PassThroughProcessor(TelemetrySink sink)
         {
             if (sink == null)
@@ -18,14 +16,14 @@
                 throw new ArgumentNullException(nameof(sink));
             }
 
-            this.sink = sink;
+            this.Sink = sink;
         }
 
-        internal TelemetrySink Sink => this.sink;
+        internal TelemetrySink Sink { get; } 
 
         public void Process(ITelemetry item)
         {
-            this.sink.Process(item);
+            this.Sink.Process(item);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -40,6 +40,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         /// <param name="item">A collected Telemetry item.</param>
         public void Process(ITelemetry item)
         {
+            var telemetryProps = item as ISupportProperties;
+            if (telemetryProps != null)
+            {
+                Utils.CopyDictionary(item.Context.GlobalProperties, telemetryProps.Properties);
+            }
+
             if (item is RequestTelemetry)
             {
                 if (!this.EventSourceInternal.IsEnabled(EventLevel.Verbose, Keywords.Requests))
@@ -367,6 +373,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 CoreEventSource.Log.LogVerbose(msg);
 
                 return;
+            }
+
+            var telemetryProps = item as ISupportProperties;
+            if (telemetryProps != null)
+            {
+                Utils.CopyDictionary(item.Context.GlobalProperties, telemetryProps.Properties);
             }
 
             handler(item);

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -512,6 +512,16 @@
             this.WriteEvent(42, httpStatusCode, this.nameProvider.Name);
         }
 
+        [Event(
+            43,
+            Keywords = Keywords.UserActionable,
+            Message = "Process was called on the TelemetrySink after it was disposed, the telemetry data was dropped.",
+            Level = EventLevel.Error)]
+        public void TelemetrySinkCalledAfterBeingDisposed(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(43, this.nameProvider.Name);
+        }
+
         /// <summary>
         /// Keywords for the PlatformEventSource.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -42,7 +42,7 @@
 
                         foreach (var baggage in currentActivity.Baggage)
                         {                            
-                            if (telemetryProp != null && telemetryProp.Properties.ContainsKey(baggage.Key))
+                            if (telemetryProp != null && !telemetryProp.Properties.ContainsKey(baggage.Key))
                             {
                                 telemetryProp.Properties.Add(baggage);
                             }
@@ -87,7 +87,7 @@
                         {
                             foreach (var item in parentContext.CorrelationContext)
                             {                                
-                                if (telemetryProp != null && telemetryProp.Properties.ContainsKey(item.Key))
+                                if (telemetryProp != null && !telemetryProp.Properties.ContainsKey(item.Key))
                                 {
                                     telemetryProp.Properties.Add(item);
                                 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -4,6 +4,7 @@
     using Implementation;
     using Microsoft.ApplicationInsights;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
 
 #if NET45
     /// <summary>
@@ -23,7 +24,7 @@
         public void Initialize(ITelemetry telemetryItem)
         {
             var itemContext = telemetryItem.Context.Operation;
-
+            var telemetryProp = telemetryItem as ISupportProperties;
             bool isActivityAvailable = false;
             isActivityAvailable = ActivityExtensions.TryRun(() =>
             { 
@@ -40,10 +41,10 @@
                         }
 
                         foreach (var baggage in currentActivity.Baggage)
-                        {
-                            if (!telemetryItem.Context.Properties.ContainsKey(baggage.Key))
+                        {                            
+                            if (telemetryProp != null && telemetryProp.Properties.ContainsKey(baggage.Key))
                             {
-                                telemetryItem.Context.Properties.Add(baggage);
+                                telemetryProp.Properties.Add(baggage);
                             }
                         }
                     }
@@ -85,10 +86,10 @@
                         if (parentContext.CorrelationContext != null)
                         {
                             foreach (var item in parentContext.CorrelationContext)
-                            {
-                                if (!telemetryItem.Context.Properties.ContainsKey(item.Key))
+                            {                                
+                                if (telemetryProp != null && telemetryProp.Properties.ContainsKey(item.Key))
                                 {
-                                    telemetryItem.Context.Properties.Add(item);
+                                    telemetryProp.Properties.Add(item);
                                 }
                             }
                         }

--- a/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -41,7 +41,7 @@
                         }
 
                         foreach (var baggage in currentActivity.Baggage)
-                        {                            
+                        {
                             if (telemetryProp != null && !telemetryProp.Properties.ContainsKey(baggage.Key))
                             {
                                 telemetryProp.Properties.Add(baggage);
@@ -86,7 +86,7 @@
                         if (parentContext.CorrelationContext != null)
                         {
                             foreach (var item in parentContext.CorrelationContext)
-                            {                                
+                            {
                                 if (telemetryProp != null && !telemetryProp.Properties.ContainsKey(item.Key))
                                 {
                                     telemetryProp.Properties.Add(item);

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetrySink.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetrySink.cs
@@ -5,6 +5,7 @@
     using System.Threading;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// Represents a destination for telemetry, consisting of a set of telemetry processors and a channel.
@@ -205,6 +206,12 @@
         /// <param name="item">Item to process.</param>
         public void Process(ITelemetry item)
         {
+            if (this.isDisposed)
+            {
+                CoreEventSource.Log.TelemetrySinkCalledAfterBeingDisposed();
+                return;
+            }
+
             this.TelemetryProcessorChain.Process(item);
         }
 

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
@@ -110,7 +110,7 @@
 
             if (false == String.IsNullOrWhiteSpace(MetricTerms.Autocollection.Moniker.Key))
             {
-                metricsClient.Context.Properties[MetricTerms.Autocollection.Moniker.Key] = MetricTerms.Autocollection.Moniker.Value;
+                metricsClient.Context.GlobalProperties[MetricTerms.Autocollection.Moniker.Key] = MetricTerms.Autocollection.Moniker.Value;
             }
 
             this.InitializeExtractors(metricsClient);
@@ -191,8 +191,14 @@
         /// <param name="extractorInfo">The string to be added to the item's properties.</param>
         private static void AddExtractorInfo(ITelemetry item, string extractorInfo)
         {
-            string extractionPipelineInfo;
-            bool hasPrevInfo = item.Context.Properties.TryGetValue(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key, out extractionPipelineInfo);
+            var itemWithProperties = item as ISupportProperties;
+            if (itemWithProperties == null)
+            {
+                return;
+            }
+
+            string extractionPipelineInfo;            
+            bool hasPrevInfo = itemWithProperties.Properties.TryGetValue(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key, out extractionPipelineInfo);
 
             if (false == hasPrevInfo)
             {
@@ -207,7 +213,7 @@
             }
 
             extractionPipelineInfo = extractionPipelineInfo + extractorInfo;
-            item.Context.Properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = extractionPipelineInfo;
+            itemWithProperties.Properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = extractionPipelineInfo;
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricAggregateToApplicationInsightsPipelineConverterBase.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricAggregateToApplicationInsightsPipelineConverterBase.cs
@@ -183,7 +183,7 @@
                         string dimensionName;
                         if (MetricDimensionNames.TelemetryContext.IsProperty(dimension.Key, out dimensionName))
                         {
-                            telemetryContext.Properties[dimensionName] = dimension.Value;
+                            telemetryContext.GlobalProperties[dimensionName] = dimension.Value;
                         }
                         else
                         {

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyMetricsExtractor.cs
@@ -244,7 +244,7 @@
 
                 Metric dependencyCallDuration = thisMetricTelemetryClient.GetMetric(
                                                             metricId: MetricTerms.Autocollection.Metric.DependencyCallDuration.Name,
-                                                            dimension1Name: MetricTerms.Autocollection.MetricId.Moniker.Key,
+                                                            dimension1Name: MetricDimensionNames.TelemetryContext.Property(MetricTerms.Autocollection.MetricId.Moniker.Key),                                                            
                                                             dimension2Name: MetricTerms.Autocollection.DependencyCall.PropertyNames.Success,
                                                             dimension3Name: MetricTerms.Autocollection.DependencyCall.PropertyNames.TypeName,
                                                             metricConfiguration: config,

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestMetricsExtractor.cs
@@ -36,7 +36,7 @@
                 Metric responseTimeMetric = metricTelemetryClient.GetMetric(
                                                     MetricTerms.Autocollection.Metric.RequestDuration.Name,
                                                     MetricTerms.Autocollection.Request.PropertyNames.Success,
-                                                    MetricTerms.Autocollection.MetricId.Moniker.Key,
+                                                    MetricDimensionNames.TelemetryContext.Property(MetricTerms.Autocollection.MetricId.Moniker.Key),
                                                     MetricConfigurations.Common.Measurement(),
                                                     MetricAggregationScope.TelemetryClient);
 

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
@@ -313,19 +313,11 @@
             // Copy internal tags:
             target.Initialize(source, instrumentationKey: null);
 
-            // Copy public properties:
-            IDictionary<string, string> sourceProperties = source.Properties;
-            IDictionary<string, string> targetProperties = target.Properties;
-            if (targetProperties != null && sourceProperties != null && sourceProperties.Count > 0)
-            {
-                foreach (KeyValuePair<string, string> property in sourceProperties)
-                {
-                    if (false == String.IsNullOrEmpty(property.Key) && false == targetProperties.ContainsKey(property.Key))
-                    {
-                        targetProperties[property.Key] = property.Value;
-                    }
-                }
-            }
+            // Copy public properties:            
+#pragma warning disable CS0618 // Type or member is obsolete
+            Utils.CopyDictionary(source.Properties, target.Properties);
+#pragma warning restore CS0618 // Type or member is obsolete
+            Utils.CopyDictionary(source.GlobalProperties, target.GlobalProperties);
 
             // Copy iKey:
 

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -104,7 +104,7 @@
 
             if (properties != null && properties.Count > 0)
             {
-                Utils.CopyDictionary(properties, telemetry.Context.Properties);
+                Utils.CopyDictionary(properties, telemetry.Properties);
             }
 
             if (metrics != null && metrics.Count > 0)
@@ -172,7 +172,7 @@
 
             if (properties != null && properties.Count > 0)
             {
-                Utils.CopyDictionary(properties, telemetry.Context.Properties);
+                Utils.CopyDictionary(properties, telemetry.Properties);
             }
 
             this.TrackTrace(telemetry);
@@ -193,7 +193,7 @@
 
             if (properties != null && properties.Count > 0)
             {
-                Utils.CopyDictionary(properties, telemetry.Context.Properties);
+                Utils.CopyDictionary(properties, telemetry.Properties);
             }
 
             this.TrackTrace(telemetry);
@@ -276,7 +276,7 @@
 
             if (properties != null && properties.Count > 0)
             {
-                Utils.CopyDictionary(properties, telemetry.Context.Properties);
+                Utils.CopyDictionary(properties, telemetry.Properties);
             }
 
             if (metrics != null && metrics.Count > 0)
@@ -399,7 +399,7 @@
 
             if (properties != null && properties.Count > 0)
             {
-                Utils.CopyDictionary(properties, availabilityTelemetry.Context.Properties);
+                Utils.CopyDictionary(properties, availabilityTelemetry.Properties);
             }
 
             if (metrics != null && metrics.Count > 0)
@@ -471,10 +471,14 @@
                     {
                         telemetryWithProperties.Properties.Add("DeveloperMode", "true");
                     }
-                }
-
-                Utils.CopyDictionary(this.Context.Properties, telemetryWithProperties.Properties);
+                }                
             }
+
+            // Properties set of TelemetryClient's Context are copied over to that of ITelemetry's Context
+#pragma warning disable CS0618 // Type or member is obsolete
+            Utils.CopyDictionary(this.Context.Properties, telemetry.Context.Properties);
+#pragma warning restore CS0618 // Type or member is obsolete
+            Utils.CopyDictionary(this.Context.GlobalProperties, telemetry.Context.GlobalProperties);
 
             telemetry.Context.Initialize(this.Context, instrumentationKey);
             foreach (ITelemetryInitializer initializer in this.configuration.TelemetryInitializers)


### PR DESCRIPTION
Fix Issue #820 

I have to abandon the prior PR as merge conflicts became too many!

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
