### PR TITLE
re-enable symbols packages

### DIFF
--- a/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -16,7 +16,7 @@
 
     <!--https://docs.microsoft.com/en-us/nuget/schema/msbuild-targets-->
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <!--PackageOutputPath>Defined in Directory.Build.props</PackageOutputPath-->
     <PackageId>Microsoft.ApplicationInsights</PackageId>
     <!--PackageVersion is defined in GlobalStaticVersion.props-->

--- a/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -16,7 +16,7 @@
 
     <!--https://docs.microsoft.com/en-us/nuget/schema/msbuild-targets-->
     <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-    <IncludeSymbols>False</IncludeSymbols>
+    <IncludeSymbols>True</IncludeSymbols>
     <!--PackageOutputPath>Defined in Directory.Build.props</PackageOutputPath-->
     <PackageId>Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel</PackageId>
     <!--PackageVersion is defined in GlobalStaticVersion.props-->


### PR DESCRIPTION
Symbols packages had to be disabled due to a bug in our build infrastructure.
That bug has been resolved and we are re-enabling this.