### PR TITLE
Fixes issue #849

### DIFF
--- a/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
+++ b/src/TelemetryChannels/ServerTelemetryChannel/Shared/Implementation/TelemetryBuffer.cs
@@ -83,7 +83,7 @@
         /// Gets or sets the maximum number of telemetry items that can be in the backlog to send. Items will be dropped
         /// once this limit is hit.
         /// </summary>
-        /// <exception cref="ArgumentOutOfRangeException">The value is zero or less.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">The value is less than the Minimum Backlog Size.</exception>
         /// <exception cref="ArgumentException">The value is less than the Capacity.</exception>
         public int BacklogSize
         {
@@ -96,7 +96,7 @@
             {
                 if (value < this.minimumBacklogSize)
                 {
-                    throw new ArgumentOutOfRangeException("value");
+                    throw new ArgumentOutOfRangeException($"capacity cannot be lower than the Minimum Backlog Size. ({this.minimumBacklogSize})");
                 }
 
                 if (value < this.capacity)


### PR DESCRIPTION
Fixes issue where a vague exception was being thrown when specifying a
lower capacity than the minimum in a ServerTelemetryChannel.

Let me know if this is the wrong branch too, could not find file in the same place on other branch and got myself a tad confused.

Fix Issue #849 .
<Short description of the fix.>

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.  
Could not run unit tests as described in this guide as I am developing on linux using dotnet core and do not have access to visual studio.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
