### PR TITLE
Add ExceptionDetailsInfo class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog will be used to generate documentation on [release notes page](ht
   Related: (https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/690)
 - Added method `ExceptionDetailsInfoList` on `ExceptionTelemetry` class that gives control to user to update exception
 message and exception type of underlying `System.Exception` object that user wants to send to telemetry. Related discussion is [here](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/498).
+- Added an option of creating ExceptionTelemetry object off of custom exception information rather than a System.Exception object.
 
 ## Version 2.7.0-beta2
 - [Fix: NullReferenceException if telemtery is tracked after TelemetryConfiguration is disposed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,15 +2,16 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.8.0-beta1
+- Added method `ExceptionDetailsInfoList` on `ExceptionTelemetry` class that gives control to user to update exception
+message and exception type of underlying `System.Exception` object that user wants to send to telemetry. Related discussion is [here](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/498).
+- Added an option of creating ExceptionTelemetry object off of custom exception information rather than a System.Exception object.
 
 ## Version 2.7.0-beta3
 - [Allow to set flags on event](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/844). It will be used in conjunction with the feature that will allow to keep IP addresses.
 - [Fix: SerializationException resolving Activity in cross app-domain calls](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/613)
 - [Make HttpClient instance static to avoid re-creating with every transmission. This had caused connection/memory leaks in .net core 2.1](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/594)
   Related: (https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/690)
-- Added method `ExceptionDetailsInfoList` on `ExceptionTelemetry` class that gives control to user to update exception
-message and exception type of underlying `System.Exception` object that user wants to send to telemetry. Related discussion is [here](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/498).
-- Added an option of creating ExceptionTelemetry object off of custom exception information rather than a System.Exception object.
 
 ## Version 2.7.0-beta2
 - [Fix: NullReferenceException if telemtery is tracked after TelemetryConfiguration is disposed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/928)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,10 @@ This changelog will be used to generate documentation on [release notes page](ht
 ## Version 2.7.0-beta3
 - [Allow to set flags on event](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/844). It will be used in conjunction with the feature that will allow to keep IP addresses.
 - [Fix: SerializationException resolving Activity in cross app-domain calls](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/613)
-- [Make HttpClient instance static to avoid re-creating with every transmission. This had caused connection/memory leaks in .net core 2.1] (https://github.com/Microsoft/ApplicationInsights-dotnet/issues/594)
+- [Make HttpClient instance static to avoid re-creating with every transmission. This had caused connection/memory leaks in .net core 2.1](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/594)
   Related: (https://github.com/Microsoft/ApplicationInsights-aspnetcore/issues/690)
+- Added method `ExceptionDetailsInfoList` on `ExceptionTelemetry` class that gives control to user to update exception
+message and exception type of underlying `System.Exception` object that user wants to send to telemetry. Related discussion is [here](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/498).
 
 ## Version 2.7.0-beta2
 - [Fix: NullReferenceException if telemtery is tracked after TelemetryConfiguration is disposed](https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/928)

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
@@ -99,6 +99,11 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Platform = 2 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Unhandled = 0 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.UserCode = 1 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Context.get -> Microsoft.ApplicationInsights.DataContracts.TelemetryContext
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.DeepClone() -> Microsoft.ApplicationInsights.Channel.ITelemetry
@@ -108,6 +113,7 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetr
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Exception exception) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Message.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Message.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Metrics.get -> System.Collections.Generic.IDictionary<string, double>

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
@@ -100,10 +100,13 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Platform = 2 -> M
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Unhandled = 0 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.UserCode = 1 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.ExceptionDetailsInfo(int id, int outerId, string typeName, string message, bool hasFullStack, string stack, System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.StackFrame> parsedStack) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.set -> void
+Microsoft.ApplicationInsights.DataContracts.StackFrame
+Microsoft.ApplicationInsights.DataContracts.StackFrame.StackFrame(string assembly, string fileName, int level, int line, string method) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Context.get -> Microsoft.ApplicationInsights.DataContracts.TelemetryContext
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.DeepClone() -> Microsoft.ApplicationInsights.Channel.ITelemetry
@@ -127,6 +130,19 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.get
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.get -> System.DateTimeOffset
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionInfo.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(Microsoft.ApplicationInsights.DataContracts.ExceptionInfo exceptionInfo) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionInfo(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.get -> System.Collections.Generic.IDictionary<string, double>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.get -> Microsoft.ApplicationInsights.DataContracts.SeverityLevel?
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteComma() -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteEndArray() -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Shipped.txt
@@ -114,6 +114,7 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Exception.get -> 
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Exception.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry() -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Exception exception) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
@@ -130,19 +131,6 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.get
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.get -> System.DateTimeOffset
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionInfo.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(Microsoft.ApplicationInsights.DataContracts.ExceptionInfo exceptionInfo) -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionInfo(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.get -> System.Collections.Generic.IDictionary<string, double>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.get -> string
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.get -> System.Collections.Generic.IDictionary<string, string>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.get -> Microsoft.ApplicationInsights.DataContracts.SeverityLevel?
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteComma() -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteEndArray() -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
@@ -99,6 +99,11 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Platform = 2 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Unhandled = 0 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.UserCode = 1 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Context.get -> Microsoft.ApplicationInsights.DataContracts.TelemetryContext
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.DeepClone() -> Microsoft.ApplicationInsights.Channel.ITelemetry
@@ -108,6 +113,7 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetr
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Exception exception) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Message.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Message.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Metrics.get -> System.Collections.Generic.IDictionary<string, double>

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
@@ -100,10 +100,13 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Platform = 2 -> M
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Unhandled = 0 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.UserCode = 1 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.ExceptionDetailsInfo(int id, int outerId, string typeName, string message, bool hasFullStack, string stack, System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.StackFrame> parsedStack) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.set -> void
+Microsoft.ApplicationInsights.DataContracts.StackFrame
+Microsoft.ApplicationInsights.DataContracts.StackFrame.StackFrame(string assembly, string fileName, int level, int line, string method) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Context.get -> Microsoft.ApplicationInsights.DataContracts.TelemetryContext
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.DeepClone() -> Microsoft.ApplicationInsights.Channel.ITelemetry
@@ -127,6 +130,19 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.get
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.get -> System.DateTimeOffset
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionInfo.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(Microsoft.ApplicationInsights.DataContracts.ExceptionInfo exceptionInfo) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionInfo(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.get -> System.Collections.Generic.IDictionary<string, double>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.get -> Microsoft.ApplicationInsights.DataContracts.SeverityLevel?
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteComma() -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteEndArray() -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Shipped.txt
@@ -114,6 +114,7 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Exception.get -> 
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Exception.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry() -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Exception exception) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
@@ -130,19 +131,6 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.get
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.get -> System.DateTimeOffset
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionInfo.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(Microsoft.ApplicationInsights.DataContracts.ExceptionInfo exceptionInfo) -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionInfo(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.get -> System.Collections.Generic.IDictionary<string, double>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.get -> string
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.get -> System.Collections.Generic.IDictionary<string, string>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.get -> Microsoft.ApplicationInsights.DataContracts.SeverityLevel?
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteComma() -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteEndArray() -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
@@ -99,6 +99,11 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Platform = 2 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Unhandled = 0 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.UserCode = 1 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Context.get -> Microsoft.ApplicationInsights.DataContracts.TelemetryContext
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.DeepClone() -> Microsoft.ApplicationInsights.Channel.ITelemetry
@@ -108,6 +113,7 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetr
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Exception exception) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Message.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Message.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Metrics.get -> System.Collections.Generic.IDictionary<string, double>

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
@@ -114,6 +114,7 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Exception.get -> 
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Exception.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry() -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Exception exception) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.HandledAt.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
@@ -129,19 +130,6 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.get
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.get -> System.DateTimeOffset
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionInfo.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(Microsoft.ApplicationInsights.DataContracts.ExceptionInfo exceptionInfo) -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionInfo(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.get -> System.Collections.Generic.IDictionary<string, double>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.get -> string
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.get -> System.Collections.Generic.IDictionary<string, string>
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.get -> Microsoft.ApplicationInsights.DataContracts.SeverityLevel?
-Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteComma() -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteEndArray() -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Shipped.txt
@@ -100,10 +100,13 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Platform = 2 -> M
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.Unhandled = 0 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt.UserCode = 1 -> Microsoft.ApplicationInsights.DataContracts.ExceptionHandledAt
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.ExceptionDetailsInfo(int id, int outerId, string typeName, string message, bool hasFullStack, string stack, System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.StackFrame> parsedStack) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.TypeName.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.get -> string
 Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo.Message.set -> void
+Microsoft.ApplicationInsights.DataContracts.StackFrame
+Microsoft.ApplicationInsights.DataContracts.StackFrame.StackFrame(string assembly, string fileName, int level, int line, string method) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Context.get -> Microsoft.ApplicationInsights.DataContracts.TelemetryContext
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.DeepClone() -> Microsoft.ApplicationInsights.Channel.ITelemetry
@@ -126,6 +129,19 @@ Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.get
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.get -> System.DateTimeOffset
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Timestamp.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionInfo.get -> Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.ExceptionTelemetry(Microsoft.ApplicationInsights.DataContracts.ExceptionInfo exceptionInfo) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionDetailsInfoList.get -> System.Collections.Generic.IReadOnlyList<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ExceptionInfo(System.Collections.Generic.IEnumerable<Microsoft.ApplicationInsights.DataContracts.ExceptionDetailsInfo> exceptionDetailsInfoList, Microsoft.ApplicationInsights.DataContracts.SeverityLevel? severityLevel, string problemId, System.Collections.Generic.IDictionary<string, string> properties, System.Collections.Generic.IDictionary<string, double> measurements) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.get -> System.Collections.Generic.IDictionary<string, double>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Measurements.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.get -> string
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.ProblemId.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.get -> System.Collections.Generic.IDictionary<string, string>
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.Properties.set -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.get -> Microsoft.ApplicationInsights.DataContracts.SeverityLevel?
+Microsoft.ApplicationInsights.DataContracts.ExceptionInfo.SeverityLevel.set -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteComma() -> void
 Microsoft.ApplicationInsights.DataContracts.IJsonWriter.WriteEndArray() -> void

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -58,20 +58,19 @@
                     new StackFrame("Some.Assembly", "LessImportantFile.dll", 1, 11, "DeeperInnerMethod")
                 });
 
-            var exceptionInfo = new ExceptionInfo(new[] {topLevelexceptionDetails, innerExceptionDetails},
+            // ACT
+            ExceptionTelemetry item = new ExceptionTelemetry(new[] {topLevelexceptionDetails, innerExceptionDetails},
                 SeverityLevel.Error, "ProblemId",
                 new Dictionary<string, string>() {["property1"] = "value1", ["property2"] = "value2"},
                 new Dictionary<string, double>() {["property1"] = 1, ["property2"] = 2});
 
-            // ACT
-            ExceptionTelemetry item = new ExceptionTelemetry(exceptionInfo);
-
-            item.ExceptionInfo.ExceptionDetailsInfoList[1].Message = "Inner exception modified";
+            item.ExceptionDetailsInfoList[1].Message = "Inner exception modified";
+            item.ProblemId = "ProblemId modified";
 
             // ASSERT
             // use internal fields to validate
             Assert.AreEqual(item.Data.Data.ver, 2);
-            Assert.AreEqual(item.Data.Data.problemId, "ProblemId");
+            Assert.AreEqual(item.Data.Data.problemId, "ProblemId modified");
             Assert.AreEqual(item.Data.Data.severityLevel, Extensibility.Implementation.External.SeverityLevel.Error);
 
             Assert.AreEqual(item.Data.Data.properties.Count, 2);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -373,7 +373,7 @@
             {
                 ExceptionDetails details = telemetry.Exceptions[counter];
                 ExceptionDetailsInfo newExceptionDetails = telemetry.ExceptionDetailsInfoList[counter];
-                Assert.ReferenceEquals(details, newExceptionDetails);
+                Assert.IsTrue(ReferenceEquals(details, newExceptionDetails.InternalExceptionDetails));
                 if (details.typeName == "System.AggregateException")
                 {
                     AssertEx.StartsWith(expectedSequence[counter], details.message);
@@ -401,11 +401,11 @@
 
             Assert.AreEqual(Constants.MaxExceptionCountToSave + 1, telemetry.Exceptions.Count);
             Assert.AreEqual(Constants.MaxExceptionCountToSave + 1, telemetry.ExceptionDetailsInfoList.Count);
-            for(int counter = 0; counter < telemetry.Exceptions.Count; counter++)
+            for(int counter = 0; counter < Constants.MaxExceptionCountToSave; counter++)
             {
                 ExceptionDetails details = telemetry.Exceptions[counter];
                 ExceptionDetailsInfo newExceptionDetails = telemetry.ExceptionDetailsInfoList[counter];
-                Assert.ReferenceEquals(details, newExceptionDetails);
+                Assert.IsTrue(ReferenceEquals(details, newExceptionDetails.InternalExceptionDetails));
                 if (details.typeName == "System.AggregateException")
                 {
                     AssertEx.StartsWith(counter.ToString(CultureInfo.InvariantCulture), details.message);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -63,7 +63,7 @@
         public void RichPayloadEventSourceExceptionSentTest()
         {
             var exceptionTelemetry = new ExceptionTelemetry(new SystemException("Test"));
-            exceptionTelemetry.Data.exceptions[0].parsedStack = new External.StackFrame[] { new External.StackFrame() };
+            exceptionTelemetry.Data.Data.exceptions[0].parsedStack = new External.StackFrame[] { new External.StackFrame() };
 
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Exceptions,

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
@@ -1,0 +1,39 @@
+﻿namespace Microsoft.ApplicationInsights.DataContracts
+{
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
+
+    /// <summary>
+    /// Wrapper class for <see cref="ExceptionDetails"/> that lets user gets/sets TypeName and Message.
+    /// </summary>
+    public sealed class ExceptionDetailsInfo
+    {
+        private readonly ExceptionDetails internalExceptionDetails = null;
+
+        /// <summary>
+        /// Constructs the 
+        /// </summary>
+        /// <param name="exceptionDetails">Instance of </param>
+        internal ExceptionDetailsInfo(ExceptionDetails exceptionDetails)
+        {
+            this.internalExceptionDetails = exceptionDetails;
+        }
+
+        /// <summary>
+        /// Gets or sets type name of the underlying <see cref="System.Exception"/> that this object represents.
+        /// </summary>
+        public string TypeName
+        {
+            get => this.internalExceptionDetails.typeName;
+            set => this.internalExceptionDetails.typeName = value;
+        }
+
+        /// <summary>
+        /// Gets or sets message name of the underlying <see cref="System.Exception"/> that this object represents.
+        /// </summary>
+        public string Message
+        {
+            get => this.internalExceptionDetails.message;
+            set => this.internalExceptionDetails.message = value;
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
@@ -14,6 +14,13 @@
         /// <summary>
         /// Constructs the instance of <see cref="ExceptionDetailsInfo"/>.
         /// </summary>
+        /// <param name="id">Exception id.</param>
+        /// <param name="outerId">Parent exception's id.</param>
+        /// <param name="typeName">Type name for the exception.</param>
+        /// <param name="message">Exception message.</param>
+        /// <param name="hasFullStack">Indicates that this exception has full stack information.</param>
+        /// <param name="stack">Exception's stack trace.</param>
+        /// <param name="parsedStack">Exception's stack.</param>
         public ExceptionDetailsInfo(int id, int outerId, string typeName, string message, bool hasFullStack,
             string stack, IEnumerable<StackFrame> parsedStack)
         {

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
@@ -7,7 +7,7 @@
     /// </summary>
     public sealed class ExceptionDetailsInfo
     {
-        private readonly ExceptionDetails internalExceptionDetails = null;
+        internal readonly ExceptionDetails InternalExceptionDetails = null;
 
         /// <summary>
         /// Constructs the 
@@ -15,7 +15,7 @@
         /// <param name="exceptionDetails">Instance of </param>
         internal ExceptionDetailsInfo(ExceptionDetails exceptionDetails)
         {
-            this.internalExceptionDetails = exceptionDetails;
+            this.InternalExceptionDetails = exceptionDetails;
         }
 
         /// <summary>
@@ -23,8 +23,8 @@
         /// </summary>
         public string TypeName
         {
-            get => this.internalExceptionDetails.typeName;
-            set => this.internalExceptionDetails.typeName = value;
+            get => this.InternalExceptionDetails.typeName;
+            set => this.InternalExceptionDetails.typeName = value;
         }
 
         /// <summary>
@@ -32,8 +32,8 @@
         /// </summary>
         public string Message
         {
-            get => this.internalExceptionDetails.message;
-            set => this.internalExceptionDetails.message = value;
+            get => this.InternalExceptionDetails.message;
+            set => this.InternalExceptionDetails.message = value;
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionDetailsInfo.cs
@@ -1,5 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.DataContracts
 {
+    using System.Collections.Generic;
+    using System.Linq;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
     /// <summary>
@@ -10,9 +12,23 @@
         internal readonly ExceptionDetails InternalExceptionDetails = null;
 
         /// <summary>
-        /// Constructs the 
+        /// Constructs the instance of <see cref="ExceptionDetailsInfo"/>.
         /// </summary>
-        /// <param name="exceptionDetails">Instance of </param>
+        public ExceptionDetailsInfo(int id, int outerId, string typeName, string message, bool hasFullStack,
+            string stack, IEnumerable<StackFrame> parsedStack)
+        {
+            this.InternalExceptionDetails = new ExceptionDetails()
+            {
+                id = id,
+                outerId = outerId,
+                typeName = typeName,
+                message = message,
+                hasFullStack = hasFullStack,
+                stack = stack,
+                parsedStack = parsedStack.Select(ps => ps.Data).ToList()
+            };
+        }
+
         internal ExceptionDetailsInfo(ExceptionDetails exceptionDetails)
         {
             this.InternalExceptionDetails = exceptionDetails;
@@ -35,5 +51,7 @@
             get => this.InternalExceptionDetails.message;
             set => this.InternalExceptionDetails.message = value;
         }
+
+        internal ExceptionDetails ExceptionDetails => this.InternalExceptionDetails;
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionInfo.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionInfo.cs
@@ -9,7 +9,7 @@
     /// <summary>
     /// Wrapper class for <see cref="ExceptionData"/> that lets user provide exception data without having the actual Exception object.
     /// </summary>
-    public sealed class ExceptionInfo
+    internal sealed class ExceptionInfo
     {
         private readonly ExceptionData data;
         

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionInfo.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionInfo.cs
@@ -1,0 +1,85 @@
+﻿namespace Microsoft.ApplicationInsights.DataContracts
+{
+    using System.Collections.Concurrent;
+    using System.Collections.Generic;
+    using System.Linq;
+    using Extensibility.Implementation;
+    using Extensibility.Implementation.External;
+
+    /// <summary>
+    /// Wrapper class for <see cref="ExceptionData"/> that lets user provide exception data without having the actual Exception object.
+    /// </summary>
+    public sealed class ExceptionInfo
+    {
+        private readonly ExceptionData data;
+        
+        /// <summary>
+        /// Constructs the instance of <see cref="ExceptionInfo"/>
+        /// </summary>
+        public ExceptionInfo(IEnumerable<ExceptionDetailsInfo> exceptionDetailsInfoList, SeverityLevel? severityLevel, string problemId,
+            IDictionary<string, string> properties, IDictionary<string, double> measurements)
+        {
+            this.data = new ExceptionData
+            {
+                exceptions = exceptionDetailsInfoList.Select(edi => edi.ExceptionDetails).ToList(),
+                severityLevel = severityLevel.TranslateSeverityLevel(),
+                problemId = problemId,
+                properties = new ConcurrentDictionary<string, string>(properties),
+                measurements = new ConcurrentDictionary<string, double>(measurements)
+            };
+        }
+
+        internal ExceptionInfo(ExceptionData data)
+        {
+            this.data = data;
+        }
+
+        /// <summary>
+        /// Gets a list of <see cref="ExceptionDetailsInfo"/> to modify as needed.
+        /// </summary>
+        public IReadOnlyList<ExceptionDetailsInfo> ExceptionDetailsInfoList => this.data.exceptions.Select(ed => new ExceptionDetailsInfo(ed)).ToList().AsReadOnly();
+
+        /// <summary>
+        /// Gets or sets Exception severity level.
+        /// </summary>
+        public SeverityLevel? SeverityLevel
+        {
+            get => this.data.severityLevel.TranslateSeverityLevel();
+            set => this.data.severityLevel = value.TranslateSeverityLevel();
+        }
+
+        /// <summary>
+        /// Gets or sets problem id.
+        /// </summary>
+        public string ProblemId
+        {
+            get => this.data.problemId;
+            set => this.data.problemId = value;
+        }
+
+        /// <summary>
+        /// Gets or sets properties collection.
+        /// </summary>
+        public IDictionary<string, string> Properties
+        {
+            get => this.data.properties;
+            set => this.data.properties = value;
+        }
+
+        /// <summary>
+        /// Gets or sets measurements collection.
+        /// </summary>
+        public IDictionary<string, double> Measurements
+        {
+            get => this.data.measurements;
+            set => this.data.measurements = value;
+        }
+
+        internal ExceptionData Data => this.data;
+
+        internal ExceptionInfo DeepClone()
+        {
+            return new ExceptionInfo(this.data.DeepClone());
+        }
+    }
+}

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -62,7 +62,7 @@
             this.Data = exceptionInfo ?? throw new ArgumentNullException(nameof(exceptionInfo));
             this.context = new TelemetryContext(this.Data.Properties);
 
-            this.UpdateData(null, exceptionInfo);
+            this.UpdateData(exceptionInfo);
         }
 
         /// <summary>
@@ -164,7 +164,7 @@
                 }
 
                 this.exception = value;
-                this.UpdateData(value, null);
+                this.UpdateData(value);
             }
         }
 
@@ -202,7 +202,7 @@
                 }
                 else
                 {
-                    this.UpdateData(this.Exception, null);
+                    this.UpdateData(this.Exception);
                 }
             }
         }
@@ -337,44 +337,52 @@
             }
         }
 
-        private void UpdateData(Exception exception, ExceptionInfo exceptionInfo)
+        private void UpdateData(Exception exception)
         {
             if (this.isCreatedFromExceptionInfo)
             {
-                this.Data = exceptionInfo ?? throw new ArgumentNullException(nameof(exceptionInfo));
-                this.context = new TelemetryContext(this.Data.Properties);
+                throw new InvalidOperationException("Operation is not supported given the state of the object.");
             }
-            else
+
+            // collect the set of exceptions detail info from the passed in exception
+            List<ExceptionDetails> exceptions = new List<ExceptionDetails>();
+            this.ConvertExceptionTree(exception, null, exceptions);
+
+            // trim if we have too many, also add a custom exception to let the user know we're trimmed
+            if (exceptions.Count > Constants.MaxExceptionCountToSave)
             {
-                // collect the set of exceptions detail info from the passed in exception
-                List<ExceptionDetails> exceptions = new List<ExceptionDetails>();
-                this.ConvertExceptionTree(exception, null, exceptions);
+                // TODO: when we localize these messages, we should consider not using InvariantCulture
+                // create our "message" exception.
+                InnerExceptionCountExceededException countExceededException =
+                    new InnerExceptionCountExceededException(
+                        string.Format(
+                            CultureInfo.InvariantCulture,
+                            "The number of inner exceptions was {0} which is larger than {1}, the maximum number allowed during transmission. All but the first {1} have been dropped.",
+                            exceptions.Count,
+                            Constants.MaxExceptionCountToSave));
 
-                // trim if we have too many, also add a custom exception to let the user know we're trimmed
-                if (exceptions.Count > Constants.MaxExceptionCountToSave)
-                {
-                    // TODO: when we localize these messages, we should consider not using InvariantCulture
-                    // create our "message" exception.
-                    InnerExceptionCountExceededException countExceededException =
-                        new InnerExceptionCountExceededException(
-                            string.Format(
-                                CultureInfo.InvariantCulture,
-                                "The number of inner exceptions was {0} which is larger than {1}, the maximum number allowed during transmission. All but the first {1} have been dropped.",
-                                exceptions.Count,
-                                Constants.MaxExceptionCountToSave));
+                // remove all but the first N exceptions
+                exceptions.RemoveRange(Constants.MaxExceptionCountToSave,
+                    exceptions.Count - Constants.MaxExceptionCountToSave);
 
-                    // remove all but the first N exceptions
-                    exceptions.RemoveRange(Constants.MaxExceptionCountToSave,
-                        exceptions.Count - Constants.MaxExceptionCountToSave);
-
-                    // we'll add our new exception and parent it to the root exception (first one in the list)
-                    exceptions.Add(ExceptionConverter.ConvertToExceptionDetails(countExceededException, exceptions[0]));
-                }
-
-                this.Data = new ExceptionInfo(exceptions.Select(ex => new ExceptionDetailsInfo(ex)), this.SeverityLevel,
-                    this.ProblemId, this.Properties, this.Metrics);
-                this.context = new TelemetryContext(this.Data.Properties);
+                // we'll add our new exception and parent it to the root exception (first one in the list)
+                exceptions.Add(ExceptionConverter.ConvertToExceptionDetails(countExceededException, exceptions[0]));
             }
+
+            this.Data = new ExceptionInfo(exceptions.Select(ex => new ExceptionDetailsInfo(ex)), this.SeverityLevel,
+                this.ProblemId, this.Properties, this.Metrics);
+            this.context = new TelemetryContext(this.Data.Properties);
+        }
+
+        private void UpdateData(ExceptionInfo exceptionInfo)
+        {
+            if (!this.isCreatedFromExceptionInfo)
+            {
+                throw new InvalidOperationException("Operation is not supported given the state of the object.");
+            }
+
+            this.Data = exceptionInfo ?? throw new ArgumentNullException(nameof(exceptionInfo));
+            this.context = new TelemetryContext(this.Data.Properties);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -54,12 +54,19 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="ExceptionTelemetry"/> class.
         /// </summary>
-        /// <param name="exceptionInfo">Exception info.</param>
-        public ExceptionTelemetry(ExceptionInfo exceptionInfo)
+        /// <param name="exceptionDetailsInfoList">Exception info.</param>
+        /// <param name="severityLevel">Severity level.</param>
+        /// <param name="problemId">Problem id.</param>
+        /// <param name="properties">Properties.</param>
+        /// <param name="measurements">Measurements.</param>
+        public ExceptionTelemetry(IEnumerable<ExceptionDetailsInfo> exceptionDetailsInfoList, SeverityLevel? severityLevel, string problemId,
+            IDictionary<string, string> properties, IDictionary<string, double> measurements)
         {
             this.isCreatedFromExceptionInfo = true;
 
-            this.Data = exceptionInfo ?? throw new ArgumentNullException(nameof(exceptionInfo));
+            ExceptionInfo exceptionInfo = new ExceptionInfo(exceptionDetailsInfoList, severityLevel, problemId, properties, measurements);
+
+            this.Data = exceptionInfo;
             this.context = new TelemetryContext(this.Data.Properties);
 
             this.UpdateData(exceptionInfo);
@@ -167,11 +174,6 @@
                 this.UpdateData(value);
             }
         }
-
-        /// <summary>
-        /// Gets the <see cref="ExceptionInfo"/> which describes the data contained within this <see cref="ITelemetry"/>.
-        /// </summary>
-        public ExceptionInfo ExceptionInfo => this.Data;
 
         /// <summary>
         /// Gets or sets ExceptionTelemetry message.

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Linq;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
@@ -11,13 +12,14 @@
     /// Telemetry type used to track exceptions.
     /// <a href="https://go.microsoft.com/fwlink/?linkid=723596">Learn more</a>
     /// </summary>
-    public sealed class ExceptionTelemetry : ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics
+    public sealed class ExceptionTelemetry : ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics 
     {
         internal const string TelemetryName = "Exception";
         internal readonly string BaseType = typeof(ExceptionData).Name;
         internal readonly ExceptionData Data;
 
         private readonly TelemetryContext context;
+        private IReadOnlyList<ExceptionDetailsInfo> exceptionDetailsInfoList;
         private Exception exception;
         private string message;
 
@@ -170,6 +172,18 @@
         }
 
         /// <summary>
+        /// Gets the list of <see cref="ExceptionDetailsInfo"/>. User can modify the contents of individual object, but
+        /// not the list itself.
+        /// </summary>
+        public IReadOnlyList<ExceptionDetailsInfo> ExceptionDetailsInfoList
+        {
+            get
+            {
+                return this.exceptionDetailsInfoList;
+            }
+        }
+
+        /// <summary>
         /// Gets a dictionary of application-defined property names and values providing additional information about this exception.
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#properties">Learn more</a>
         /// </summary>
@@ -216,8 +230,6 @@
         /// </summary>
         public void SetParsedStack(System.Diagnostics.StackFrame[] frames)
         {
-            List<StackFrame> orderedStackTrace = new List<StackFrame>();
-
             if (this.Exceptions != null && this.Exceptions.Count > 0)
             {
                 if (frames != null && frames.Length > 0)
@@ -312,6 +324,7 @@
             }
 
             this.Data.exceptions = exceptions;
+            this.exceptionDetailsInfoList = exceptions.Select(ex => new ExceptionDetailsInfo(ex)).ToList().AsReadOnly();
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/StackFrame.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/StackFrame.cs
@@ -1,0 +1,27 @@
+﻿namespace Microsoft.ApplicationInsights.DataContracts
+{
+    using System;
+
+    /// <summary>
+    /// Wrapper class for <see cref="Extensibility.Implementation.External.StackFrame"/> for API exposure.
+    /// </summary>
+    public sealed class StackFrame
+    {
+        /// <summary>
+        /// Constructs an instance.
+        /// </summary>
+        public StackFrame(string assembly, string fileName, int level, int line, string method)
+        {
+            this.Data = new Extensibility.Implementation.External.StackFrame()
+            {
+                assembly = assembly,
+                fileName = fileName,
+                level = level,
+                line = line,
+                method = method
+            };
+        }
+
+        internal Extensibility.Implementation.External.StackFrame Data { get; private set; } = null;
+    }
+}

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -11,7 +11,6 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Platform;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
@@ -190,7 +189,7 @@
 
                     int stackFrameArrayIndex = 0;
 
-                    foreach (StackFrame frame in exceptionDetails.parsedStack)
+                    foreach (External.StackFrame frame in exceptionDetails.parsedStack)
                     {
                         if (stackFrameArrayIndex++ != 0)
                         {
@@ -209,7 +208,7 @@
             }
         }
 
-        private static void SerializeStackFrame(StackFrame frame, IJsonWriter writer)
+        private static void SerializeStackFrame(External.StackFrame frame, IJsonWriter writer)
         {
             writer.WriteProperty("level", frame.level);
             writer.WriteProperty(
@@ -364,11 +363,11 @@
                 {
                     writer.WriteStartObject();
 
-                    writer.WriteProperty("ver", exceptionTelemetry.Data.ver);
-                    writer.WriteProperty("problemId", exceptionTelemetry.Data.problemId);
-                    Utils.CopyDictionary(exceptionTelemetry.Context.GlobalProperties, exceptionTelemetry.Data.properties);
-                    writer.WriteProperty("properties", exceptionTelemetry.Data.properties);
-                    writer.WriteProperty("measurements", exceptionTelemetry.Data.measurements);
+                    writer.WriteProperty("ver", exceptionTelemetry.Data.Data.ver);
+                    writer.WriteProperty("problemId", exceptionTelemetry.Data.Data.problemId);
+                    Utils.CopyDictionary(exceptionTelemetry.Context.GlobalProperties, exceptionTelemetry.Data.Data.properties);
+                    writer.WriteProperty("properties", exceptionTelemetry.Data.Data.properties);
+                    writer.WriteProperty("measurements", exceptionTelemetry.Data.Data.measurements);
                     writer.WritePropertyName("exceptions");
                     {
                         writer.WriteStartArray();
@@ -378,9 +377,9 @@
                         writer.WriteEndArray();
                     }
 
-                    if (exceptionTelemetry.Data.severityLevel.HasValue)
+                    if (exceptionTelemetry.Data.Data.severityLevel.HasValue)
                     {
-                        writer.WriteProperty("severityLevel", exceptionTelemetry.Data.severityLevel.Value.ToString());
+                        writer.WriteProperty("severityLevel", exceptionTelemetry.Data.Data.severityLevel.Value.ToString());
                     }
 
                     writer.WriteEndObject();

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -502,7 +502,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             eventSourceOptionsKeywordsProperty.SetValue(eventSourceOptions, keywords);
             var dummyExceptionData = new ExceptionData();
             var dummyExceptionDetails = new ExceptionDetails();
-            var dummyStackFrame = new StackFrame();
+            var dummyStackFrame = new External.StackFrame();
             var writeMethod = writeGenericMethod.MakeGenericMethod(new
             {
                 PartA_iKey = this.dummyPartAiKeyValue,
@@ -550,7 +550,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as ExceptionTelemetry;
-                    var data = telemetryItem.Data;
+                    var data = telemetryItem.Data.Data;
                     var extendedData = new
                     {
                         // The properties and layout should be the same as the anonymous type in the above MakeGenericMethod

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     ExceptionTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
                     telemetryItem.Context.SanitizedTags,
-                    telemetryItem.Data,
+                    telemetryItem.Data.Data,
                     telemetryItem.Context.Flags,
                     Keywords.Exceptions);
             }


### PR DESCRIPTION
Fix Issue #498 .
Adds a class `ExceptionDetailsInfo` which acts as a wrapper for internal `ExceptionDetails` and is used to update the `TypeName` and `Message` fields of internal `ExceptionDetails` objects.

- [X] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [X] Design discussion issue #498 
- [ ] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
