### PR TITLE
Add hex checking and parsing in TelemetryConfigurationFactory 

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -328,6 +328,14 @@
             object instance = TestableTelemetryConfigurationFactory.LoadInstance(definition, typeof(int), null, null);
             Assert.AreEqual(42, instance);
         }
+        
+        [TestMethod]
+        public void LoadInstanceConvertsValueToExpectedTypeGivenXmlDefinitionWithNoChildElementsParseHexValue()
+        {
+            var definition = new XElement("Definition", "0x42");
+            object instance = TestableTelemetryConfigurationFactory.LoadInstance(definition, typeof(int), null, null);
+            Assert.AreEqual(66, instance);
+        }
 
         [TestMethod]
         public void LoadInstanceTrimsValueOfGivenXmlElementToIgnoreWhitespaceUsersMayAddToConfiguration()

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -411,7 +411,16 @@
                 }
                 else
                 {
-                    instance = Convert.ChangeType(valueString, expectedType, CultureInfo.InvariantCulture);
+                    if (valueString.ToLower().IndexOf("0x") == 0)
+                    {
+                        CultureInfo provider = CultureInfo.InvariantCulture;
+
+                        instance = Int32.Parse(valueString.Remove(0, 2), NumberStyles.AllowHexSpecifier, provider);
+                    }
+                    else
+                    {
+                        instance = Convert.ChangeType(valueString, expectedType, CultureInfo.InvariantCulture);
+                    }
                 }
             }
             catch (InvalidCastException e)


### PR DESCRIPTION
Fix Issue #551 
 change to allow TelemetryConfigurationFactory  to read hex values
 added a new unit test for reading hex values

@Dmitry-Matveev 