### PR TITLE
fix compile issue. updated changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - Added method `ExceptionDetailsInfoList` on `ExceptionTelemetry` class that gives control to user to update exception
 message and exception type of underlying `System.Exception` object that user wants to send to telemetry. Related discussion is [here](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/498).
 - Added an option of creating ExceptionTelemetry object off of custom exception information rather than a System.Exception object.
+- [Add support for hex values in config](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/551)
 
 ## Version 2.7.0-beta3
 - [Allow to set flags on event](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/844). It will be used in conjunction with the feature that will allow to keep IP addresses.

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -411,7 +411,7 @@
                 }
                 else
                 {
-                    if (valueString.ToLower().IndexOf("0x") == 0)
+                    if (valueString.IndexOf("0x", StringComparison.OrdinalIgnoreCase) == 0)
                     {
                         CultureInfo provider = CultureInfo.InvariantCulture;
 


### PR DESCRIPTION
PR #877 was merged without a build and introduced compile errors:

- fix compiler issue: `Error CA1304: Microsoft.Globalization : Because the behavior of 'string.ToLower()' could vary based on the current user's locale settings, replace this call in 'TelemetryConfigurationFactory.LoadInstanceFromValue(XElement, Type, ref object)' with a call to 'string.ToLower(CultureInfo)'. If the result of 'string.ToLower(CultureInfo)' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'CultureInfo' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.`
- fix compiler issue: `Error CA1307: Microsoft.Globalization : Because the behavior of 'string.IndexOf(string)' could vary based on the current user's locale settings, replace this call in 'TelemetryConfigurationFactory.LoadInstanceFromValue(XElement, Type, ref object)' with a call to 'string.IndexOf(string, StringComparison)'. If the result of 'string.IndexOf(string, StringComparison)' will be displayed to the user, such as when sorting a list of items for display in a list box, specify 'StringComparison.CurrentCulture' or 'StringComparison.CurrentCultureIgnoreCase' as the 'StringComparison' parameter. If comparing case-insensitive identifiers, such as file ***hs, environment variables, or registry keys and values, specify 'StringComparison.OrdinalIgnoreCase'. Otherwise, if comparing case-sensitive identifiers, specify 'StringComparison.Ordinal'.`
- updated changelog