### PR TITLE
ITelemetry.SerializeData instead of Serialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ This changelog will be used to generate documentation on [release notes page](ht
 ## Version 2.8.0-beta1
 - [Add a new distict properties collection, GlobalProperties, on TelemetryContext, and obsolete the Properties on TelemetryContext.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/820)
 - [Added support for strongly typed extensibility for Telemetry types using IExtension.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/871)
+- [New method SerializeData(ISerializationWriter writer) defined in ITelemetry. All existing types implement this method to emit information about it's fields to channels who can serialize this data]
+   (continuation of https://github.com/Microsoft/ApplicationInsights-dotnet/issues/871)
 - [Allow to track PageViewPerformance data type](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/673).
 - Added method `ExceptionDetailsInfoList` on `ExceptionTelemetry` class that gives control to user to update exception
 message and exception type of underlying `System.Exception` object that user wants to send to telemetry. Related discussion is [here](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/498).

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -296,55 +296,42 @@ Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Flags.set -> void
 const Microsoft.ApplicationInsights.DataContracts.TelemetryContext.FlagDropIdentifiers = 2097152 -> long
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.Channel.ITelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Channel.ITelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.set -> void
-override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.set -> void
-override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.set -> void
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
@@ -358,6 +345,7 @@ Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(s
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.TimeSpan? value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.DateTimeOffset? value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter value) -> void
+Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IList<string> items) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IList<Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter> items) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IDictionary<string, string> items) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -297,42 +297,55 @@ const Microsoft.ApplicationInsights.DataContracts.TelemetryContext.FlagDropIdent
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.Channel.ITelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.Channel.ITelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.EventTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.set -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.set -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.set -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.IExtension

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -296,55 +296,42 @@ Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Flags.set -> void
 const Microsoft.ApplicationInsights.DataContracts.TelemetryContext.FlagDropIdentifiers = 2097152 -> long
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.Channel.ITelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Channel.ITelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.set -> void
-override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.set -> void
-override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.set -> void
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
@@ -358,6 +345,7 @@ Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(s
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.TimeSpan? value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.DateTimeOffset? value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter value) -> void
+Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IList<string> items) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IList<Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter> items) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IDictionary<string, string> items) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -297,42 +297,55 @@ const Microsoft.ApplicationInsights.DataContracts.TelemetryContext.FlagDropIdent
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.Channel.ITelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.Channel.ITelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.EventTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.set -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.set -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.set -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.IExtension

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -298,42 +298,55 @@ const Microsoft.ApplicationInsights.DataContracts.TelemetryContext.FlagDropIdent
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.Channel.ITelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.Channel.ITelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.EventTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.set -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.set -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.set -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.set -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.IExtension

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -297,55 +297,42 @@ Microsoft.ApplicationInsights.DataContracts.TelemetryContext.Flags.set -> void
 const Microsoft.ApplicationInsights.DataContracts.TelemetryContext.FlagDropIdentifiers = 2097152 -> long
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.Channel.ITelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.Channel.ITelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Channel.ITelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.AvailabilityTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.EventTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.EventTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.MetricTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewPerformanceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PageViewTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.PerformanceCounterTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.SessionStateTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Extension.set -> void
-Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Extension.set -> void
-override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.DependencyTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Extension.set -> void
-override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.get -> Microsoft.ApplicationInsights.Extensibility.IExtension
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Extension.set -> void
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 abstract Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.SerializeData(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter
 Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter.Serialize(Microsoft.ApplicationInsights.Extensibility.ISerializationWriter serializationWriter) -> void
@@ -359,6 +346,7 @@ Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(s
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.TimeSpan? value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.DateTimeOffset? value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter value) -> void
+Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter value) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IList<string> items) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IList<Microsoft.ApplicationInsights.Extensibility.ISerializableWithWriter> items) -> void
 Microsoft.ApplicationInsights.Extensibility.ISerializationWriter.WriteProperty(string name, System.Collections.Generic.IDictionary<string, string> items) -> void

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/MyTestExtension.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/MyTestExtension.cs
@@ -6,8 +6,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
     public class MyTestExtension : IExtension
     {
-        int myIntField;
-        string myStringField;
+        public int myIntField;
+        public string myStringField;
 
         public IExtension DeepClone()
         {

--- a/Test/TestFramework/Shared/StubTelemetry.cs
+++ b/Test/TestFramework/Shared/StubTelemetry.cs
@@ -51,5 +51,10 @@
         {
             
         }
+
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
+
+        }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Channel/ITelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/Channel/ITelemetry.cs
@@ -55,5 +55,10 @@
         /// Writes serialization info about the class using the given <see cref="ISerializationWriter"/>
         /// </summary>
         void Serialize(ISerializationWriter serializationWriter);
+
+        /// <summary>
+        /// Writes serialization info about the data class of the implementing type using the given <see cref="ISerializationWriter"/>
+        /// </summary>
+        void SerializeData(ISerializationWriter serializationWriter);
     }
 }

--- a/src/Microsoft.ApplicationInsights/Channel/ITelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/Channel/ITelemetry.cs
@@ -50,12 +50,7 @@
         /// </summary>
         /// <returns>The cloned object.</returns>
         ITelemetry DeepClone();
-
-        /// <summary>
-        /// Writes serialization info about the class using the given <see cref="ISerializationWriter"/>
-        /// </summary>
-        void Serialize(ISerializationWriter serializationWriter);
-
+        
         /// <summary>
         /// Writes serialization info about the data class of the implementing type using the given <see cref="ISerializationWriter"/>
         /// </summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
@@ -185,9 +185,15 @@
             this.WriteEnvelopeProperties(serializationWriter);            
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
@@ -179,21 +179,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);            
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data);            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -348,9 +348,15 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.WriteEnvelopeProperties(serializationWriter);                      
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public override void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.InternalData);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -342,21 +342,9 @@ namespace Microsoft.ApplicationInsights.DataContracts
         }
 
         /// <inheritdoc/>
-        public override void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);                      
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public override void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.InternalData);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.InternalData);            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
@@ -142,9 +142,15 @@
             this.WriteEnvelopeProperties(serializationWriter);            
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
@@ -136,21 +136,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);            
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -284,9 +284,15 @@
             this.WriteEnvelopeProperties(serializationWriter);            
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -278,21 +278,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);            
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data.Data);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
@@ -252,21 +252,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);            
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
@@ -258,9 +258,15 @@
             this.WriteEnvelopeProperties(serializationWriter);            
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewPerformanceTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewPerformanceTelemetry.cs
@@ -232,9 +232,15 @@
             this.WriteEnvelopeProperties(serializationWriter);            
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewPerformanceTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewPerformanceTelemetry.cs
@@ -226,21 +226,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);            
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
@@ -179,21 +179,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {            
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);            
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data            
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
@@ -185,9 +185,15 @@
             this.WriteEnvelopeProperties(serializationWriter);            
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data            
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/PerformanceCounterTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PerformanceCounterTelemetry.cs
@@ -198,6 +198,12 @@
             this.Data.Serialize(serializationWriter);
         }
 
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
+            this.Data.SerializeData(serializationWriter);
+        }
+
         /// <summary>
         /// Sanitizes the properties based on constraints.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/PerformanceCounterTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PerformanceCounterTelemetry.cs
@@ -193,12 +193,6 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {
-            this.Data.Serialize(serializationWriter);
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
             this.Data.SerializeData(serializationWriter);

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -236,21 +236,9 @@
         }
 
         /// <inheritdoc/>
-        public override void Serialize(ISerializationWriter serializationWriter)
-        {
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data
-        }
-
-        /// <inheritdoc/>
         public override void SerializeData(ISerializationWriter serializationWriter)
         {            
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);            
+            serializationWriter.WriteProperty(this.Data);                        
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -242,9 +242,15 @@
             this.WriteEnvelopeProperties(serializationWriter);
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            this.SerializeData(serializationWriter);
             serializationWriter.WriteEndObject(); // data
+        }
+
+        /// <inheritdoc/>
+        public override void SerializeData(ISerializationWriter serializationWriter)
+        {            
+            serializationWriter.WriteProperty("baseData", this.Data);
+            serializationWriter.WriteProperty("extension", this.Extension);            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/SessionStateTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/SessionStateTelemetry.cs
@@ -145,5 +145,11 @@
         {
             this.Data.Serialize(serializationWriter);
         }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
+            this.Data.SerializeData(serializationWriter);
+        }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/SessionStateTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/SessionStateTelemetry.cs
@@ -141,12 +141,6 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {
-            this.Data.Serialize(serializationWriter);
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
             this.Data.SerializeData(serializationWriter);

--- a/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
@@ -137,21 +137,9 @@
         }
 
         /// <inheritdoc/>
-        public void Serialize(ISerializationWriter serializationWriter)
-        {
-            serializationWriter.WriteProperty("name", this.WriteTelemetryName(TelemetryName));
-            this.WriteEnvelopeProperties(serializationWriter);
-            serializationWriter.WriteStartObject("data");
-            serializationWriter.WriteProperty("baseType", this.BaseType);
-            this.SerializeData(serializationWriter);
-            serializationWriter.WriteEndObject(); // data
-        }
-
-        /// <inheritdoc/>
         public void SerializeData(ISerializationWriter serializationWriter)
         {
-            serializationWriter.WriteProperty("baseData", this.Data);
-            serializationWriter.WriteProperty("extension", this.Extension);
+            serializationWriter.WriteProperty(this.Data);            
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
@@ -143,9 +143,15 @@
             this.WriteEnvelopeProperties(serializationWriter);
             serializationWriter.WriteStartObject("data");
             serializationWriter.WriteProperty("baseType", this.BaseType);
+            this.SerializeData(serializationWriter);
+            serializationWriter.WriteEndObject(); // data
+        }
+
+        /// <inheritdoc/>
+        public void SerializeData(ISerializationWriter serializationWriter)
+        {
             serializationWriter.WriteProperty("baseData", this.Data);
             serializationWriter.WriteProperty("extension", this.Extension);
-            serializationWriter.WriteEndObject(); // data
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/ISerializationWriter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/ISerializationWriter.cs
@@ -44,6 +44,11 @@
         void WriteProperty(string name, ISerializableWithWriter value);
 
         /// <summary>
+        /// Writes value ISerializableWithWriter field
+        /// </summary>
+        void WriteProperty(ISerializableWithWriter value);
+
+        /// <summary>
         /// Writes name and values for a IList field of strings
         /// </summary>
         void WriteProperty(string name, IList<string> items);

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializationWriter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializationWriter.cs
@@ -154,10 +154,8 @@
         public void WriteProperty(ISerializableWithWriter value)
         {
             if (value != null)
-            {
-                this.WriteStartObject();
-                value.Serialize(this);
-                this.WriteEndObject();
+            {                
+                value.Serialize(this);                
             }
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializationWriter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializationWriter.cs
@@ -151,6 +151,17 @@
         }
 
         /// <inheritdoc/>
+        public void WriteProperty(ISerializableWithWriter value)
+        {
+            if (value != null)
+            {
+                this.WriteStartObject();
+                value.Serialize(this);
+                this.WriteEndObject();
+            }
+        }
+
+        /// <inheritdoc/>
         public void WriteProperty(string name, IDictionary<string, double> values)
         {
             if (values != null && values.Count > 0)

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -235,7 +235,12 @@
 
                 SerializeHelper(telemetryItem, jsonSerializationWriter, availabilityTelemetry.BaseType, AvailabilityTelemetry.TelemetryName);
             }
-            
+            else
+            {
+                string msg = string.Format(CultureInfo.InvariantCulture, "Unknown telemetry type: {0}", telemetryItem.GetType());
+                CoreEventSource.Log.LogVerbose(msg);
+            }
+
             jsonSerializationWriter.WriteEndObject();
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -155,62 +155,176 @@
         }
 
         private static void SerializeTelemetryItem(ITelemetry telemetryItem, JsonSerializationWriter jsonSerializationWriter)
-        {                        
-                if (telemetryItem is EventTelemetry)
+        {
+            jsonSerializationWriter.WriteStartObject();
+
+            if (telemetryItem is EventTelemetry)
                 {
                     EventTelemetry eventTelemetry = telemetryItem as EventTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, eventTelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(EventTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", eventTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
                 else if (telemetryItem is ExceptionTelemetry)
                 {
                     ExceptionTelemetry exTelemetry = telemetryItem as ExceptionTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, exTelemetry.Data.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(ExceptionTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", exTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
                 else if (telemetryItem is MetricTelemetry)
                 {
                     MetricTelemetry mTelemetry = telemetryItem as MetricTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, mTelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(MetricTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", mTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
                 else if (telemetryItem is PageViewTelemetry)
                 {
                     PageViewTelemetry pvTelemetry = telemetryItem as PageViewTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pvTelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(PageViewTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", pvTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
                 else if (telemetryItem is PageViewPerformanceTelemetry)
                 {
                     PageViewPerformanceTelemetry pvptelemetry = telemetryItem as PageViewPerformanceTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pvptelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(PageViewPerformanceTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", PageViewPerformanceTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
                 else if (telemetryItem is DependencyTelemetry)
                 {
                     DependencyTelemetry depTelemetry = telemetryItem as DependencyTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, depTelemetry.InternalData.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(DependencyTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", depTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
                 else if (telemetryItem is RequestTelemetry)
                 {
                     RequestTelemetry reqTelemetry = telemetryItem as RequestTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, reqTelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(RequestTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", reqTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
 #pragma warning disable 618
                 else if (telemetryItem is PerformanceCounterTelemetry)
                 {
                     PerformanceCounterTelemetry pcTelemetry = telemetryItem as PerformanceCounterTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pcTelemetry.Properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(MetricTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", pcTelemetry.Data.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
+                }
+                else if (telemetryItem is SessionStateTelemetry)
+                {
+                    SessionStateTelemetry ssTelemetry = telemetryItem as SessionStateTelemetry;
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(EventTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", ssTelemetry.Data.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
 #pragma warning restore 618
-                else if (telemetryItem is TraceTelemetry)
+            else if (telemetryItem is TraceTelemetry)
                 {
                     TraceTelemetry traceTelemetry = telemetryItem as TraceTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, traceTelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(TraceTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", traceTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }                
                 else if (telemetryItem is AvailabilityTelemetry)
                 {
                     AvailabilityTelemetry availabilityTelemetry = telemetryItem as AvailabilityTelemetry;
                     Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, availabilityTelemetry.Data.properties);
+
+                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(AvailabilityTelemetry.TelemetryName));
+                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteStartObject("data");
+                    jsonSerializationWriter.WriteProperty("baseType", availabilityTelemetry.BaseType);
+                    jsonSerializationWriter.WriteStartObject("baseData");
+                    telemetryItem.SerializeData(jsonSerializationWriter);
+                    jsonSerializationWriter.WriteEndObject(); // baseData
+                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+                    jsonSerializationWriter.WriteEndObject(); // data
                 }
-                
-                jsonSerializationWriter.WriteStartObject();
-                telemetryItem.Serialize(jsonSerializationWriter);
+            
                 jsonSerializationWriter.WriteEndObject();
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -159,173 +159,97 @@
             jsonSerializationWriter.WriteStartObject();
 
             if (telemetryItem is EventTelemetry)
-                {
-                    EventTelemetry eventTelemetry = telemetryItem as EventTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, eventTelemetry.Data.properties);
+            {
+                EventTelemetry eventTelemetry = telemetryItem as EventTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, eventTelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(EventTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", eventTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is ExceptionTelemetry)
-                {
-                    ExceptionTelemetry exTelemetry = telemetryItem as ExceptionTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, exTelemetry.Data.Data.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, eventTelemetry.BaseType, EventTelemetry.TelemetryName);
+            }
+            else if (telemetryItem is ExceptionTelemetry)
+            {
+                ExceptionTelemetry exTelemetry = telemetryItem as ExceptionTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, exTelemetry.Data.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(ExceptionTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", exTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is MetricTelemetry)
-                {
-                    MetricTelemetry mTelemetry = telemetryItem as MetricTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, mTelemetry.Data.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, exTelemetry.BaseType, ExceptionTelemetry.TelemetryName);
+            }
+            else if (telemetryItem is MetricTelemetry)
+            {
+                MetricTelemetry mTelemetry = telemetryItem as MetricTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, mTelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(MetricTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", mTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is PageViewTelemetry)
-                {
-                    PageViewTelemetry pvTelemetry = telemetryItem as PageViewTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pvTelemetry.Data.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, mTelemetry.BaseType, MetricTelemetry.TelemetryName);                
+            }
+            else if (telemetryItem is PageViewTelemetry)
+            {
+                PageViewTelemetry pvTelemetry = telemetryItem as PageViewTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pvTelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(PageViewTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", pvTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is PageViewPerformanceTelemetry)
-                {
-                    PageViewPerformanceTelemetry pvptelemetry = telemetryItem as PageViewPerformanceTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pvptelemetry.Data.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, pvTelemetry.BaseType, PageViewTelemetry.TelemetryName);
+            }
+            else if (telemetryItem is PageViewPerformanceTelemetry)
+            {
+                PageViewPerformanceTelemetry pvptelemetry = telemetryItem as PageViewPerformanceTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pvptelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(PageViewPerformanceTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", PageViewPerformanceTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is DependencyTelemetry)
-                {
-                    DependencyTelemetry depTelemetry = telemetryItem as DependencyTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, depTelemetry.InternalData.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, PageViewPerformanceTelemetry.BaseType, PageViewPerformanceTelemetry.TelemetryName);
+            }
+            else if (telemetryItem is DependencyTelemetry)
+            {
+                DependencyTelemetry depTelemetry = telemetryItem as DependencyTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, depTelemetry.InternalData.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(DependencyTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", depTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is RequestTelemetry)
-                {
-                    RequestTelemetry reqTelemetry = telemetryItem as RequestTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, reqTelemetry.Data.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, depTelemetry.BaseType, DependencyTelemetry.TelemetryName);                
+            }
+            else if (telemetryItem is RequestTelemetry)
+            {
+                RequestTelemetry reqTelemetry = telemetryItem as RequestTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, reqTelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(RequestTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", reqTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
+                SerializeHelper(telemetryItem, jsonSerializationWriter, reqTelemetry.BaseType, RequestTelemetry.TelemetryName);                
+            }
 #pragma warning disable 618
-                else if (telemetryItem is PerformanceCounterTelemetry)
-                {
-                    PerformanceCounterTelemetry pcTelemetry = telemetryItem as PerformanceCounterTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pcTelemetry.Properties);
+            else if (telemetryItem is PerformanceCounterTelemetry)
+            {
+                PerformanceCounterTelemetry pcTelemetry = telemetryItem as PerformanceCounterTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, pcTelemetry.Properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(MetricTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", pcTelemetry.Data.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
-                else if (telemetryItem is SessionStateTelemetry)
-                {
-                    SessionStateTelemetry ssTelemetry = telemetryItem as SessionStateTelemetry;
-
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(EventTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", ssTelemetry.Data.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
+                SerializeHelper(telemetryItem, jsonSerializationWriter, pcTelemetry.Data.BaseType, MetricTelemetry.TelemetryName);
+            }
+            else if (telemetryItem is SessionStateTelemetry)
+            {
+                SessionStateTelemetry ssTelemetry = telemetryItem as SessionStateTelemetry;
+                SerializeHelper(telemetryItem, jsonSerializationWriter, ssTelemetry.Data.BaseType, EventTelemetry.TelemetryName);
+            }
 #pragma warning restore 618
-            else if (telemetryItem is TraceTelemetry)
-                {
-                    TraceTelemetry traceTelemetry = telemetryItem as TraceTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, traceTelemetry.Data.properties);
+        else if (telemetryItem is TraceTelemetry)
+            {
+                TraceTelemetry traceTelemetry = telemetryItem as TraceTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, traceTelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(TraceTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", traceTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }                
-                else if (telemetryItem is AvailabilityTelemetry)
-                {
-                    AvailabilityTelemetry availabilityTelemetry = telemetryItem as AvailabilityTelemetry;
-                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, availabilityTelemetry.Data.properties);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, traceTelemetry.BaseType, TraceTelemetry.TelemetryName);
+            }                
+            else if (telemetryItem is AvailabilityTelemetry)
+            {
+                AvailabilityTelemetry availabilityTelemetry = telemetryItem as AvailabilityTelemetry;
+                Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, availabilityTelemetry.Data.properties);
 
-                    jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(AvailabilityTelemetry.TelemetryName));
-                    telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteStartObject("data");
-                    jsonSerializationWriter.WriteProperty("baseType", availabilityTelemetry.BaseType);
-                    jsonSerializationWriter.WriteStartObject("baseData");
-                    telemetryItem.SerializeData(jsonSerializationWriter);
-                    jsonSerializationWriter.WriteEndObject(); // baseData
-                    jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
-                    jsonSerializationWriter.WriteEndObject(); // data
-                }
+                SerializeHelper(telemetryItem, jsonSerializationWriter, availabilityTelemetry.BaseType, AvailabilityTelemetry.TelemetryName);
+            }
             
-                jsonSerializationWriter.WriteEndObject();
+            jsonSerializationWriter.WriteEndObject();
+        }
+
+        private static void SerializeHelper(ITelemetry telemetryItem, JsonSerializationWriter jsonSerializationWriter, string baseType, string telemetryName)
+        {
+            jsonSerializationWriter.WriteProperty("name", telemetryItem.WriteTelemetryName(telemetryName));
+            telemetryItem.WriteEnvelopeProperties(jsonSerializationWriter);
+            jsonSerializationWriter.WriteStartObject("data");
+            jsonSerializationWriter.WriteProperty("baseType", baseType);
+            jsonSerializationWriter.WriteStartObject("baseData");
+            telemetryItem.SerializeData(jsonSerializationWriter);
+            jsonSerializationWriter.WriteEndObject(); // baseData
+            jsonSerializationWriter.WriteProperty("extension", telemetryItem.Extension);
+            jsonSerializationWriter.WriteEndObject(); // data
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationTelemetry.cs
@@ -100,9 +100,6 @@
         public abstract ITelemetry DeepClone();
 
         /// <inheritdoc/>
-        public abstract void Serialize(ISerializationWriter serializationWriter);
-
-        /// <inheritdoc/>
         public abstract void SerializeData(ISerializationWriter serializationWriter);
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationTelemetry.cs
@@ -102,6 +102,9 @@
         /// <inheritdoc/>
         public abstract void Serialize(ISerializationWriter serializationWriter);
 
+        /// <inheritdoc/>
+        public abstract void SerializeData(ISerializationWriter serializationWriter);
+
         /// <summary>
         /// Sets operation Id.
         /// </summary>


### PR DESCRIPTION
Make ITelemetry implement SerializeData instead of Serialize, as only Data part need to be serialized. Rest of the content are known within ITelemetry itself and hence require no explicit serialization call.

So if user want to define a new type, implement ITelemetry. (which include SerializeData - to let channels know what fields are defined by the user. All channels should know how to serialzie the rest of the content as they are on `ITelemetry` itself.)

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
