### PR TITLE
Tilee/fix sdl fxcop

### DIFF
--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/FormattableStringTools.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/FormattableStringTools.cs
@@ -40,10 +40,9 @@ namespace System
             return str;
         }
 
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Globalization", "CA1305: Specify IFormatProvider", Justification = "Intended overload.")]
         public override string ToString()
         {
-            string str = String.Format(this.format, this.args);
+            string str = String.Format(CultureInfo.InvariantCulture, this.format, this.args);
             return str;
         }
 

--- a/src/Microsoft.ApplicationInsights/MetricConfigurations.cs
+++ b/src/Microsoft.ApplicationInsights/MetricConfigurations.cs
@@ -10,7 +10,7 @@
         /// <summary>
         /// Groups extension methods that return pre-defined metric configurations and related constants.
         /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104", Justification = "Singelton is intended.")]
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Security", "CA2104:DoNotDeclareReadOnlyMutableReferenceTypes", Justification = "Singleton is intended.")]
         public static readonly MetricConfigurations Common = new MetricConfigurations();
 
         private MetricConfigurations()

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalCube.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalCube.cs
@@ -361,23 +361,23 @@
             { 
                 if (Math.Round(timeout.TotalMilliseconds) >= (double)Int32.MaxValue)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(timeout), $"{nameof(timeout)} must be smaller than {Int32.MaxValue} msec, but it is {timeout}.");
+                    throw new ArgumentOutOfRangeException(nameof(timeout), Invariant($"{nameof(timeout)} must be smaller than {Int32.MaxValue} msec, but it is {timeout}."));
                 }
 
                 if (Math.Round(timeout.TotalMilliseconds) < 1)
                 {
-                    throw new ArgumentOutOfRangeException(nameof(timeout), $"{nameof(timeout)} must be zero, positive or Infinite, but it is {timeout}.");
+                    throw new ArgumentOutOfRangeException(nameof(timeout), Invariant($"{nameof(timeout)} must be zero, positive or Infinite, but it is {timeout}."));
                 }
             }
 
             if (Math.Round(sleepDuration.TotalMilliseconds) > (double)Int32.MaxValue)
             {
-                throw new ArgumentOutOfRangeException(nameof(sleepDuration), $"{nameof(sleepDuration)} must be smaller than {Int32.MaxValue} msec, but it is {sleepDuration}.");
+                throw new ArgumentOutOfRangeException(nameof(sleepDuration), Invariant($"{nameof(sleepDuration)} must be smaller than {Int32.MaxValue} msec, but it is {sleepDuration}."));
             }
 
             if (Math.Round(sleepDuration.TotalMilliseconds) < 0)
             {
-                throw new ArgumentOutOfRangeException(nameof(sleepDuration), $"{nameof(sleepDuration)} must be non-negative, but it is {sleepDuration}.");
+                throw new ArgumentOutOfRangeException(nameof(sleepDuration), Invariant($"{nameof(sleepDuration)} must be non-negative, but it is {sleepDuration}."));
             }
 
             int timeoutMillis = (int)Math.Round(timeout.TotalMilliseconds);


### PR DESCRIPTION
Titanium SDL Review. fixing fxcop issues.

6 issues found for D:\a\1\_sdt\logs\FxCop\FxCop.xml	

- (,): error CA2104: DoNotDeclareReadOnlyMutableReferenceTypes : Remove the read-only designation from 'MetricConfigurations.Common' or change the field to one that is an immutable reference type. If the reference type 'MetricConfigurations' is, in fact, immutable, exclude this message.	
 	
 	
- src\Microsoft.ApplicationInsights\Metrics\Implementation\ConcurrentDatastructures\MultidimensionalCube.cs(369,): error CA1305: SpecifyIFormatProvider : Because the behavior of 'string.Format(string, object, object)' could vary based on the current user's locale settings, replace this call in 'MultidimensionalCube&lt;TDimensionValue, TPoint&gt;.&lt;TryGetOrCreatePointAsync&gt;d__23.MoveNext()' with a call to 'string.Format(IFormatProvider, string, params object[])'. If the result of 'string.Format(IFormatProvider, string, params object[])' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.	
 	
 	
- src\Microsoft.ApplicationInsights\Metrics\Implementation\ConcurrentDatastructures\MultidimensionalCube.cs(380,): error CA1305: SpecifyIFormatProvider : Because the behavior of 'string.Format(string, object, object)' could vary based on the current user's locale settings, replace this call in 'MultidimensionalCube&lt;TDimensionValue, TPoint&gt;.&lt;TryGetOrCreatePointAsync&gt;d__23.MoveNext()' with a call to 'string.Format(IFormatProvider, string, params object[])'. If the result of 'string.Format(IFormatProvider, string, params object[])' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.	
 	
 	
- src\Microsoft.ApplicationInsights\Metrics\Implementation\ConcurrentDatastructures\MultidimensionalCube.cs(364,): error CA1305: SpecifyIFormatProvider : Because the behavior of 'string.Format(string, object, object, object)' could vary based on the current user's locale settings, replace this call in 'MultidimensionalCube&lt;TDimensionValue, TPoint&gt;.&lt;TryGetOrCreatePointAsync&gt;d__23.MoveNext()' with a call to 'string.Format(IFormatProvider, string, params object[])'. If the result of 'string.Format(IFormatProvider, string, params object[])' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.	
 	
 	
- src\Microsoft.ApplicationInsights\Metrics\Implementation\ConcurrentDatastructures\MultidimensionalCube.cs(375,): error CA1305: SpecifyIFormatProvider : Because the behavior of 'string.Format(string, object, object, object)' could vary based on the current user's locale settings, replace this call in 'MultidimensionalCube&lt;TDimensionValue, TPoint&gt;.&lt;TryGetOrCreatePointAsync&gt;d__23.MoveNext()' with a call to 'string.Format(IFormatProvider, string, params object[])'. If the result of 'string.Format(IFormatProvider, string, params object[])' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.	
 	
 	
- src\Microsoft.ApplicationInsights\Extensibility\Implementation\FormattableStringTools.cs(46,): error CA1305: SpecifyIFormatProvider : Because the behavior of 'string.Format(string, params object[])' could vary based on the current user's locale settings, replace this call in 'FormattableString.ToString()' with a call to 'string.Format(IFormatProvider, string, params object[])'. If the result of 'string.Format(IFormatProvider, string, params object[])' will be displayed to the user, specify 'CultureInfo.CurrentCulture' as the 'IFormatProvider' parameter. Otherwise, if the result will be stored and accessed by software, such as when it is persisted to disk or to a database, specify 'CultureInfo.InvariantCulture'.	