### PR TITLE
Response code shouldn't be overwritten to 200 if not set

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -143,7 +143,7 @@
                 Assert.AreEqual(2, item.data.baseData.ver);
                 Assert.IsNotNull(item.data.baseData.id);
                 Assert.IsNotNull(item.time);
-                Assert.AreEqual("", item.data.baseData.responseCode);
+                Assert.AreEqual("200", item.data.baseData.responseCode);
                 Assert.AreEqual(new TimeSpan(), TimeSpan.Parse(item.data.baseData.duration));
                 Assert.IsTrue(item.data.baseData.success);
             }
@@ -187,6 +187,17 @@
         public void SanitizeWillInitializeStatusCode()
         {
             RequestTelemetry telemetry = new RequestTelemetry();
+
+            ((ITelemetry)telemetry).Sanitize();
+
+            Assert.AreEqual("200", telemetry.ResponseCode);
+        }
+
+        [TestMethod]
+        public void SanitizeWillInitializeStatusCodeIfSuccessIsFalse()
+        {
+            RequestTelemetry telemetry = new RequestTelemetry();
+            telemetry.Success = false;
 
             ((ITelemetry)telemetry).Sanitize();
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -143,7 +143,7 @@
                 Assert.AreEqual(2, item.data.baseData.ver);
                 Assert.IsNotNull(item.data.baseData.id);
                 Assert.IsNotNull(item.time);
-                Assert.AreEqual("200", item.data.baseData.responseCode);
+                Assert.AreEqual("", item.data.baseData.responseCode);
                 Assert.AreEqual(new TimeSpan(), TimeSpan.Parse(item.data.baseData.duration));
                 Assert.IsTrue(item.data.baseData.success);
             }
@@ -190,7 +190,7 @@
 
             ((ITelemetry)telemetry).Sanitize();
 
-            Assert.AreEqual("200", telemetry.ResponseCode);
+            Assert.AreEqual("", telemetry.ResponseCode);
         }
 
         [TestMethod]

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -256,15 +256,15 @@
             this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
 
             // Required fields
-            if (string.IsNullOrEmpty(this.ResponseCode))
-            {
-                this.ResponseCode = string.Empty;
-            }
-
             if (!this.Success.HasValue)
             {
                 this.Success = true;
             }
+
+            if (string.IsNullOrEmpty(this.ResponseCode))
+            {
+                this.ResponseCode = this.Success.Value ? "200" : string.Empty;
+            }           
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -255,10 +255,14 @@
             this.Data.id = this.Data.id.SanitizeName();
             this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
 
-            // Required field
+            // Required fields
             if (string.IsNullOrEmpty(this.ResponseCode))
             {
-                this.ResponseCode = "200";
+                this.ResponseCode = string.Empty;
+            }
+
+            if (!this.Success.HasValue)
+            {
                 this.Success = true;
             }
         }


### PR DESCRIPTION
Fix Issue # .
In our internal 'custom requests' tracking like for Service Bus implementation we don't set response code, but set success to false and as a result success is overwritten to true and response code set to 200. It shouldn't happen in case of StartOperation as well because response code doesn't apply there.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.


