### PR TITLE
Perf Impro - Use TimeSpan for duration instead of string to avoid conversions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.8.0
+- [Perf Improvement - Use TimeSpan instead of String for durations to avoid conversions.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/927)
+
 ## Version 2.8.0-beta2
 - [TelemetryProcessors (sampling, autocollectedmetricaggregator), TelemetryChannel (ServerTelemetryChannel) added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/907)
 	If you are upgrading, and have added/modified TelemetryProcessors/TelemetryChannel, make sure to copy them to the default sink section.

--- a/Schema/generateSchema.ps1
+++ b/Schema/generateSchema.ps1
@@ -1,5 +1,5 @@
-$generatorPath = "C:\src\mseng\AppInsights-Common"
-$schemasPath = "C:\src\mseng\DataCollectionSchemas"
+$generatorPath = "C:\repo\zMSAzure-AppInsights-Common"
+$schemasPath = "C:\repo\ApplicationInsights-Home\EndpointSpecs\Schemas"
 $publicSchemaLocation = "https://raw.githubusercontent.com/Microsoft/ApplicationInsights-Home/master/EndpointSpecs/Schemas/Bond"
 $localPublicSchema = $false
 
@@ -7,7 +7,7 @@ $localPublicSchema = $false
 $currentDir = $scriptPath = split-path -parent $MyInvocation.MyCommand.Definition
 #fix path
 $generatorPath = "$generatorPath\..\bin\Debug\BondSchemaGenerator\BondSchemaGenerator"
-$schemasPath = "$schemasPath\v2\Bond\"
+$schemasPath = "$schemasPath\Bond\"
 
 
 
@@ -113,6 +113,15 @@ dir "$currentDir\obj\gbc" | ForEach-Object {
     RegExReplace $_.FullName "= nothing;" "= null;"
 }
 
+
+#################################################################################################
+## Use TimeSpan instead of String for duration to improve performance by avoiding conversions.
+#################################################################################################
+RegExReplace "$currentDir\obj\gbc\RemoteDependencyData_types.cs" "string duration" "System.TimeSpan duration"
+RegExReplace "$currentDir\obj\gbc\RemoteDependencyData_types.cs" "duration = """"" "duration = System.TimeSpan.Zero"
+
+RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "string duration" "System.TimeSpan duration"
+RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "duration = """"" "duration = System.TimeSpan.Zero"
 
 #####################################################################
 ## COPY GENERATED FILES TO THE REPOSITORY

--- a/Schema/generateSchema.ps1
+++ b/Schema/generateSchema.ps1
@@ -123,6 +123,9 @@ RegExReplace "$currentDir\obj\gbc\RemoteDependencyData_types.cs" "duration = """
 RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "string duration" "System.TimeSpan duration"
 RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "duration = """"" "duration = System.TimeSpan.Zero"
 
+RegExReplace "$currentDir\obj\gbc\AvailabilityData_types.cs" "string duration" "System.TimeSpan duration"
+RegExReplace "$currentDir\obj\gbc\AvailabilityData_types.cs" "duration = """"" "duration = System.TimeSpan.Zero"
+
 #####################################################################
 ## COPY GENERATED FILES TO THE REPOSITORY
 #####################################################################

--- a/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
@@ -40,7 +40,7 @@
             : this()
         {
             this.Data.name = name;
-            this.Data.duration = duration.ToString(string.Empty, CultureInfo.InvariantCulture);
+            this.Data.duration = duration;
             this.Data.success = success;
             this.Data.runLocation = runLocation;
             this.Data.message = message;

--- a/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
@@ -85,12 +85,12 @@
         {
             get
             {
-                return Utils.ValidateDuration(this.Data.duration);
+                return this.Data.duration;
             }
 
             set
             {
-                this.Data.duration = value.ToString();
+                this.Data.duration = value;
             }
         }
 

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -215,8 +215,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public override TimeSpan Duration
         {
-            get { return Utils.ValidateDuration(this.InternalData.duration); }
-            set { this.InternalData.duration = value.ToString(); }
+            get { return this.InternalData.duration; }
+            set { this.InternalData.duration = value; }
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -155,8 +155,8 @@
         /// </summary>
         public override TimeSpan Duration
         {
-            get { return Utils.ValidateDuration(this.Data.duration); }
-            set { this.Data.duration = value.ToString(); }
+            get { return this.Data.duration; }
+            set { this.Data.duration = value; }
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/AvailabilityDataISerializableWithWriter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/AvailabilityDataISerializableWithWriter.cs
@@ -14,7 +14,7 @@
             serializationWriter.WriteProperty("ver", this.ver);
             serializationWriter.WriteProperty("id", this.id);
             serializationWriter.WriteProperty("name", this.name);
-            serializationWriter.WriteProperty("duration", Utils.ValidateDuration(this.duration));
+            serializationWriter.WriteProperty("duration", this.duration);
             serializationWriter.WriteProperty("success", this.success);
             serializationWriter.WriteProperty("runLocation", this.runLocation);
             serializationWriter.WriteProperty("message", this.message);

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/AvailabilityData_types.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/AvailabilityData_types.cs
@@ -54,7 +54,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         
         
-        public string duration { get; set; }
+        public System.TimeSpan duration { get; set; }
 
         
         
@@ -91,7 +91,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             ver = 2;
             id = "";
             this.name = "";
-            duration = "";
+            duration = System.TimeSpan.Zero;
             runLocation = "";
             message = "";
             properties = new ConcurrentDictionary<string, string>();

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyDataISerializableWithWriter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyDataISerializableWithWriter.cs
@@ -15,7 +15,7 @@
             serializationWriter.WriteProperty("name", this.name);
             serializationWriter.WriteProperty("id", this.id);
             serializationWriter.WriteProperty("data", this.data);
-            serializationWriter.WriteProperty("duration", Utils.ValidateDuration(this.duration));
+            serializationWriter.WriteProperty("duration", this.duration);
             serializationWriter.WriteProperty("resultCode", this.resultCode);
             serializationWriter.WriteProperty("success", this.success);
             serializationWriter.WriteProperty("type", this.type);

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_types.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_types.cs
@@ -58,7 +58,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         
         
-        public string duration { get; set; }
+        public System.TimeSpan duration { get; set; }
 
         
         
@@ -100,7 +100,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             this.name = "";
             id = "";
             resultCode = "";
-            duration = "";
+            duration = System.TimeSpan.Zero;
             success = true;
             
             target = "";

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestDataISerializableWithWriter.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestDataISerializableWithWriter.cs
@@ -15,7 +15,7 @@
             serializationWriter.WriteProperty("id", this.id);
             serializationWriter.WriteProperty("source", this.source);
             serializationWriter.WriteProperty("name", this.name);
-            serializationWriter.WriteProperty("duration", Utils.ValidateDuration(this.duration));
+            serializationWriter.WriteProperty("duration", this.duration);
             serializationWriter.WriteProperty("success", this.success);
             serializationWriter.WriteProperty("responseCode", this.responseCode);
             serializationWriter.WriteProperty("url", this.url);

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_types.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_types.cs
@@ -57,7 +57,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         
         
-        public string duration { get; set; }
+        public System.TimeSpan duration { get; set; }
 
         
         
@@ -94,7 +94,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             id = "";
             source = "";
             this.name = "";
-            duration = "";
+            duration = System.TimeSpan.Zero;
             responseCode = "";
             success = true;
             url = "";


### PR DESCRIPTION
Internal structures for Dependency and Request modified to use TimeSpan for duration field instead of string. This will avoid conversions leading to better performance.

Fix Issue #927 .
<Short description of the fix.>

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
