### PR TITLE
Metric Aggregation metadata is stored into a field instead of properties dictionary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.8.0
-- [Perf Improvement - Use TimeSpan instead of String for durations to avoid conversions.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/927)
+- Perf Improvements
+	https://github.com/Microsoft/ApplicationInsights-dotnet/issues/927
+	https://github.com/Microsoft/ApplicationInsights-dotnet/issues/930
 
 ## Version 2.8.0-beta2
 - [TelemetryProcessors (sampling, autocollectedmetricaggregator), TelemetryChannel (ServerTelemetryChannel) added automatically to the default ApplicationInsights.config are moved under the default telemetry sink.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/907)

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -261,6 +261,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
                 {
                     this.InternalData.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
                 }
+
                 return this.InternalData.properties;
             }
         }

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -257,7 +257,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         {            
             get
             {
-                if (!this.InternalData.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
+                if (!string.IsNullOrEmpty(this.MetricExtractorInfo) && !this.InternalData.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
                 {
                     this.InternalData.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
                 }

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
-
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Metrics;
     using static System.Threading.LazyInitializer;
 
     /// <summary>
@@ -254,8 +254,15 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#properties">Learn more</a>
         /// </summary>
         public override IDictionary<string, string> Properties
-        {
-            get { return this.InternalData.properties; }
+        {            
+            get
+            {
+                if (!this.InternalData.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
+                {
+                    this.InternalData.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
+                }
+                return this.InternalData.properties;
+            }
         }
 
         /// <summary>
@@ -293,6 +300,15 @@ namespace Microsoft.ApplicationInsights.DataContracts
         {
             get { return this.samplingPercentage; }
             set { this.samplingPercentage = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the MetricExtractorInfo.
+        /// </summary>
+        internal string MetricExtractorInfo
+        {
+            get;
+            set;
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -168,7 +168,7 @@
         {
             get
             {
-                if (!this.Data.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
+                if (!string.IsNullOrEmpty(this.MetricExtractorInfo) && !this.Data.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
                 {
                     this.Data.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
                 }  

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -7,6 +7,7 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Metrics;
 
     /// <summary>
     /// Encapsulates information about a web request handled by the application.
@@ -165,7 +166,14 @@
         /// </summary>
         public override IDictionary<string, string> Properties
         {
-            get { return this.Data.properties; }
+            get
+            {
+                if (!this.Data.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
+                {
+                    this.Data.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
+                }                
+                return this.Data.properties;
+            }
         }
 
         /// <summary>
@@ -224,6 +232,15 @@
         {
             get { return this.Data.source; }
             set { this.Data.source = value; }
+        }
+
+        /// <summary>
+        /// Gets or sets the MetricExtractorInfo.
+        /// </summary>
+        internal string MetricExtractorInfo
+        {
+            get;
+            set;
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -171,7 +171,8 @@
                 if (!this.Data.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
                 {
                     this.Data.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
-                }                
+                }  
+                
                 return this.Data.properties;
             }
         }

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
@@ -191,29 +191,39 @@
         /// <param name="extractorInfo">The string to be added to the item's properties.</param>
         private static void AddExtractorInfo(ITelemetry item, string extractorInfo)
         {
-            var itemWithProperties = item as ISupportProperties;
-            if (itemWithProperties == null)
+            string extractionPipelineInfo = String.Empty;
+            if (item is RequestTelemetry)
             {
-                return;
-            }
-
-            string extractionPipelineInfo;            
-            bool hasPrevInfo = itemWithProperties.Properties.TryGetValue(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key, out extractionPipelineInfo);
-
-            if (false == hasPrevInfo)
-            {
-                extractionPipelineInfo = String.Empty;
-            }
-            else
-            {
+                var req = item as RequestTelemetry;
+                extractionPipelineInfo = req.MetricExtractorInfo;
                 if (extractionPipelineInfo.Length > 0)
                 {
                     extractionPipelineInfo = extractionPipelineInfo + "; ";
                 }
-            }
+                else
+                {
+                    extractionPipelineInfo = String.Empty;
+                }
 
-            extractionPipelineInfo = extractionPipelineInfo + extractorInfo;
-            itemWithProperties.Properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = extractionPipelineInfo;
+                extractionPipelineInfo = extractionPipelineInfo + extractorInfo;
+                req.MetricExtractorInfo = extractorInfo;
+            }
+            else if (item is DependencyTelemetry)
+            {
+                var dep = item as DependencyTelemetry;
+                extractionPipelineInfo = dep.MetricExtractorInfo;
+                if (extractionPipelineInfo.Length > 0)
+                {
+                    extractionPipelineInfo = extractionPipelineInfo + "; ";
+                }
+                else
+                {
+                    extractionPipelineInfo = String.Empty;
+                }
+
+                extractionPipelineInfo = extractionPipelineInfo + extractorInfo;
+                dep.MetricExtractorInfo = extractorInfo;
+            }                                   
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
@@ -196,7 +196,7 @@
             {
                 var req = item as RequestTelemetry;
                 extractionPipelineInfo = req.MetricExtractorInfo;
-                if (extractionPipelineInfo.Length > 0)
+                if (extractionPipelineInfo?.Length > 0)
                 {
                     extractionPipelineInfo = extractionPipelineInfo + "; ";
                 }
@@ -212,7 +212,7 @@
             {
                 var dep = item as DependencyTelemetry;
                 extractionPipelineInfo = dep.MetricExtractorInfo;
-                if (extractionPipelineInfo.Length > 0)
+                if (extractionPipelineInfo?.Length > 0)
                 {
                     extractionPipelineInfo = extractionPipelineInfo + "; ";
                 }

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
@@ -190,40 +190,31 @@
         /// <param name="item">The telemetry item to be tagged.</param>
         /// <param name="extractorInfo">The string to be added to the item's properties.</param>
         private static void AddExtractorInfo(ITelemetry item, string extractorInfo)
-        {
-            string extractionPipelineInfo = String.Empty;
+        {            
             if (item is RequestTelemetry)
             {
                 var req = item as RequestTelemetry;
-                extractionPipelineInfo = req.MetricExtractorInfo;
-                if (extractionPipelineInfo?.Length > 0)
-                {
-                    extractionPipelineInfo = extractionPipelineInfo + "; ";
-                }
-                else
-                {
-                    extractionPipelineInfo = String.Empty;
-                }
-
-                extractionPipelineInfo = extractionPipelineInfo + extractorInfo;
-                req.MetricExtractorInfo = extractorInfo;
+                req.MetricExtractorInfo = ExtractionPipelineInfo(req.MetricExtractorInfo, extractorInfo);
             }
             else if (item is DependencyTelemetry)
             {
                 var dep = item as DependencyTelemetry;
-                extractionPipelineInfo = dep.MetricExtractorInfo;
-                if (extractionPipelineInfo?.Length > 0)
-                {
-                    extractionPipelineInfo = extractionPipelineInfo + "; ";
-                }
-                else
-                {
-                    extractionPipelineInfo = String.Empty;
-                }
-
-                extractionPipelineInfo = extractionPipelineInfo + extractorInfo;
-                dep.MetricExtractorInfo = extractorInfo;
+                dep.MetricExtractorInfo = ExtractionPipelineInfo(dep.MetricExtractorInfo, extractorInfo);
             }                                   
+        }
+
+        private static string ExtractionPipelineInfo(string extractionPipelineInfo, string extractorInfo)
+        {
+            if (extractionPipelineInfo?.Length > 0)
+            {
+                extractionPipelineInfo = extractionPipelineInfo + "; ";
+            }
+            else
+            {
+                extractionPipelineInfo = String.Empty;
+            }
+            
+            return extractionPipelineInfo + extractorInfo;
         }
 
         /// <summary>


### PR DESCRIPTION
Metric Aggregation metadata is stored into a field instead of properties dictionary, to improve performance.
When someone read the properties, the field value is copied to the properties, so change in behavior.

Since metric aggregator sits before Sampling, this avoids the Properties (ConcurrentDictionary) access until late in the pipeline (serialization). In effect, for items that are dropped after sampling, no Properties access.

Fix #930 

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
