### PR TITLE
Handle securityexception more smoothly

### DIFF
--- a/Test/TestFramework/Shared/StubPlatform.cs
+++ b/Test/TestFramework/Shared/StubPlatform.cs
@@ -2,10 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Security;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     internal class StubPlatform : IPlatform
     {
@@ -25,7 +27,18 @@
 
         public string GetEnvironmentVariable(string name)
         {
-            return Environment.GetEnvironmentVariable(name);
+            try
+            {
+                return Environment.GetEnvironmentVariable(name);
+            }
+            catch (SecurityException e)
+            {
+                // Not being able to get the environment variable is crucial and
+                // cant be dodged without some sort of default values.
+                // Since this is not an option in this context, lets just log and rethrow.
+                CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
+                throw e;
+            }
         }
 
         public string GetMachineName()

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -1,4 +1,7 @@
-﻿#if !NETSTANDARD1_3 // netstandard1.3 has it's own implementation
+﻿using System.Security;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+#if !NETSTANDARD1_3 // netstandard1.3 has it's own implementation
 namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
 {
     using System;
@@ -181,6 +184,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
             catch (SecurityException e)
             {
                 CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
+                throw e;
             }
         }
 
@@ -197,6 +201,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
             catch (SecurityException e)
             {
                 CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
+                throw e;
             }
         }
     }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -174,7 +174,14 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
 
         public string GetEnvironmentVariable(string name)
         {
-            return Environment.GetEnvironmentVariable(name);
+            try
+            {
+                return Environment.GetEnvironmentVariable(name);
+            }
+            catch (SecurityException e)
+            {
+                CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
+            }
         }
 
         /// <summary>
@@ -183,7 +190,14 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
         /// <returns>The machine name.</returns>
         public string GetMachineName()
         {
-            return Environment.GetEnvironmentVariable("COMPUTERNAME");
+            try
+            {
+                return Environment.GetEnvironmentVariable("COMPUTERNAME");
+            }
+            catch (SecurityException e)
+            {
+                CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
+            }
         }
     }
 }

--- a/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -22,12 +22,21 @@
         private readonly IIdentityProvider identityProvider;
 
         public ApplicationFolderProvider(string folderName = null)
-            : this(Environment.GetEnvironmentVariables(), folderName)
+            : this(null, folderName)
         {
         }
 
         internal ApplicationFolderProvider(IDictionary environment, string folderName = null)
         {
+            try
+            {
+                environment = Environment.GetEnvironmentVariables();
+            }
+            catch (SecurityException e)
+            {
+                throw new ArgumentNullException(nameof(environment), e);
+            }
+
             if (environment == null)
             {
                 throw new ArgumentNullException(nameof(environment));


### PR DESCRIPTION
Fix Issue #657 .
This merge request tries to handle access of SecurityExceptions thrown by accessing Environment.GetEnvironmentVariable() a bit more smoothly by adding the exception to logging.

- [ X ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ x] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you. 
