### PR TITLE
Fix the perf issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.8.1
+[Patch release for addressing  perf regression.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/952)
+
 ## Version 2.8.0
 - [New API to store/retrieve any raw objects on TelemetryContext to enable AutoCollectors to pass additional information for use by TelemetryInitializers.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/937)
 - Perf Improvements

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -31,6 +31,18 @@
         }
 
         /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInRequestUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new RequestTelemetry());
+        }
+
+        /// <summary>
         /// Tests tracking trace telemetry.
         /// </summary>
         [TestMethod]
@@ -41,6 +53,19 @@
                 new TraceTelemetry("TestTrace", SeverityLevel.Information),
                 typeof(External.MessageData),
                 (client, item) => { client.TrackTrace((TraceTelemetry)item); });
+        }
+
+
+        /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInTraceUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new TraceTelemetry());
         }
 
         /// <summary>
@@ -54,6 +79,18 @@
                 new EventTelemetry("TestEvent"),
                 typeof(External.EventData),
                 (client, item) => { client.TrackEvent((EventTelemetry)item); });
+        }
+
+        /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInEventUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new EventTelemetry());
         }
 
         /// <summary>
@@ -73,6 +110,18 @@
         }
 
         /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInExceptionUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new ExceptionTelemetry());
+        }
+
+        /// <summary>
         /// Tests tracking metric telemetry.
         /// </summary>
         [TestMethod]
@@ -86,16 +135,41 @@
         }
 
         /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInMetricUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new MetricTelemetry());
+        }
+
+        /// <summary>
         /// Tests tracking dependency telemetry.
         /// </summary>
         [TestMethod]
         public void RichPayloadEventSourceDependencySentTest()
         {
+            
             this.DoTracking(
                 RichPayloadEventSource.Keywords.Dependencies,
                 new DependencyTelemetry("Custom", "Target", "TestDependency", "TestCommand", DateTimeOffset.Now, TimeSpan.Zero, "200", true),
                 typeof(External.RemoteDependencyData),
                 (client, item) => { client.TrackDependency((DependencyTelemetry)item); });
+        }
+
+        /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInDependencyUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new DependencyTelemetry());
         }
 
         /// <summary>
@@ -109,6 +183,18 @@
                 new PageViewTelemetry("TestPage"),
                 typeof(External.PageViewData),
                 (client, item) => { client.TrackPageView((PageViewTelemetry)item); });
+        }
+
+        /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInPageviewUnlessEnabled()
+        {
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new PageViewTelemetry());
         }
 
         /// <summary>
@@ -127,6 +213,20 @@
         }
 
         /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInSessionStateUnlessEnabled()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new SessionStateTelemetry());
+#pragma warning restore CS0618 // Type or member is obsolete
+        }
+
+        /// <summary>
         /// Tests tracking session state telemetry.
         /// </summary>
         [TestMethod]
@@ -139,6 +239,20 @@
                 typeof(External.MetricData),
                 (client, item) => { client.Track((PerformanceCounterTelemetry)item); });
 #pragma warning restore 618
+        }
+
+        /// <summary>
+        /// RichPayloadEventSource does not copy GlobalProperties unless it is enabled.
+        /// </summary>
+        [TestMethod]
+        [Ignore("Fails when run in parallel with other tests which enables RichPayloadEventSource for testing." +
+                "Even though the listener is disposed by tests, the EventSource itself is not disposed, and IsEnabled is" +
+                "only an approximation as per MSDN. Will disable this until we find a better way to test this. ")]
+        public void A_RichPayloadEventSourceDoesNotCopyGlobalPropertiesInPerformanceCounterUnlessEnabled()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(new PerformanceCounterTelemetry());
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>
@@ -284,6 +398,10 @@
 
                     track(client, item);
 
+#pragma warning disable CS0618 // Type or member is obsolete
+                    Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
+#pragma warning restore CS0618 // Type or member is obsolete
+
                     var actualEvent = listener.Messages.FirstOrDefault();
 
                     Assert.IsNotNull(actualEvent);
@@ -345,6 +463,34 @@
             {
                 // 4.5 doesn't have RichPayload events
                 Assert.IsNull(RichPayloadEventSource.Log.EventSourceInternal);
+            }
+        }
+
+        private void ValidateGlobalTelemetryIsNotCopiedIfNotEnabled(ITelemetry item)
+        {
+            if (IsRunningOnEnvironmentSupportingRichPayloadEventSource())
+            {
+                var client = new TelemetryClient();
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                item.Context.Properties.Add("property1", "value1");
+#pragma warning restore CS0618 // Type or member is obsolete
+                (item as ISupportProperties)?.Properties.Add("itemprop1", "itemvalue1");
+                item.Context.GlobalProperties.Add("globalproperty1", "globalvalue1");
+                
+                client.Track(item);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+                Assert.IsFalse(item.Context.Properties.ContainsKey("globalproperty1"),
+                    "Item Properties should not contain the globalproperties as its copied before serialization which is done only if RichPayloadEventSource is enabled.");
+                Assert.IsTrue(item.Context.Properties.ContainsKey("property1"),
+                    "Item Properties should contain the values set.");
+                if (item is ISupportProperties)
+                {
+                    Assert.IsTrue(item.Context.Properties.ContainsKey("itemprop1"),
+                        "Item Properties should contain the values set via ISupportProperties.");
+                }
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -22,6 +22,16 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         private readonly long dummyPartAFlagsValue = 0;
         private readonly IDictionary<string, string> dummyPartATagsValue = new Dictionary<string, string>();
 
+        private static void CopyGlobalPropertiesIfRequired(ITelemetry telemetry, IDictionary<string, string> itemProperties)
+        {
+            // This check avoids accessing the public accessor GlobalProperties
+            // unless needed, to avoid the penality of ConcurrentDictionary instantiation.
+            if (telemetry.Context.GlobalPropertiesValue != null)
+            {
+                Utils.CopyDictionary(telemetry.Context.GlobalProperties, itemProperties);
+            }
+        }
+
         /// <summary>
         /// Create handlers for all AI telemetry types.
         /// </summary>
@@ -225,6 +235,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as RequestTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -283,6 +294,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as TraceTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -335,6 +347,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as EventTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -393,6 +406,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as DependencyTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.InternalData;
                     var extendedData = new
                     {
@@ -465,6 +479,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as MetricTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -553,6 +568,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as ExceptionTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data.Data;
                     var extendedData = new
                     {
@@ -637,6 +653,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     item.Sanitize();
 #pragma warning disable 618
                     var telemetryItem = (item as PerformanceCounterTelemetry).Data;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
 #pragma warning restore 618
                     var data = telemetryItem.Data;
                     var extendedData = new
@@ -701,6 +718,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as PageViewTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -761,6 +779,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     item.Sanitize();
                     var telemetryItem = item as PageViewTelemetry;
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -815,6 +834,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 #pragma warning disable 618
                     var telemetryItem = (item as SessionStateTelemetry).Data;
 #pragma warning restore 618
+                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -232,10 +232,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as RequestTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -291,10 +291,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as TraceTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -344,10 +344,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as EventTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -403,10 +403,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as DependencyTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.InternalData;
                     var extendedData = new
                     {
@@ -476,10 +476,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                  
                     var telemetryItem = item as MetricTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -565,10 +565,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as ExceptionTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data.Data;
                     var extendedData = new
                     {
@@ -649,12 +649,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
 #pragma warning disable 618
                     var telemetryItem = (item as PerformanceCounterTelemetry).Data;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
 #pragma warning restore 618
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -715,10 +715,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as PageViewTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -776,10 +776,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
                     var telemetryItem = item as PageViewTelemetry;
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {
@@ -829,12 +829,12 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             return (item) =>
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
-                {
-                    item.Sanitize();
+                {                    
 #pragma warning disable 618
                     var telemetryItem = (item as SessionStateTelemetry).Data;
 #pragma warning restore 618
                     CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -46,10 +46,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = item as RequestTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     RequestTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -65,9 +65,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     return;
                 }
 
-                item.Sanitize();
                 var telemetryItem = item as TraceTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     TraceTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -83,9 +83,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     return;
                 }
 
-                item.Sanitize();
                 var telemetryItem = item as EventTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -101,9 +101,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     return;
                 }
 
-                item.Sanitize();
                 var telemetryItem = item as DependencyTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     DependencyTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -118,10 +118,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = item as MetricTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -136,10 +136,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = item as ExceptionTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     ExceptionTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -155,10 +155,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = (item as PerformanceCounterTelemetry).Data;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -174,10 +174,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = item as PageViewTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     PageViewTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -192,10 +192,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = item as PageViewPerformanceTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     PageViewPerformanceTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -211,10 +211,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = (item as SessionStateTelemetry).Data;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -229,10 +229,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 {
                     return;
                 }
-
-                item.Sanitize();
+                
                 var telemetryItem = item as AvailabilityTelemetry;
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                item.Sanitize();
                 this.WriteEvent(
                     AvailabilityTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -40,17 +40,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         /// <param name="item">A collected Telemetry item.</param>
         public void Process(ITelemetry item)
         {
-            var telemetryProps = item as ISupportProperties;
-            if (telemetryProps != null)
-            {
-                // This check avoids accessing the public accessor GlobalProperties
-                // unless needed, to avoid the penality of ConcurrentDictionary instantiation.
-                if (item.Context.GlobalPropertiesValue != null)
-                {
-                    Utils.CopyDictionary(item.Context.GlobalProperties, telemetryProps.Properties);
-                }
-            }
-
             if (item is RequestTelemetry)
             {
                 if (!this.EventSourceInternal.IsEnabled(EventLevel.Verbose, Keywords.Requests))
@@ -60,6 +49,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as RequestTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     RequestTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -77,6 +67,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as TraceTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     TraceTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -94,6 +85,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as EventTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -111,6 +103,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as DependencyTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     DependencyTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -128,6 +121,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as MetricTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -145,6 +139,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as ExceptionTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     ExceptionTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -163,6 +158,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = (item as PerformanceCounterTelemetry).Data;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     MetricTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -181,6 +177,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as PageViewTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     PageViewTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -198,6 +195,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as PageViewPerformanceTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     PageViewPerformanceTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -216,6 +214,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = (item as SessionStateTelemetry).Data;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     EventTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -233,6 +232,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
                 item.Sanitize();
                 var telemetryItem = item as AvailabilityTelemetry;
+                CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 this.WriteEvent(
                     AvailabilityTelemetry.TelemetryName,
                     telemetryItem.Context.InstrumentationKey,
@@ -279,6 +279,16 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
+        }
+
+        private static void CopyGlobalPropertiesIfRequired(ITelemetry telemetry, IDictionary<string, string> itemProperties)
+        {
+            // This check avoids accessing the public accessor GlobalProperties
+            // unless needed, to avoid the penality of ConcurrentDictionary instantiation.
+            if (telemetry.Context.GlobalPropertiesValue != null)
+            {
+                Utils.CopyDictionary(telemetry.Context.GlobalProperties, itemProperties);
+            }
         }
 
         /// <summary>
@@ -405,17 +415,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 CoreEventSource.Log.LogVerbose(msg);
 
                 return;
-            }
-
-            var telemetryProps = item as ISupportProperties;
-            if (telemetryProps != null)
-            {
-                // This check avoids accessing the public accessor GlobalProperties
-                // unless needed, to avoid the penality of ConcurrentDictionary instantiation.
-                if (item.Context.GlobalPropertiesValue != null)
-                {
-                    Utils.CopyDictionary(item.Context.GlobalProperties, telemetryProps.Properties);
-                }
             }
 
             handler(item);


### PR DESCRIPTION
TelemetryContext.GlobalProperties was copied to TelemetryContext.Properties in RichPayloadEventSource.Process
without checking if RichPayloadEventSource is enabled or not

Fix Issue #952  .
<Short description of the fix.>

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
