### PR TITLE
Track non-unique error when operation id do not match Activity id

### DIFF
--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationHolder.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationHolder.cs
@@ -80,12 +80,17 @@
                             var currentActivity = Activity.Current;
                             if (currentActivity == null || operationTelemetry.Id != currentActivity.Id)
                             {
-                                CoreEventSource.Log.InvalidOperationToStopError(
+                                // this is for internal error reporting
+                                CoreEventSource.Log.InvalidOperationToStopError();
+
+                                // this are details with unique ids for debugging
+                                CoreEventSource.Log.InvalidOperationToStopDetails(
                                     string.Format(
                                         CultureInfo.InvariantCulture,
-                                        "Telemetry Id '{0}' does not match current Activity '{1}'", 
+                                        "Telemetry Id '{0}' does not match current Activity '{1}'",
                                         operationTelemetry.Id,
                                         currentActivity?.Id));
+
                                 return;
                             }
 
@@ -99,10 +104,14 @@
                             var currentOperationContext = CallContextHelpers.GetCurrentOperationContext();
                             if (currentOperationContext == null || operationTelemetry.Id != currentOperationContext.ParentOperationId)
                             {
-                                CoreEventSource.Log.InvalidOperationToStopError(
+                                // this is for internal error reporting
+                                CoreEventSource.Log.InvalidOperationToStopError();
+
+                                // this are details with unique ids for debugging
+                                CoreEventSource.Log.InvalidOperationToStopDetails(
                                     string.Format(
                                         CultureInfo.InvariantCulture,
-                                        "Telemetry Id '{0}' does not match current context '{1}'",
+                                        "Telemetry Id '{0}' does not match current Activity '{1}'",
                                         operationTelemetry.Id,
                                         currentOperationContext?.ParentOperationId));
                                 return;

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -32,10 +32,10 @@
         /// <summary>
         /// Logs the information when there operation to stop does not match the current operation.
         /// </summary>
-        [Event(2, Message = "Operation to stop does not match the current operation. Details: {0}", Level = EventLevel.Error)]
-        public void InvalidOperationToStopError(string details, string appDomainName = "Incorrect")
+        [Event(2, Message = "Operation to stop does not match the current operation. Telemetry is not tracked.", Level = EventLevel.Error)]
+        public void InvalidOperationToStopError(string appDomainName = "Incorrect")
         {
-            this.WriteEvent(2, details, this.nameProvider.Name);
+            this.WriteEvent(2, this.nameProvider.Name);
         }
 
         [Event(
@@ -523,6 +523,16 @@
         {
             this.WriteEvent(43, this.nameProvider.Name);
         }
+
+        /// <summary>
+        /// Logs the detais when there operation to stop does not match the current operation.
+        /// </summary>
+        [Event(44, Message = "Operation to stop does not match the current operation. Details {0}.", Level = EventLevel.Warning)]
+        public void InvalidOperationToStopDetails(string details, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(44, details, this.nameProvider.Name);
+        }
+
 
         /// <summary>
         /// Keywords for the PlatformEventSource.

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -533,7 +533,6 @@
             this.WriteEvent(44, details, this.nameProvider.Name);
         }
 
-
         /// <summary>
         /// Keywords for the PlatformEventSource.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
@@ -89,7 +89,7 @@
             // after StartOperation call and before operation is stopped.
             // Before removing this call (for optimization), make sure:
             // 1) correlation ids are set before method leaves
-            // 2) RichPayloadEventSource is refactored to work without ikey in Start event (or ikey is set)
+            // 2) RichPayloadEventSource is re-factored to work without ikey in Start event (or ikey is set)
             //    and does not require other properties in telemetry
             telemetryClient.Initialize(operationTelemetry);
 
@@ -196,8 +196,8 @@
         /// 
         ///   // Extract tracing context from the message before processing it
         ///   // Note that some protocols may define how Activity should be serialized into the message,
-        ///   // and some client SDKs implemeting them may provide Extract method.
-        ///   // For other protocols/libraries, serialization has to be agreed between procuder and consumer
+        ///   // and some client SDKs implementing them may provide Extract method.
+        ///   // For other protocols/libraries, serialization has to be agreed between producer and consumer
         ///   // and Inject/Extract pattern to be implemented
         ///   var activity = message.ExtractActivity();
         /// 
@@ -212,7 +212,7 @@
         /// <remarks><para>Activity represents tracing context; it contains correlation identifiers and extended properties that are propagated to external calls.
         /// See <a href="https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/ActivityUserGuide.md"/> for more details.</para>
         /// <para>When Activity instance is passed to StartOperation, it is expected that Activity has ParentId (if it was provided by upstream service), but has not been started yet.
-        /// It may also have additional Tags and Baggage to augument telemetry.</para>
+        /// It may also have additional Tags and Baggage to augment telemetry.</para>
         /// </remarks>
         /// <typeparam name="T">Type of the telemetry item.</typeparam>
         /// <param name="telemetryClient">Telemetry client object.</param>
@@ -240,7 +240,7 @@
             // after StartOperation call and before operation is stopped.
             // Before removing this call (for optimization), make sure:
             // 1) correlation ids are set before method leaves
-            // 2) RichPayloadEventSource is refactored to work without ikey in Start event (or ikey is set)
+            // 2) RichPayloadEventSource is re-factored to work without ikey in Start event (or ikey is set)
             //    and does not require other properties in telemetry
             telemetryClient.Initialize(operationTelemetry);
 


### PR DESCRIPTION
We see messages like 
```
Operation to stop does not match the current operation. Details: Telemetry Id '|a9795xxxxxxxxxxxxxx5.efa5555b_1.1.1.1.1.5.1.1.1.1.3.1.1.3.1.1.3.1.' does not match current Activity '|a9795xxxxxxxxxxxxxx5.efa5555b_1.1.1.1.1.5.1.1.1.1.3.1.1.3.1.1.3.1.1.
```

which are unique and does not allow us to understand the impact of the issue.

This change makes the message unique and also writes a detailed message with Warning for debugging.