### PR TITLE
Send event source name with internal AI errors

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/PortalDiagnosticsSenderTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/PortalDiagnosticsSenderTest.cs
@@ -44,6 +44,7 @@
             {
                 MetaData = new EventMetaData
                 {
+                    EventSourceName = "TelemetryCorrelation",
                     EventId = 10,
                     Keywords = 0x20,
                     Level = EventLevel.Warning,
@@ -58,7 +59,7 @@
             var trace = this.sendItems[0] as TraceTelemetry;
             Assert.IsNotNull(trace);
             Assert.AreEqual(
-                "AI (Internal): Error occurred at My function, some failure", 
+                "AI (Internal): [TelemetryCorrelation] Error occurred at My function, some failure", 
                 trace.Message);
         }
 
@@ -109,7 +110,7 @@
             var trace = this.sendItems[0] as TraceTelemetry;
             Assert.IsNotNull(trace);
             Assert.AreEqual(
-                "AI (Internal): Something failed",
+                "AI (Internal): [] Something failed",
                 trace.Message);
             Assert.AreEqual(0, trace.Properties.Count);
         }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
@@ -25,6 +25,7 @@
 
             var metadata = new EventMetaData
             {                
+                EventSourceName = eventSourceEvent.EventSource?.Name,
                 Keywords = (long)eventSourceEvent.Keywords,
                 MessageFormat = eventSourceEvent.Message,
                 EventId = eventSourceEvent.EventId,
@@ -34,7 +35,7 @@
             var traceEvent = new TraceEvent
             {
                 MetaData = metadata,
-                Payload = eventSourceEvent.Payload != null ? eventSourceEvent.Payload.ToArray() : null
+                Payload = eventSourceEvent.Payload?.ToArray()
             };
 
             this.listener.WriteEvent(traceEvent);

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/EventMetaData.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/EventMetaData.cs
@@ -7,6 +7,8 @@
     /// </summary>
     internal class EventMetaData
     {
+        public string EventSourceName { get; set; }
+
         public int EventId { get; set; }
 
         public string MessageFormat { get; set; }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/PortalDiagnosticsSender.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/PortalDiagnosticsSender.cs
@@ -58,7 +58,7 @@
             {
                 if (eventData.MetaData != null && !string.IsNullOrEmpty(eventData.MetaData.MessageFormat))
                 {
-                    // Check if trace message is sended to the portal (somewhere before in the stack)
+                    // Check if trace message is sent to the portal (somewhere before in the stack)
                     // It allows to avoid infinite recursion if sending to the portal traces something.
                     if (!ThreadResourceLock.IsResourceLocked)
                     {
@@ -108,7 +108,8 @@
             }
             else
             {
-                message = AiNonUserActionable + message;
+                string eventSourceName = '[' + eventData.MetaData.EventSourceName + "] ";
+                message = AiNonUserActionable + eventSourceName + message;
             }
 
             traceTelemetry.Message = message;


### PR DESCRIPTION
It's useful to know which event source sent an error.