### PR TITLE
Add new method on telemetryclient to initialize ikey.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 ## Version 2.9.0-beta1
 - [Remove unused reference to System.Web.Extesions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
+- [Added new method on TelemetryClient to initialize just instrumntation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
 
 ## Version 2.8.1
 [Patch release addressing perf regression.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/952)

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.ApplicationInsights.TelemetryClient.InitializeInstrumentationKey(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.ApplicationInsights.TelemetryClient.InitializeInstrumentationKey(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -1,0 +1,1 @@
+Microsoft.ApplicationInsights.TelemetryClient.InitializeInstrumentationKey(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry) -> void

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryContextTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TelemetryContextTest.cs
@@ -116,6 +116,17 @@
         }
 
         [TestMethod]
+        public void InitializeInstrumentationKeySetsTelemetryInstrumentationKey()
+        {
+            var sourceInstrumentationKey = "TestValue";
+            var target = new TelemetryContext();
+
+            target.InitializeInstrumentationkey(sourceInstrumentationKey);
+
+            Assert.AreEqual("TestValue", target.InstrumentationKey);
+        }
+
+        [TestMethod]
         public void InitializeSetsTelemetryInstrumentationKeyFromArgument()
         {
             var source = new TelemetryContext { InstrumentationKey = "TestValue" };
@@ -133,6 +144,17 @@
             var target = new TelemetryContext { InstrumentationKey = "TargetValue" };
 
             target.Initialize(source, source.InstrumentationKey);
+
+            Assert.AreEqual("TargetValue", target.InstrumentationKey);
+        }
+
+        [TestMethod]
+        public void InitializeInstrumentationKeyDoesNotOverrideTelemetryInstrumentationKey()
+        {
+            var sourceInstrumentationKey = "SourceValue";
+            var target = new TelemetryContext { InstrumentationKey = "TargetValue" };
+
+            target.InitializeInstrumentationkey(sourceInstrumentationKey);
 
             Assert.AreEqual("TargetValue", target.InstrumentationKey);
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -154,6 +154,65 @@
 
         #endregion
 
+        #region InitializeIKey
+
+        [TestMethod]
+        public void InitializeIKeySetsIkeyFromContext()
+        {
+            EventTelemetry telemetry = new EventTelemetry("TestEvent");
+
+            var tc = new TelemetryClient();
+            // Set ikey on Context
+            tc.InstrumentationKey = "mykey";
+            tc.InitializeInstrumentationKey(telemetry);
+
+            Assert.AreEqual("mykey",telemetry.Context.InstrumentationKey);
+        }
+
+        [TestMethod]
+        public void InitializeIKeySetsIkeyFromCofig()
+        {
+            EventTelemetry telemetry = new EventTelemetry("TestEvent");
+
+            // Set ikey on config
+            var config = new TelemetryConfiguration("mykey");
+            var tc = new TelemetryClient(config);
+            tc.InitializeInstrumentationKey(telemetry);
+
+            Assert.AreEqual("mykey", telemetry.Context.InstrumentationKey);
+        }
+
+        [TestMethod]
+        public void InitializeIKeySetsIkeyFromContextOverConfig()
+        {
+            EventTelemetry telemetry = new EventTelemetry("TestEvent");
+
+            // Set ikey on config
+            var config = new TelemetryConfiguration("mykeyonconfig");
+            var tc = new TelemetryClient(config);
+            // Set ikey on Context as well.
+            tc.InstrumentationKey = "mykeyoncontext";
+            tc.InitializeInstrumentationKey(telemetry);
+
+            // ikey on Context takes priority.
+            Assert.AreEqual("mykeyoncontext", telemetry.Context.InstrumentationKey);
+        }
+
+        [TestMethod]
+        public void InitializeIKeyDoesNotOverrideIKey()
+        {
+            EventTelemetry telemetry = new EventTelemetry("TestEvent");
+            telemetry.Context.InstrumentationKey = "expectedIKey";
+
+            var tc = new TelemetryClient();
+            tc.InstrumentationKey = "mykey";
+            tc.InitializeInstrumentationKey(telemetry);
+
+            Assert.AreEqual("expectedIKey", telemetry.Context.InstrumentationKey);
+        }
+
+        #endregion
+
         #region TrackMetric
 
         [TestMethod]

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -268,7 +268,7 @@
         /// </summary>
         internal void Initialize(TelemetryContext source, string instrumentationKey)
         {
-            InitializeInstrumentationkey(instrumentationKey);
+            this.InitializeInstrumentationkey(instrumentationKey);
 
             this.Flags |= source.Flags;
 

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -194,7 +194,7 @@
             }
 
             if (this.rawObjectsTemp.TryGetValue(key, out rawObject))
-            {                
+            {
                 return true;
             }
             else
@@ -243,7 +243,7 @@
 
         internal void ClearTempRawObjects()
         {
-          this.rawObjectsTemp.Clear();
+            this.rawObjectsTemp.Clear();
         }
 
         internal TelemetryContext DeepClone(IDictionary<string, string> properties)
@@ -268,7 +268,7 @@
         /// </summary>
         internal void Initialize(TelemetryContext source, string instrumentationKey)
         {
-            Property.Initialize(ref this.instrumentationKey, instrumentationKey);
+            InitializeInstrumentationkey(instrumentationKey);
 
             this.Flags |= source.Flags;
 
@@ -280,6 +280,14 @@
             source.operation?.CopyTo(this.Operation);
             source.location?.CopyTo(this.Location);
             source.Internal.CopyTo(this.Internal);
+        }
+
+        /// <summary>
+        /// Initialize this instance's instrumentation key.
+        /// </summary>
+        internal void InitializeInstrumentationkey(string instrumentationKey)
+        {
+            Property.Initialize(ref this.instrumentationKey, instrumentationKey);
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -451,6 +451,23 @@
         /// <summary>
         /// This method is an internal part of Application Insights infrastructure. Do not call.
         /// </summary>
+        /// <param name="telemetry">Telemetry item to initialize instrumentation key.</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void InitializeInstrumentationKey(ITelemetry telemetry)
+        {
+            string instrumentationKey = this.Context.InstrumentationKey;
+
+            if (string.IsNullOrEmpty(instrumentationKey))
+            {
+                instrumentationKey = this.configuration.InstrumentationKey;
+            }
+
+            telemetry.Context.InitializeInstrumentationkey(instrumentationKey);
+        }
+
+        /// <summary>
+        /// This method is an internal part of Application Insights infrastructure. Do not call.
+        /// </summary>
         /// <param name="telemetry">Telemetry item to initialize.</param>
         [EditorBrowsable(EditorBrowsableState.Never)]
         public void Initialize(ITelemetry telemetry)


### PR DESCRIPTION
…trumentation key only.

Fix Issue #966 

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
