### PR TITLE
Perf Improvements - RequestTelemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,10 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 ## Version 2.9.0-beta1
 - [Remove unused reference to System.Web.Extesions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
-- [Added new method on TelemetryClient to initialize just instrumntation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
+Perf Improvements
+- [Added new method on TelemetryClient to initialize just instrumentation key. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
+- [RequestTelemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/969)
+- [RequestTelemetry modified to not service public fields with data class to avoid converting between types.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/965)
 
 ## Version 2.8.1
 [Patch release addressing perf regression.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/952)

--- a/Schema/generateSchema.ps1
+++ b/Schema/generateSchema.ps1
@@ -117,6 +117,9 @@ dir "$currentDir\obj\gbc" | ForEach-Object {
 	RegExReplace $_.FullName "measurements = new ConcurrentDictionary<string, double>\(\);"
 }
 
+	# Remove "properties" field declaration as its is done lazy in a separate partial class
+    RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "public IDictionary<string, string> properties { get; set; }"
+	RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "properties = new ConcurrentDictionary<string, string>\(\);"
 
 #################################################################################################
 ## Use TimeSpan instead of String for duration to improve performance by avoiding conversions.

--- a/Schema/generateSchema.ps1
+++ b/Schema/generateSchema.ps1
@@ -117,8 +117,7 @@ dir "$currentDir\obj\gbc" | ForEach-Object {
 	RegExReplace $_.FullName "measurements = new ConcurrentDictionary<string, double>\(\);"
 }
 
-	# Remove "properties" field declaration as its is done lazy in a separate partial class
-    
+	# Remove "properties" instantiation as its is done lazy in the public RequestTelemetry class.
 	RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "properties = new ConcurrentDictionary<string, string>\(\);"
 
 #################################################################################################

--- a/Schema/generateSchema.ps1
+++ b/Schema/generateSchema.ps1
@@ -118,7 +118,7 @@ dir "$currentDir\obj\gbc" | ForEach-Object {
 }
 
 	# Remove "properties" field declaration as its is done lazy in a separate partial class
-    RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "public IDictionary<string, string> properties { get; set; }"
+    
 	RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "properties = new ConcurrentDictionary<string, string>\(\);"
 
 #################################################################################################

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -427,7 +427,7 @@
                     track(client, item);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                     Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
+                    Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     var actualEvent = listener.Messages.FirstOrDefault();

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -427,7 +427,7 @@
                     track(client, item);
 
 #pragma warning disable CS0618 // Type or member is obsolete
-                    Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
+                     Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
 #pragma warning restore CS0618 // Type or member is obsolete
 
                     var actualEvent = listener.Messages.FirstOrDefault();

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -31,7 +31,7 @@
         private IExtension extension;
         private double? samplingPercentage;
         private bool? success;
-        private IDictionary<string, double> measurements;
+        private IDictionary<string, double> measurementsValue;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTelemetry"/> class.
@@ -64,10 +64,13 @@
         {
             this.Duration = source.Duration;
             this.Id = source.Id;
-            Utils.CopyDictionary(source.Metrics, this.Metrics);
+            if (source.measurementsValue != null)
+            {
+                Utils.CopyDictionary(source.Metrics, this.Metrics);
+            }
+
             this.Name = source.Name;
-            this.context = source.context.DeepClone(null);
-            Utils.CopyDictionary(source.Properties, this.Properties);
+            this.context = source.context.DeepClone();
             this.ResponseCode = source.ResponseCode;
             this.Source = source.Source;
             this.Success = source.Success;
@@ -201,7 +204,7 @@
         /// </summary>
         public override IDictionary<string, double> Metrics
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.measurements, () => new ConcurrentDictionary<string, double>()); }
+            get { return LazyInitializer.EnsureInitialized(ref this.measurementsValue, () => new ConcurrentDictionary<string, double>()); }
         }
 
         /// <summary>
@@ -251,9 +254,9 @@
                              var req = new RequestData();
                              req.duration = this.Duration;
                              req.id = this.Id;
-                             req.measurements = this.Metrics;
+                             req.measurements = this.measurementsValue;
                              req.name = this.Name;
-                             req.properties = this.Properties;
+                             req.properties = this.context.PropertiesValue;
                              req.responseCode = this.ResponseCode;
                              req.source = this.Source;
                              if (this.Success != null && this.Success.HasValue)

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -1,8 +1,10 @@
 ﻿namespace Microsoft.ApplicationInsights.DataContracts
 {
     using System;
+    using System.Collections.Concurrent;
     using System.Collections.Generic;
     using System.Globalization;
+    using System.Threading;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -23,19 +25,20 @@
         internal new const string TelemetryName = "Request";
 
         internal readonly string BaseType = typeof(RequestData).Name;
-        internal readonly RequestData Data;
+        internal RequestData DataInternal;
         private readonly TelemetryContext context;
         private bool successFieldSet;
         private IExtension extension;
         private double? samplingPercentage;
+        private bool? success;
+        private IDictionary<string, double> measurements;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTelemetry"/> class.
         /// </summary>
         public RequestTelemetry()
         {
-            this.Data = new RequestData();
-            this.context = new TelemetryContext(this.Data.properties);
+            this.context = new TelemetryContext();
             this.GenerateId();
         }
 
@@ -59,8 +62,18 @@
         /// <param name="source">Source instance of <see cref="RequestTelemetry"/> to clone from.</param>
         private RequestTelemetry(RequestTelemetry source)
         {
-            this.Data = source.Data.DeepClone();
-            this.context = source.context.DeepClone(this.Data.properties);
+            this.Duration = source.Duration;
+            this.Id = source.Id;
+            Utils.CopyDictionary(source.Metrics, this.Metrics);
+            this.Name = source.Name;
+            this.context = source.context.DeepClone(null);
+            Utils.CopyDictionary(source.Properties, this.Properties);
+            this.ResponseCode = source.ResponseCode;
+            this.Source = source.Source;
+            this.Success = source.Success;
+            this.Url = source.Url;
+
+            
             this.Sequence = source.Sequence;
             this.Timestamp = source.Timestamp;
             this.successFieldSet = source.successFieldSet;
@@ -99,8 +112,8 @@
         /// </summary>
         public override string Id
         {
-            get { return this.Data.id; }
-            set { this.Data.id = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -108,8 +121,8 @@
         /// </summary>
         public override string Name
         {
-            get { return this.Data.name; }
-            set { this.Data.name = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -117,8 +130,8 @@
         /// </summary>
         public string ResponseCode
         {
-            get { return this.Data.responseCode; }
-            set { this.Data.responseCode = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -130,7 +143,7 @@
             {
                 if (this.successFieldSet)
                 {
-                    return this.Data.success;
+                    return this.success;
                 }
 
                 return null;
@@ -140,12 +153,12 @@
             {
                 if (value != null && value.HasValue)
                 {
-                    this.Data.success = value.Value;
+                    this.success = value.Value;
                     this.successFieldSet = true;
                 }
                 else
                 {
-                    this.Data.success = true;
+                    this.success = true;
                     this.successFieldSet = false;
                 }
             }
@@ -156,8 +169,8 @@
         /// </summary>
         public override TimeSpan Duration
         {
-            get { return this.Data.duration; }
-            set { this.Data.duration = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -166,37 +179,23 @@
         /// </summary>
         public override IDictionary<string, string> Properties
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             get
             {
-                if (!string.IsNullOrEmpty(this.MetricExtractorInfo) && !this.Data.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
+                if (!string.IsNullOrEmpty(this.MetricExtractorInfo) && !this.Context.Properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
                 {
-                    this.Data.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
-                }  
-                
-                return this.Data.properties;
+                    this.Context.Properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
+                }
+
+                return this.Context.Properties;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
         /// <summary>
         /// Gets or sets request url (optional).
         /// </summary>
-        public Uri Url
-        {
-            get
-            {
-                if (this.Data.url.IsNullOrWhiteSpace())
-                {
-                    return null;
-                }
-
-                return new Uri(this.Data.url, UriKind.RelativeOrAbsolute);
-            }
-
-            set
-            {
-                this.Data.url = value?.ToString();
-            }
-        }
+        public Uri Url { get; set; }
 
         /// <summary>
         /// Gets a dictionary of application-defined request metrics.
@@ -204,7 +203,7 @@
         /// </summary>
         public override IDictionary<string, double> Metrics
         {
-            get { return this.Data.measurements; }
+            get { return LazyInitializer.EnsureInitialized(ref this.measurements, () => new ConcurrentDictionary<string, double>()); }
         }
 
         /// <summary>
@@ -231,8 +230,8 @@
         /// </summary>
         public string Source
         {
-            get { return this.Data.source; }
-            set { this.Data.source = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -242,6 +241,37 @@
         {
             get;
             set;
+        }
+
+        internal RequestData Data
+        {
+            get
+            {
+                return LazyInitializer.EnsureInitialized(ref this.DataInternal,
+                     () =>
+                         {
+                             var req = new RequestData();
+                             req.duration = this.Duration;
+                             req.id = this.Id;
+                             req.measurements = this.Metrics;
+                             req.name = this.Name;
+                             req.properties = this.Properties;
+                             req.responseCode = this.ResponseCode;
+                             req.source = this.Source;
+                             if (this.Success != null && this.Success.HasValue)
+                             {
+                                 req.success = this.Success.Value;
+                             }
+
+                             req.url = this.Url?.ToString();
+                             return req;
+                         });
+            }
+
+            private set
+            {
+                 this.DataInternal = value;
+            }
         }
 
         /// <summary>
@@ -270,8 +300,8 @@
             this.Url = this.Url.SanitizeUri();
 
             // Set for backward compatibility:
-            this.Data.id = this.Data.id.SanitizeName();
-            this.Data.id = Utils.PopulateRequiredStringValue(this.Data.id, "id", typeof(RequestTelemetry).FullName);
+            this.Id = this.Id.SanitizeName();
+            this.Id = Utils.PopulateRequiredStringValue(this.Id, "id", typeof(RequestTelemetry).FullName);
 
             // Required fields
             if (!this.Success.HasValue)

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -72,8 +72,6 @@
             this.Source = source.Source;
             this.Success = source.Success;
             this.Url = source.Url;
-
-            
             this.Sequence = source.Sequence;
             this.Timestamp = source.Timestamp;
             this.successFieldSet = source.successFieldSet;

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -244,6 +244,13 @@
             set;
         }
 
+        /// <summary>
+        /// Gets the Data associated with this Telemetry instance.
+        /// This is being served by a singleton instance, so this will
+        /// not pickup changes made to the telemetry after first call to this.
+        /// It is recommended to make all changes (including sanitization)
+        /// to this telemetry before calling Data.
+        /// </summary>
         internal RequestData Data
         {
             get
@@ -286,7 +293,10 @@
 
         /// <inheritdoc/>
         public override void SerializeData(ISerializationWriter serializationWriter)
-        {            
+        {
+            // To ensure that all changes to telemetry are reflected in serialization,
+            // the underlying field is set to null, which forces it to be re-created.
+            this.dataPrivate = null;
             serializationWriter.WriteProperty(this.Data);                        
         }
 

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -25,8 +25,8 @@
         internal new const string TelemetryName = "Request";
 
         internal readonly string BaseType = typeof(RequestData).Name;
-        internal RequestData DataInternal;
         private readonly TelemetryContext context;
+        private RequestData dataPrivate;
         private bool successFieldSet;
         private IExtension extension;
         private double? samplingPercentage;
@@ -245,7 +245,7 @@
         {
             get
             {
-                return LazyInitializer.EnsureInitialized(ref this.DataInternal,
+                return LazyInitializer.EnsureInitialized(ref this.dataPrivate,
                      () =>
                          {
                              var req = new RequestData();
@@ -268,7 +268,7 @@
 
             private set
             {
-                 this.DataInternal = value;
+                 this.dataPrivate = value;
             }
         }
 

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -256,8 +256,20 @@
                 Utils.CopyDictionary(this.GlobalProperties, other.GlobalProperties);
             }
 
+            if (this.PropertiesValue != null)
+            {
+#pragma warning disable CS0618 // Type or member is obsolete
+                Utils.CopyDictionary(this.Properties, other.Properties);
+#pragma warning restore CS0618 // Type or member is obsolete
+            }
+
             other.InstrumentationKey = this.InstrumentationKey;
             return other;
+        }
+
+        internal TelemetryContext DeepClone()
+        {
+            return this.DeepClone(null);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TelemetryContext.cs
@@ -248,7 +248,6 @@
 
         internal TelemetryContext DeepClone(IDictionary<string, string> properties)
         {
-            Debug.Assert(properties != null, "properties parameter should not be null");
             var other = new TelemetryContext(properties);
             // This check avoids accessing the public accessor GlobalProperties
             // unless needed, to avoid the penality of ConcurrentDictionary instantiation.

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData.cs
@@ -13,6 +13,5 @@
 #endif
     internal partial class RequestData
     {
-        
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData.cs
@@ -13,22 +13,6 @@
 #endif
     internal partial class RequestData
     {
-        public RequestData DeepClone()
-        {
-            var other = new RequestData();
-            other.ver = this.ver;
-            other.id = this.id;
-            other.source = this.source;
-            other.name = this.name;
-            other.duration = this.duration;
-            other.responseCode = this.responseCode;
-            other.success = this.success;
-            other.url = this.url;
-            Debug.Assert(other.properties != null, "The constructor should have allocated properties dictionary");
-            Debug.Assert(other.measurements != null, "The constructor should have allocated the measurements dictionary");
-            Utils.CopyDictionary(this.properties, other.properties);
-            Utils.CopyDictionary(this.measurements, other.measurements);
-            return other;
-        }
+        
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_types.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_types.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         public int ver { get; set; }
 
-            
+        
         
         
         public string id { get; set; }
@@ -77,6 +77,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         
         
+        public IDictionary<string, string> properties { get; set; }
+
+        
+        
         
         
 
@@ -94,6 +98,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             responseCode = "";
             success = true;
             url = "";
+            
+            
         }
     }
 } // AI

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_types.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_types.cs
@@ -39,7 +39,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         public int ver { get; set; }
 
-        
+            
         
         
         public string id { get; set; }
@@ -77,10 +77,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         
         
         
-        public IDictionary<string, string> properties { get; set; }
-
-        
-        
         
         
 
@@ -98,8 +94,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             responseCode = "";
             success = true;
             url = "";
-            properties = new ConcurrentDictionary<string, string>();
-            
         }
     }
 } // AI

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
@@ -3,7 +3,8 @@
     using System.Collections.Generic;
 
     /// <summary>
-    /// Partial class to implement ISerializableWithWriter. TODO: Remove this
+    /// Partial class to declare measurements.( This is to be removed once
+    /// every telemetry type gets rid of internal Data classes)
     /// </summary>
     internal partial class RequestData
     {

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
@@ -2,6 +2,7 @@
 {
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Threading;
 
     /// <summary>
     /// Partial class to implement ISerializableWithWriter
@@ -9,13 +10,20 @@
     internal partial class RequestData
     {
         private IDictionary<string, double> measurementsInternal;
+        private IDictionary<string, string> propertiesInternal;
 
 #pragma warning disable SA1300 // Element must begin with upper-case letter
         public IDictionary<string, double> measurements
 #pragma warning restore SA1300 // Element must begin with upper-case letter
         {
-            get { return System.Threading.LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
+            get { return LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
             set { this.measurementsInternal = value; }
+        }
+
+        public IDictionary<string, string> properties
+        {
+            get { return LazyInitializer.EnsureInitialized(ref this.propertiesInternal, () => new ConcurrentDictionary<string, string>()); }
+            set { this.propertiesInternal = value; }
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
@@ -14,7 +14,6 @@
 
 #pragma warning disable SA1300 // Element must begin with upper-case letter
         public IDictionary<string, double> measurements
-#pragma warning restore SA1300 // Element must begin with upper-case letter
         {
             get { return LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
             set { this.measurementsInternal = value; }
@@ -25,5 +24,6 @@
             get { return LazyInitializer.EnsureInitialized(ref this.propertiesInternal, () => new ConcurrentDictionary<string, string>()); }
             set { this.propertiesInternal = value; }
         }
+#pragma warning restore SA1300 // Element must begin with upper-case letter
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
@@ -1,28 +1,17 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
-    using System.Collections.Concurrent;
     using System.Collections.Generic;
-    using System.Threading;
 
     /// <summary>
-    /// Partial class to implement ISerializableWithWriter
+    /// Partial class to implement ISerializableWithWriter. TODO: Remove this
     /// </summary>
     internal partial class RequestData
     {
-        private IDictionary<string, double> measurementsInternal;
-        private IDictionary<string, string> propertiesInternal;
-
 #pragma warning disable SA1300 // Element must begin with upper-case letter
-        public IDictionary<string, string> properties
-        {
-            get { return LazyInitializer.EnsureInitialized(ref this.propertiesInternal, () => new ConcurrentDictionary<string, string>()); }
-            set { this.propertiesInternal = value; }
-        }
-
         public IDictionary<string, double> measurements
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
-            set { this.measurementsInternal = value; }
+            get;
+            set;
         }
 #pragma warning restore SA1300 // Element must begin with upper-case letter
     }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RequestData_typeslazy.cs
@@ -13,16 +13,16 @@
         private IDictionary<string, string> propertiesInternal;
 
 #pragma warning disable SA1300 // Element must begin with upper-case letter
-        public IDictionary<string, double> measurements
-        {
-            get { return LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
-            set { this.measurementsInternal = value; }
-        }
-
         public IDictionary<string, string> properties
         {
             get { return LazyInitializer.EnsureInitialized(ref this.propertiesInternal, () => new ConcurrentDictionary<string, string>()); }
             set { this.propertiesInternal = value; }
+        }
+
+        public IDictionary<string, double> measurements
+        {
+            get { return LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
+            set { this.measurementsInternal = value; }
         }
 #pragma warning restore SA1300 // Element must begin with upper-case letter
     }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -215,7 +215,12 @@
             else if (telemetryItem is RequestTelemetry)
             {
                 RequestTelemetry reqTelemetry = telemetryItem as RequestTelemetry;
-                CopyGlobalPropertiesIfExist(telemetryItem.Context, reqTelemetry.Data.properties);
+                if (telemetryItem.Context.GlobalPropertiesValue != null)
+                {
+                    Utils.CopyDictionary(telemetryItem.Context.GlobalProperties, reqTelemetry.Properties);
+                }
+
+                // CopyGlobalPropertiesIfExist(telemetryItem.Context, reqTelemetry.Data.properties);
 
                 SerializeHelper(telemetryItem, jsonSerializationWriter, reqTelemetry.BaseType, RequestTelemetry.TelemetryName);
             }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -242,6 +242,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                     }
 
                     item.Sanitize();
+                    // Sanitize, Copying global properties is to be done before calling .Data here,
+                    // as Data returns a singleton instance, which won't be updated with changes made
+                    // after .Data is called.
                     var data = telemetryItem.Data;
                     var extendedData = new
                     {

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -233,8 +233,14 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             {
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {                    
-                    var telemetryItem = item as RequestTelemetry;
-                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    var telemetryItem = item as RequestTelemetry;                    
+                    // This check avoids accessing the public accessor GlobalProperties
+                    // unless needed, to avoid the penality of ConcurrentDictionary instantiation.
+                    if (item.Context.GlobalPropertiesValue != null)
+                    {
+                        Utils.CopyDictionary(item.Context.GlobalProperties, telemetryItem.Properties);
+                    }
+
                     item.Sanitize();
                     var data = telemetryItem.Data;
                     var extendedData = new

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -48,6 +48,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 }
                 
                 var telemetryItem = item as RequestTelemetry;
+                // Sanitize, Copying global properties is to be done before calling .Data,
+                // as Data returns a singleton instance, which won't be updated with changes made
+                // after .Data is called.
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 item.Sanitize();
                 this.WriteEvent(

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -493,8 +493,11 @@
 
             // Properties set of TelemetryClient's Context are copied over to that of ITelemetry's Context
 #pragma warning disable CS0618 // Type or member is obsolete
-            Utils.CopyDictionary(this.Context.Properties, telemetry.Context.Properties);
-            
+            if (this.Context.PropertiesValue != null)
+            {
+                Utils.CopyDictionary(this.Context.Properties, telemetry.Context.Properties);
+            }
+
 #pragma warning restore CS0618 // Type or member is obsolete
 
             // This check avoids accessing the public accessor GlobalProperties


### PR DESCRIPTION
Fix Issue #969 #965 
This removes the usage of bond generated internal class from RequestTelemetry. RequestTelemetry now servers all fields from within. During serialization, the RequestData class is generated for RichpayloadEventSource.

This led to removing URI to String conversions amd doing lazy instantiation of ConcurrentDictionary for the Properties field.


- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
