### PR TITLE
Adding ISupportMetrics support to PageViewTelemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 ## Version 2.9.0-beta1
 - [Remove unused reference to System.Web.Extesions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
-- [Added new method on TelemetryClient to initialize just instrumntation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
+- [Added new method on TelemetryClient to initialize just instrumentation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
+- [PageViewTelemetry](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/8673ed1d15005713755e0bb9594acfe0ee00b869/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs) now supports [ISupportMetrics](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/39a5ef23d834777eefdd72149de705a016eb06b0/src/Microsoft.ApplicationInsights/DataContracts/ISupportMetrics.cs)
 
 ## Version 2.8.1
 [Patch release addressing perf regression.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/952)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.9.0-beta1
-- [Remove unused reference to System.Web.Extesions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
+- [Remove unused reference to System.Web.Extensions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
 - [Added new method on TelemetryClient to initialize just instrumentation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
 - [PageViewTelemetry](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/8673ed1d15005713755e0bb9594acfe0ee00b869/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs) now supports [ISupportMetrics](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/39a5ef23d834777eefdd72149de705a016eb06b0/src/Microsoft.ApplicationInsights/DataContracts/ISupportMetrics.cs)
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PageViewTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PageViewTelemetryTest.cs
@@ -52,6 +52,16 @@
         }
 
         [TestMethod]
+        public void PageViewTelemetryImplementsISupportMetrics()
+        {
+            PageViewTelemetry item = new PageViewTelemetry();
+            item.Metrics.Add("Test", 10);
+
+            Assert.IsNotNull(item as ISupportMetrics);
+            Assert.AreEqual(10, (item as ISupportMetrics).Metrics["Test"]);
+        }
+
+        [TestMethod]
         public void PageViewTelemetrySerializesToJsonCorrectly()
         {
             var expected = new PageViewTelemetry("My Page");

--- a/findMsBuild.cmd
+++ b/findMsBuild.cmd
@@ -6,10 +6,10 @@ IF DEFINED MSBUILD (
   IF EXIST "%MSBUILD%" GOTO :eof
 )
 
-SET VSWHERE=..\packages\vswhere\tools\vswhere.exe
+SET VSWHERE=vswhere\tools\vswhere.exe
 IF NOT EXIST "%VSWHERE%" nuget.exe install vswhere -NonInteractive -ExcludeVersion -Source https://www.nuget.org/api/v2 > nul
 
-FOR /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -version %VSVERSION% -products * -requires Microsoft.Component.MSBuild -property installationPath`) DO (
+FOR /f "usebackq tokens=*" %%i in (`"%VSWHERE%" -version %VSVERSION% -products * -requires Microsoft.Component.MSBuild -property installationPath -prerelease`) DO (
   SET MSBUILD=%%i\MSBuild\%VSVERSION%\Bin\MSBuild.exe
 )
 

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
@@ -18,11 +18,11 @@
     /// method.
     /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#page-views">Learn more</a>
     /// </remarks>
-    public sealed class PageViewTelemetry : ITelemetry, ISupportProperties, ISupportSampling
+    public sealed class PageViewTelemetry : ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics
     {
         internal const string TelemetryName = "PageView";
 
-        internal readonly string BaseType = typeof(PageViewData).Name;        
+        internal readonly string BaseType = typeof(PageViewData).Name;
         internal readonly PageViewData Data;
         private readonly TelemetryContext context;
         private IExtension extension;


### PR DESCRIPTION
Fix Issue # https://github.com/Microsoft/ApplicationInsights-dotnet/issues/971.
<Short description of the fix.>
PageViewTelemetry today implements ISupportMetrics but does not declare the same in class declaration. Adding ISupportMetrics as one of the implemented interfaces in class definition.
Additionally fixing the findMSBuild script to work with pre-release versions of VisualStudio.

- [ X] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
