### PR TITLE
change vsts linux build to remove deprecated pool

### DIFF
--- a/.vsts/linux-build.yml
+++ b/.vsts/linux-build.yml
@@ -1,5 +1,5 @@
-queue:
-  name: Hosted Linux
+pool:
+  vmImage: 'ubuntu-16.04'
 steps:
 - task: DotNetCoreInstaller@0
   inputs:


### PR DESCRIPTION
Fix Issue # .
https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=vsts&tabs=yaml#hosted-linux-preview-pool-deprecation

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
