### PR TITLE
RequestTelemetry contructor modified to revert behavior change from previous PR

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -29,6 +29,13 @@ namespace Microsoft.ApplicationInsights.DataContracts
         {
             var request = new RequestTelemetry();
             Assert.IsFalse(string.IsNullOrEmpty(request.Id));
+
+            // Validate that fields are not null.       
+            Assert.IsFalse(request.Source == null);
+            Assert.IsFalse(request.Name == null);            
+            Assert.IsFalse(request.ResponseCode == null);
+            Assert.IsFalse(request.Success == null);                        
+            Assert.IsFalse(request.Duration == null);
         }
 
         [TestMethod]

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -40,6 +40,11 @@
         {
             this.context = new TelemetryContext();
             this.GenerateId();
+            this.Source = string.Empty;
+            this.Name = string.Empty;
+            this.ResponseCode = string.Empty;
+            this.Success = true;
+            this.Duration = System.TimeSpan.Zero;
         }
 
         /// <summary>


### PR DESCRIPTION
This PR https://github.com/Microsoft/ApplicationInsights-dotnet/pull/970/files altered the behavior of RequestTelemetry() ctor - but NOT populating string fields with "" empty strings.

This may have undesired effects, and hence behavior is made same as previous  - all string fields are initialized to String.Empty in the default constructor. (Added a unit test as well for the sme)

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
