### PR TITLE
Mikp/perf optimizations

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/ITelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/ITelemetryTest.cs
@@ -82,11 +82,11 @@
             {
                 var instance = new TTelemetry();
                 var actualValue = property.GetValue(instance, null);
-                Assert.IsNotNull(actualValue, typeof(TTelemetry).Name + "." + property.Name + " should not be null by default to prevent NullReferenceException.");
+                Assert.IsNotNull(actualValue, nameof(TTelemetry) + "." + property.Name + " should not be null by default to prevent NullReferenceException.");
             }
             catch (TargetInvocationException e)
             {
-                Assert.Fail(typeof(TTelemetry).Name + "." + property.Name + " should not be null by default to prevent NullReferenceException." + e.InnerException.Message);
+                Assert.Fail(nameof(TTelemetry) + "." + property.Name + " should not be null by default to prevent NullReferenceException." + e.InnerException.Message);
             }
         }
 
@@ -98,11 +98,11 @@
                 try
                 {
                     property.SetValue(instance, null, null);
-                    Assert.Fail(typeof(TTelemetry).Name + "." + property.Name + " setter should throw " + expectedException.Name + " when value is " + (invalidValue ?? "null") + ".");
+                    Assert.Fail(nameof(TTelemetry) + "." + property.Name + " setter should throw " + expectedException.Name + " when value is " + (invalidValue ?? "null") + ".");
                 }
                 catch (TargetInvocationException e)
                 {
-                    Assert.AreEqual(expectedException, e.InnerException.GetType(), typeof(TTelemetry).Name + "." + property.Name + " setter should throw " + expectedException.Name + " when value is " + (invalidValue ?? "null") + ".");
+                    Assert.AreEqual(expectedException, e.InnerException.GetType(), nameof(TTelemetry) + "." + property.Name + " setter should throw " + expectedException.Name + " when value is " + (invalidValue ?? "null") + ".");
                 }
             }
         }
@@ -113,7 +113,7 @@
             {
                 var instance = new TTelemetry();
                 property.SetValue(instance, value, null);
-                Assert.AreEqual(value, property.GetValue(instance, null), typeof(TTelemetry).Name + "." + property.Name + " setter should change property value.");
+                Assert.AreEqual(value, property.GetValue(instance, null), nameof(TTelemetry) + "." + property.Name + " setter should change property value.");
             }
         }
 
@@ -144,21 +144,21 @@
 
         private void ClassShouldBePublic()
         {
-            Assert.IsTrue(typeof(TTelemetry).GetTypeInfo().IsPublic, typeof(TTelemetry).Name + " should be public to allow instantiation in user code.");
+            Assert.IsTrue(typeof(TTelemetry).GetTypeInfo().IsPublic, nameof(TTelemetry) + " should be public to allow instantiation in user code.");
         }
 
         private void ClassShouldHaveDefaultConstructorToSupportTelemetryContext()
         {
             Assert.IsNotNull(
                 typeof(TTelemetry).GetTypeInfo().DeclaredConstructors.SingleOrDefault(c => c.GetParameters().Length == 0),
-                typeof(TTelemetry).Name + " should have default constructor to support TelemetryContext.");
+                nameof(TTelemetry) + " should have default constructor to support TelemetryContext.");
         }
 
         private void ClassShouldHaveParameterizedConstructorToSimplifyCreationOfValidTelemetryInstancesInUserCode()
         {
             Assert.IsTrue(
                 typeof(TTelemetry).GetTypeInfo().DeclaredConstructors.Any(c => c.GetParameters().Length > 0),
-                typeof(TTelemetry).Name + " should have a parameterized constructor to simplify creation of valid telemetry in user code.");
+                nameof(TTelemetry) + " should have a parameterized constructor to simplify creation of valid telemetry in user code.");
         }
 
         private void ClassShouldImplementISupportCustomPropertiesIfItDefinesPropertiesProperty()

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/AvailabilityTelemetryTest.cs
@@ -45,7 +45,7 @@
             Assert.AreEqual(expected.Sequence, item.seq);
             Assert.AreEqual(expected.Context.InstrumentationKey, item.iKey);
             AssertEx.AreEqual(expected.Context.SanitizedTags.ToArray(), item.tags.ToArray());
-            Assert.AreEqual(typeof(AI.AvailabilityData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.AvailabilityData), item.data.baseType);
 
             Assert.AreEqual(expected.Duration, TimeSpan.Parse(item.data.baseData.duration));
             Assert.AreEqual(expected.Message, item.data.baseData.message);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -62,7 +62,7 @@
             Assert.AreEqual(expected.Sequence, item.seq);
             Assert.AreEqual(expected.Context.InstrumentationKey, item.iKey);
             AssertEx.AreEqual(expected.Context.SanitizedTags.ToArray(), item.tags.ToArray());
-            Assert.AreEqual(typeof(AI.RemoteDependencyData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.RemoteDependencyData), item.data.baseType);
 
             Assert.AreEqual(expected.Id, item.data.baseData.id);
             Assert.AreEqual(expected.ResultCode, item.data.baseData.resultCode);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/EventTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/EventTelemetryTest.cs
@@ -60,7 +60,7 @@
 
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(AI.ItemType.Event, item.name);
-            Assert.AreEqual(typeof(AI.EventData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.EventData), item.data.baseType);
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(expected.Name, item.data.baseData.name);
             AssertEx.AreEqual(expected.Metrics.ToArray(), item.data.baseData.measurements.ToArray());

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/ExceptionTelemetryTest.cs
@@ -386,7 +386,7 @@
         {
             ExceptionTelemetry original = CreateExceptionTelemetry();
             var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(original);
-            Assert.AreEqual(typeof(AI.ExceptionData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.ExceptionData), item.data.baseType);
         }
 
         [TestMethod]

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/MetricTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/MetricTelemetryTest.cs
@@ -103,7 +103,7 @@
 
             var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(expected);
 
-            Assert.AreEqual(typeof(AI.MetricData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.MetricData), item.data.baseType);
 
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(1, item.data.baseData.metrics.Count);
@@ -138,7 +138,7 @@
 
             var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.MetricData>(expected);
 
-            Assert.AreEqual(typeof(AI.MetricData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.MetricData), item.data.baseType);
 
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(1, item.data.baseData.metrics.Count);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PageViewTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/PageViewTelemetryTest.cs
@@ -75,7 +75,7 @@
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.PageView);
 
-            Assert.AreEqual(typeof(AI.PageViewData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.PageViewData), item.data.baseType);
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(expected.Name, item.data.baseData.name);
             Assert.AreEqual(expected.Duration, TimeSpan.Parse(item.data.baseData.duration));

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/RequestTelemetryTest.cs
@@ -117,7 +117,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.Request);
 
-            Assert.AreEqual(typeof(AI.RequestData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.RequestData), item.data.baseType);
 
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(expected.Id, item.data.baseData.id);
@@ -154,7 +154,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.Request);
 
-            Assert.AreEqual(typeof(AI.RequestData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.RequestData), item.data.baseType);
 
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(expected.Id, item.data.baseData.id);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TraceTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/TraceTelemetryTest.cs
@@ -68,7 +68,7 @@
 
             // NOTE: It's correct that we use the v1 name here, and therefore we test against it.
             Assert.AreEqual(item.name, AI.ItemType.Message);
-            Assert.AreEqual(typeof(AI.MessageData).Name, item.data.baseType);
+            Assert.AreEqual(nameof(AI.MessageData), item.data.baseType);
             Assert.AreEqual(2, item.data.baseData.ver);
             Assert.AreEqual(expected.Message, item.data.baseData.message);
             AssertEx.AreEqual(expected.Properties.ToArray(), item.data.baseData.properties.ToArray());

--- a/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Availability";
 
-        internal readonly string BaseType = typeof(AvailabilityData).Name;
+        internal readonly string BaseType = nameof(AvailabilityData);
         internal readonly AvailabilityData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/AvailabilityTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Availability";
 
-        internal readonly string BaseType = nameof(AvailabilityData);
+        internal const string BaseType = nameof(AvailabilityData);
         internal readonly AvailabilityData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
     {
         internal new const string TelemetryName = "RemoteDependency";
 
-        internal readonly string BaseType = typeof(RemoteDependencyData).Name;
+        internal readonly string BaseType = nameof(RemoteDependencyData);
 
         internal readonly RemoteDependencyData InternalData;
         private readonly TelemetryContext context;

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -20,7 +20,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
     {
         internal new const string TelemetryName = "RemoteDependency";
 
-        internal readonly string BaseType = nameof(RemoteDependencyData);
+        internal const string BaseType = nameof(RemoteDependencyData);
 
         internal readonly RemoteDependencyData InternalData;
         private readonly TelemetryContext context;

--- a/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Event";
 
-        internal readonly string BaseType = nameof(EventData);
+        internal const string BaseType = nameof(EventData);
         internal readonly EventData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/EventTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Event";
 
-        internal readonly string BaseType = typeof(EventData).Name;
+        internal readonly string BaseType = nameof(EventData);
         internal readonly EventData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -16,7 +16,7 @@
     public sealed class ExceptionTelemetry : ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics
     {
         internal const string TelemetryName = "Exception";
-        internal readonly string BaseType = typeof(ExceptionData).Name;
+        internal readonly string BaseType = nameof(ExceptionData);
         internal ExceptionInfo Data = null;
 
         private readonly bool isCreatedFromExceptionInfo = false;

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -16,7 +16,7 @@
     public sealed class ExceptionTelemetry : ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics
     {
         internal const string TelemetryName = "Exception";
-        internal readonly string BaseType = nameof(ExceptionData);
+        internal const string BaseType = nameof(ExceptionData);
         internal ExceptionInfo Data = null;
 
         private readonly bool isCreatedFromExceptionInfo = false;

--- a/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Metric";
 
-        internal readonly string BaseType = nameof(MetricData);
+        internal const string BaseType = nameof(MetricData);
         internal readonly MetricData Data;
         internal readonly DataPoint Metric;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/MetricTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Metric";
 
-        internal readonly string BaseType = typeof(MetricData).Name;        
+        internal readonly string BaseType = nameof(MetricData);
         internal readonly MetricData Data;
         internal readonly DataPoint Metric;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
@@ -22,7 +22,7 @@
     {
         internal const string TelemetryName = "PageView";
 
-        internal readonly string BaseType = nameof(PageViewData);
+        internal const string BaseType = nameof(PageViewData);
         internal readonly PageViewData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs
@@ -22,7 +22,7 @@
     {
         internal const string TelemetryName = "PageView";
 
-        internal readonly string BaseType = typeof(PageViewData).Name;
+        internal readonly string BaseType = nameof(PageViewData);
         internal readonly PageViewData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -24,7 +24,7 @@
     {
         internal new const string TelemetryName = "Request";
 
-        internal readonly string BaseType = typeof(RequestData).Name;
+        internal readonly string BaseType = nameof(RequestData);
         private readonly TelemetryContext context;
         private RequestData dataPrivate;
         private bool successFieldSet;
@@ -297,7 +297,7 @@
             // To ensure that all changes to telemetry are reflected in serialization,
             // the underlying field is set to null, which forces it to be re-created.
             this.dataPrivate = null;
-            serializationWriter.WriteProperty(this.Data);                        
+            serializationWriter.WriteProperty(this.Data);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/RequestTelemetry.cs
@@ -24,7 +24,7 @@
     {
         internal new const string TelemetryName = "Request";
 
-        internal readonly string BaseType = nameof(RequestData);
+        internal const string BaseType = nameof(RequestData);
         private readonly TelemetryContext context;
         private RequestData dataPrivate;
         private bool successFieldSet;

--- a/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Message";
 
-        internal readonly string BaseType = typeof(MessageData).Name;
+        internal readonly string BaseType = nameof(MessageData);
         internal readonly MessageData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/TraceTelemetry.cs
@@ -17,7 +17,7 @@
     {
         internal const string TelemetryName = "Message";
 
-        internal readonly string BaseType = nameof(MessageData);
+        internal const string BaseType = nameof(MessageData);
         internal readonly MessageData Data;
         private readonly TelemetryContext context;
         private IExtension extension;

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -175,28 +175,28 @@
                 EventTelemetry eventTelemetry = telemetryItem as EventTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, eventTelemetry.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, eventTelemetry.BaseType, EventTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, EventTelemetry.BaseType, EventTelemetry.TelemetryName);
             }
             else if (telemetryItem is ExceptionTelemetry)
             {
                 ExceptionTelemetry exTelemetry = telemetryItem as ExceptionTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, exTelemetry.Data.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, exTelemetry.BaseType, ExceptionTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, ExceptionTelemetry.BaseType, ExceptionTelemetry.TelemetryName);
             }
             else if (telemetryItem is MetricTelemetry)
             {
                 MetricTelemetry mTelemetry = telemetryItem as MetricTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, mTelemetry.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, mTelemetry.BaseType, MetricTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, MetricTelemetry.BaseType, MetricTelemetry.TelemetryName);
             }
             else if (telemetryItem is PageViewTelemetry)
             {
                 PageViewTelemetry pvTelemetry = telemetryItem as PageViewTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, pvTelemetry.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, pvTelemetry.BaseType, PageViewTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, PageViewTelemetry.BaseType, PageViewTelemetry.TelemetryName);
             }
             else if (telemetryItem is PageViewPerformanceTelemetry)
             {
@@ -210,7 +210,7 @@
                 DependencyTelemetry depTelemetry = telemetryItem as DependencyTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, depTelemetry.InternalData.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, depTelemetry.BaseType, DependencyTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, DependencyTelemetry.BaseType, DependencyTelemetry.TelemetryName);
             }
             else if (telemetryItem is RequestTelemetry)
             {
@@ -222,7 +222,7 @@
 
                 // CopyGlobalPropertiesIfExist(telemetryItem.Context, reqTelemetry.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, reqTelemetry.BaseType, RequestTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, RequestTelemetry.BaseType, RequestTelemetry.TelemetryName);
             }
 #pragma warning disable 618
             else if (telemetryItem is PerformanceCounterTelemetry)
@@ -230,12 +230,12 @@
                 PerformanceCounterTelemetry pcTelemetry = telemetryItem as PerformanceCounterTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, pcTelemetry.Data.Properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, pcTelemetry.Data.BaseType, MetricTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, MetricTelemetry.BaseType, MetricTelemetry.TelemetryName);
             }
             else if (telemetryItem is SessionStateTelemetry)
             {
                 SessionStateTelemetry ssTelemetry = telemetryItem as SessionStateTelemetry;
-                SerializeHelper(telemetryItem, jsonSerializationWriter, ssTelemetry.Data.BaseType, EventTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, EventTelemetry.BaseType, EventTelemetry.TelemetryName);
             }
 #pragma warning restore 618
             else if (telemetryItem is TraceTelemetry)
@@ -243,14 +243,14 @@
                 TraceTelemetry traceTelemetry = telemetryItem as TraceTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, traceTelemetry.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, traceTelemetry.BaseType, TraceTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, TraceTelemetry.BaseType, TraceTelemetry.TelemetryName);
             }
             else if (telemetryItem is AvailabilityTelemetry)
             {
                 AvailabilityTelemetry availabilityTelemetry = telemetryItem as AvailabilityTelemetry;
                 CopyGlobalPropertiesIfExist(telemetryItem.Context, availabilityTelemetry.Data.properties);
 
-                SerializeHelper(telemetryItem, jsonSerializationWriter, availabilityTelemetry.BaseType, AvailabilityTelemetry.TelemetryName);
+                SerializeHelper(telemetryItem, jsonSerializationWriter, AvailabilityTelemetry.BaseType, AvailabilityTelemetry.TelemetryName);
             }
             else
             {

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -107,10 +107,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
         /// <returns>The machine name.</returns>
         public string GetMachineName()
         {
-            return LazyInitializer.EnsureInitialized(ref this.hostName, this.GetHostName);
+            return this.hostName ?? (this.hostName = GetHostName());
         }
 
-        private string GetHostName()
+        private static string GetHostName()
         {
             try
             {

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -57,7 +57,7 @@
 
                 if (modules != null)
                 {
-                    // Create diagnostics module so configuration loading errors are reported to the portal    
+                    // Create diagnostics module so configuration loading errors are reported to the portal
                     modules.Modules.Add(new DiagnosticsTelemetryModule());
                 }
 

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/ApplicationInsightsTelemetryPipeline.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/ApplicationInsightsTelemetryPipeline.cs
@@ -52,7 +52,7 @@
                 throw new ArgumentException(Invariant($"Cannot track the specified {metricAggregate}, because there is no {nameof(IMetricAggregateToTelemetryPipelineConverter)}")
                                           + Invariant($" registered for it. A converter must be added to {nameof(MetricAggregateToTelemetryPipelineConverters)}")
                                           + Invariant($".{nameof(MetricAggregateToTelemetryPipelineConverters.Registry)} for the pipeline type")
-                                          + Invariant($" '{typeof(ApplicationInsightsTelemetryPipeline).Name}' and {nameof(metricAggregate.AggregationKindMoniker)}")
+                                          + Invariant($" '{nameof(ApplicationInsightsTelemetryPipeline)}' and {nameof(metricAggregate.AggregationKindMoniker)}")
                                           + Invariant($" '{metricAggregate.AggregationKindMoniker}'."));
             }
 

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricAggregateToTelemetryPipelineConverters.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricAggregateToTelemetryPipelineConverters.cs
@@ -55,7 +55,7 @@
 
             ////if (false == typeof(IMetricTelemetryPipeline).IsAssignableFrom(pipelineType))
             ////{
-            ////    throw new ArgumentException($"{nameof(pipelineType)} must specify a type that implements the interface '{typeof(IMetricTelemetryPipeline).Name}'"
+            ////    throw new ArgumentException($"{nameof(pipelineType)} must specify a type that implements the interface '{nameof(IMetricTelemetryPipeline)}'"
             ////                              + $", but it specifies the type '{pipelineType.Name}' that does not implement that interface.");
             ////}
 

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -24,7 +24,6 @@
     {
         private const string VersionPrefix = "dotnet:";
         private readonly TelemetryConfiguration configuration;
-        private TelemetryContext context;
         private string sdkVersion;
 
         /// <summary>
@@ -60,9 +59,11 @@
         /// </summary>
         public TelemetryContext Context
         {
-            get { return LazyInitializer.EnsureInitialized(ref this.context, () => new TelemetryContext()); }
-            internal set { this.context = value; }
+            get;
+            internal set;
         }
+
+        = new TelemetryContext();
 
         /// <summary>
         /// Gets or sets the default instrumentation key for all <see cref="ITelemetry"/> objects logged in this <see cref="TelemetryClient"/>.
@@ -532,7 +533,8 @@
             // Currently backend requires SDK version to comply "name: version"
             if (string.IsNullOrEmpty(telemetry.Context.Internal.SdkVersion))
             {
-                var version = LazyInitializer.EnsureInitialized(ref this.sdkVersion, () => SdkVersionUtils.GetSdkVersion(VersionPrefix));
+                var version = this.sdkVersion ?? (this.sdkVersion = SdkVersionUtils.GetSdkVersion(VersionPrefix));
+                // var version = LazyInitializer.EnsureInitialized(ref this.sdkVersion, () => SdkVersionUtils.GetSdkVersion(VersionPrefix));
                 telemetry.Context.Internal.SdkVersion = version;
             }
 

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -534,7 +534,6 @@
             if (string.IsNullOrEmpty(telemetry.Context.Internal.SdkVersion))
             {
                 var version = this.sdkVersion ?? (this.sdkVersion = SdkVersionUtils.GetSdkVersion(VersionPrefix));
-                // var version = LazyInitializer.EnsureInitialized(ref this.sdkVersion, () => SdkVersionUtils.GetSdkVersion(VersionPrefix));
                 telemetry.Context.Internal.SdkVersion = version;
             }
 

--- a/src/ServerTelemetryChannel/SamplingTelemetryProcessor.cs
+++ b/src/ServerTelemetryChannel/SamplingTelemetryProcessor.cs
@@ -161,7 +161,7 @@
             double samplingPercentage = this.SamplingPercentage;
 
             //// If sampling rate is 100% and we aren't distinguishing between evaluated/unevaluated items, there is nothing to do:
-            if (this.SampledNext.Equals(this.UnsampledNext) && samplingPercentage >= 100.0 - 1.0E-12)
+            if (samplingPercentage >= 100.0 - 1.0E-12 && this.SampledNext.Equals(this.UnsampledNext))
             {
                 this.SampledNext.Process(item);
                 return;


### PR DESCRIPTION
Performance optimizations for various isolated places as identified by local profiling on a single core app.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.


* SamplingTelemetryProcessor: compare primitives first 
* multiple places: use compile-time nameof(), instead of runtime typeof().Name
* PlatformImplementation: GetMachineName - reduce usage of volatile-accessing LazyInitializers
* TelemetryClient: create TelemetryContext at construction, to remove unnecessary lazy initialization-related checks