### PR TITLE
Optimize Dependency Telemetry

### DIFF
--- a/Schema/generateSchema.ps1
+++ b/Schema/generateSchema.ps1
@@ -117,8 +117,9 @@ dir "$currentDir\obj\gbc" | ForEach-Object {
 	RegExReplace $_.FullName "measurements = new ConcurrentDictionary<string, double>\(\);"
 }
 
-	# Remove "properties" instantiation as its is done lazy in the public RequestTelemetry class.
+	# Remove "properties" instantiation as its is done lazy in the public RequestTelemetry,DependencyTelemetry classes.
 	RegExReplace "$currentDir\obj\gbc\RequestData_types.cs" "properties = new ConcurrentDictionary<string, string>\(\);"
+	RegExReplace "$currentDir\obj\gbc\RemoteDependencyData_types.cs" "properties = new ConcurrentDictionary<string, string>\(\);"
 
 #################################################################################################
 ## Use TimeSpan instead of String for duration to improve performance by avoiding conversions.

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -84,6 +84,9 @@
             AssertEx.AreEqual(expected.Properties.ToArray(), item.data.baseData.properties.ToArray());
         }
 
+        [TestMethod]
+        /// Test validates that if Serialize is called multiple times, and telemetry is modified
+        /// in between, serialize always gives the latest state.
         public void RemoteDependencySerializationPicksUpCorrectState()
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry();

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -23,7 +23,13 @@
         {
             var defaultDependencyTelemetry = new DependencyTelemetry();
             Assert.AreEqual(true, defaultDependencyTelemetry.Success, "Success is expected to be true");
-        }
+            Assert.IsNotNull(defaultDependencyTelemetry.Target);
+            Assert.IsNotNull(defaultDependencyTelemetry.Name);
+            Assert.IsNotNull(defaultDependencyTelemetry.Data);
+            Assert.IsNotNull(defaultDependencyTelemetry.ResultCode);
+            Assert.IsNotNull(defaultDependencyTelemetry.Id);
+            Assert.IsNotNull(defaultDependencyTelemetry.Type);
+    }
 
         [TestMethod]
         public void DependencyTelemetryITelemetryContractConsistentlyWithOtherTelemetryTypes()
@@ -56,6 +62,35 @@
         public void RemoteDependencyTelemetrySerializesToJson()
         {
             DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry();
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
+
+            Assert.AreEqual<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(item.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
+            Assert.AreEqual(expected.Sequence, item.seq);
+            Assert.AreEqual(expected.Context.InstrumentationKey, item.iKey);
+            AssertEx.AreEqual(expected.Context.SanitizedTags.ToArray(), item.tags.ToArray());
+            Assert.AreEqual(nameof(AI.RemoteDependencyData), item.data.baseType);
+
+            Assert.AreEqual(expected.Id, item.data.baseData.id);
+            Assert.AreEqual(expected.ResultCode, item.data.baseData.resultCode);
+            Assert.AreEqual(expected.Name, item.data.baseData.name);
+            Assert.AreEqual(expected.Duration, TimeSpan.Parse(item.data.baseData.duration));
+            Assert.AreEqual(expected.Type, item.data.baseData.type);
+
+            Assert.AreEqual(expected.Success, item.data.baseData.success);
+            AssertEx.AreEqual(expected.Properties.ToArray(), item.data.baseData.properties.ToArray());
+        }
+
+        public void RemoteDependencySerializationPicksUpCorrectState()
+        {
+            DependencyTelemetry expected = this.CreateRemoteDependencyTelemetry();
+            ((ITelemetry)expected).Sanitize();
+            byte[] buf = new byte[1000000];
+            expected.SerializeData(new JsonSerializationWriter(new StreamWriter(new MemoryStream(buf))));
+
+            // Change the telemetry after serialization.
+            expected.Name = expected.Name + "new";
+
+            // Validate that the newly updated Name is picked up.
             var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.RemoteDependencyData>(expected);
 
             Assert.AreEqual<DateTimeOffset>(expected.Timestamp, DateTimeOffset.Parse(item.time, null, System.Globalization.DateTimeStyles.AssumeUniversal));
@@ -177,7 +212,9 @@
             telemetry.Type = new string('D', Property.MaxDependencyTypeLength + 1);
             telemetry.Properties.Add(new string('X', Property.MaxDictionaryNameLength) + 'X', new string('X', Property.MaxValueLength + 1));
             telemetry.Properties.Add(new string('X', Property.MaxDictionaryNameLength) + 'Y', new string('X', Property.MaxValueLength + 1));
-            
+            telemetry.Metrics.Add(new string('Y', Property.MaxDictionaryNameLength) + 'X', 42.0);
+            telemetry.Metrics.Add(new string('Y', Property.MaxDictionaryNameLength) + 'Y', 42.0);
+
             ((ITelemetry)telemetry).Sanitize();
 
             Assert.AreEqual(new string('Z', Property.MaxNameLength), telemetry.Name);
@@ -193,6 +230,11 @@
             Assert.AreEqual(new string('X', Property.MaxValueLength), t.Values.ToArray()[0]);
 
             Assert.AreSame(telemetry.Properties, telemetry.Properties);
+
+            Assert.AreEqual(2, telemetry.Metrics.Count);
+            var keys = telemetry.Metrics.Keys.OrderBy(s => s).ToArray();
+            Assert.AreEqual(new string('Y', Property.MaxDictionaryNameLength), keys[1]);
+            Assert.AreEqual(new string('Y', Property.MaxDictionaryNameLength - 3) + "1", keys[0]);
         }
 
         [TestMethod]

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -5,6 +5,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
     using System.Collections.Generic;
     using System.ComponentModel;
     using System.Globalization;
+    using System.Threading;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -19,22 +20,29 @@ namespace Microsoft.ApplicationInsights.DataContracts
     public sealed class DependencyTelemetry : OperationTelemetry, ITelemetry, ISupportProperties, ISupportSampling, ISupportMetrics, IAiSerializableTelemetry
     {
         internal new const string TelemetryName = "RemoteDependency";
-
-        internal readonly RemoteDependencyData InternalData;
+        
         private readonly TelemetryContext context;
         private IExtension extension;
         private double? samplingPercentage;
         private bool successFieldSet;
+        private bool success = true;
+        private IDictionary<string, double> measurementsValue;
+        private RemoteDependencyData internalDataPrivate;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="DependencyTelemetry"/> class.
         /// </summary>
         public DependencyTelemetry()
-        {
-            this.InternalData = new RemoteDependencyData();
+        {            
             this.successFieldSet = true;
-            this.context = new TelemetryContext(this.InternalData.properties);
+            this.context = new TelemetryContext();
             this.GenerateId();
+            this.Name = string.Empty;
+            this.Id = string.Empty;
+            this.ResultCode = string.Empty;
+            this.Duration = TimeSpan.Zero;
+            this.Target = string.Empty;
+            this.Type = string.Empty;
         }
 
         /// <summary>
@@ -88,14 +96,34 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         /// <param name="source">Source instance of <see cref="DependencyTelemetry"/> to clone from.</param>
         private DependencyTelemetry(DependencyTelemetry source)
-        {
-            this.InternalData = source.InternalData.DeepClone();
-            this.context = source.context.DeepClone(this.InternalData.properties);
+        {            
+            if (source.measurementsValue != null)
+            {
+                Utils.CopyDictionary(source.Metrics, this.Metrics);
+            }
+
+            this.context = source.context.DeepClone();
             this.Sequence = source.Sequence;
             this.Timestamp = source.Timestamp;
             this.samplingPercentage = source.samplingPercentage;
             this.successFieldSet = source.successFieldSet;
             this.extension = source.extension?.DeepClone();
+
+            var other = new RemoteDependencyData();
+            other.ver = this.ver;
+            other.name = this.name;
+            other.id = this.id;
+            other.resultCode = this.resultCode;
+            other.duration = this.duration;
+            other.success = this.success;
+            other.data = this.data;
+            other.target = this.target;
+            other.type = this.type;
+            Debug.Assert(other.properties != null, "The constructor should have allocated properties dictionary");
+            Debug.Assert(other.measurements != null, "The constructor should have allocated the measurements dictionary");
+            Utils.CopyDictionary(this.properties, other.properties);
+            Utils.CopyDictionary(this.measurements, other.measurements);
+            return other;
         }
 
         /// <inheritdoc />
@@ -136,8 +164,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public override string Id
         {
-            get { return this.InternalData.id; }
-            set { this.InternalData.id = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -145,8 +173,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public string ResultCode
         {
-            get { return this.InternalData.resultCode; }
-            set { this.InternalData.resultCode = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -154,8 +182,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public override string Name
         {
-            get { return this.InternalData.name; }
-            set { this.InternalData.name = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -164,8 +192,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         [Obsolete("Renamed to Data")]
         public string CommandName
         {
-            get { return this.InternalData.data; }
-            set { this.InternalData.data = value; }
+            get { return this.Data; }
+            set { this.Data = value; }
         }
 
         /// <summary>
@@ -173,8 +201,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public string Data
         {
-            get { return this.InternalData.data; }
-            set { this.InternalData.data = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -182,8 +210,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public string Target
         {
-            get { return this.InternalData.target; }
-            set { this.InternalData.target = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -201,8 +229,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public string Type
         {
-            get { return this.InternalData.type; }
-            set { this.InternalData.type = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -210,8 +238,8 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public override TimeSpan Duration
         {
-            get { return this.InternalData.duration; }
-            set { this.InternalData.duration = value; }
+            get;
+            set;
         }
 
         /// <summary>
@@ -223,7 +251,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
             {
                 if (this.successFieldSet)
                 {
-                    return this.InternalData.success;
+                    return this.success;
                 }
 
                 return null;
@@ -233,12 +261,12 @@ namespace Microsoft.ApplicationInsights.DataContracts
             {
                 if (value != null && value.HasValue)
                 {
-                    this.InternalData.success = value.Value;
+                    this.success = value.Value;
                     this.successFieldSet = true;
                 }
                 else
                 {
-                    this.InternalData.success = true;
+                    this.success = true;
                     this.successFieldSet = false;
                 }
             }
@@ -252,12 +280,14 @@ namespace Microsoft.ApplicationInsights.DataContracts
         {            
             get
             {
-                if (!string.IsNullOrEmpty(this.MetricExtractorInfo) && !this.InternalData.properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
+#pragma warning disable CS0618 // Type or member is obsolete
+                if (!string.IsNullOrEmpty(this.MetricExtractorInfo) && !this.Context.Properties.ContainsKey(MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key))
                 {
-                    this.InternalData.properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
+                    this.Context.Properties[MetricTerms.Extraction.ProcessedByExtractors.Moniker.Key] = this.MetricExtractorInfo;
                 }
 
-                return this.InternalData.properties;
+                return this.Context.Properties;
+#pragma warning restore CS0618 // Type or member is obsolete
             }
         }
 
@@ -267,7 +297,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// </summary>
         public override IDictionary<string, double> Metrics
         {
-            get { return this.InternalData.measurements; }
+            get { return LazyInitializer.EnsureInitialized(ref this.measurementsValue, () => new ConcurrentDictionary<string, double>()); }
         }
 
         /// <summary>
@@ -306,7 +336,41 @@ namespace Microsoft.ApplicationInsights.DataContracts
             get;
             set;
         }
-        
+
+        /// <summary>
+        /// Gets the InternalData associated with this Telemetry instance.
+        /// This is being served by a singleton instance, so this will
+        /// not pickup changes made to the telemetry after first call to this.
+        /// It is recommended to make all changes (including sanitization)
+        /// to this telemetry before calling InternalData.
+        /// </summary>
+        internal RemoteDependencyData InternalData
+        {
+            get
+            {
+                return LazyInitializer.EnsureInitialized(ref this.internalDataPrivate,
+                    () =>
+                    {
+                        var req = new RemoteDependencyData();
+                        req.duration = this.Duration;
+                        req.id = this.Id;
+                        req.measurements = this.measurementsValue;
+                        req.name = this.Name;
+                        req.properties = this.context.PropertiesValue;
+                        req.resultCode = this.ResultCode;
+                        req.target = this.Target;
+                        req.success = this.success;
+                        req.data = this.Data;
+                        return req;
+                    });
+            }
+
+            private set
+            {
+                this.internalDataPrivate = value;
+            }
+        }
+
         /// <summary>
         /// Deeply clones a <see cref="DependencyTelemetry"/> object.
         /// </summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -115,8 +115,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.Success = source.Success;
             this.Data = source.Data;
             this.Target = source.Target;
-            this.Type = source.Type;
-            // other.ver = this.ver;
+            this.Type = source.Type;            
         }
 
         /// <inheritdoc />
@@ -354,6 +353,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
                         req.target = this.Target;
                         req.success = this.success;
                         req.data = this.Data;
+                        req.type = this.Type;
                         return req;
                     });
             }

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -108,22 +108,15 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.samplingPercentage = source.samplingPercentage;
             this.successFieldSet = source.successFieldSet;
             this.extension = source.extension?.DeepClone();
-
-            var other = new RemoteDependencyData();
-            other.ver = this.ver;
-            other.name = this.name;
-            other.id = this.id;
-            other.resultCode = this.resultCode;
-            other.duration = this.duration;
-            other.success = this.success;
-            other.data = this.data;
-            other.target = this.target;
-            other.type = this.type;
-            Debug.Assert(other.properties != null, "The constructor should have allocated properties dictionary");
-            Debug.Assert(other.measurements != null, "The constructor should have allocated the measurements dictionary");
-            Utils.CopyDictionary(this.properties, other.properties);
-            Utils.CopyDictionary(this.measurements, other.measurements);
-            return other;
+            this.Name = source.Name;
+            this.Id = source.Id;
+            this.ResultCode = source.ResultCode;
+            this.Duration = source.Duration;
+            this.Success = source.Success;
+            this.Data = source.Data;
+            this.Target = source.Target;
+            this.Type = source.Type;
+            // other.ver = this.ver;
         }
 
         /// <inheritdoc />

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -43,6 +43,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.Duration = TimeSpan.Zero;
             this.Target = string.Empty;
             this.Type = string.Empty;
+            this.Data = string.Empty;
         }
 
         /// <summary>
@@ -401,6 +402,9 @@ namespace Microsoft.ApplicationInsights.DataContracts
         /// <inheritdoc/>
         public override void SerializeData(ISerializationWriter serializationWriter)
         {
+            // To ensure that all changes to telemetry are reflected in serialization,
+            // the underlying field is set to null, which forces it to be re-created.
+            this.internalDataPrivate = null;
             serializationWriter.WriteProperty(this.InternalData);            
         }
 

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -420,6 +420,7 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.Type = this.Type.SanitizeDependencyType();
             this.Data = this.Data.SanitizeData();
             this.Properties.SanitizeProperties();
+            this.Metrics.SanitizeMeasurements();
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData.cs
@@ -13,23 +13,5 @@
 #endif
     internal partial class RemoteDependencyData
     {
-        public RemoteDependencyData DeepClone()
-        {
-            var other = new RemoteDependencyData();
-            other.ver = this.ver;
-            other.name = this.name;
-            other.id = this.id;
-            other.resultCode = this.resultCode;
-            other.duration = this.duration;
-            other.success = this.success;
-            other.data = this.data;
-            other.target = this.target;
-            other.type = this.type;
-            Debug.Assert(other.properties != null, "The constructor should have allocated properties dictionary");
-            Debug.Assert(other.measurements != null, "The constructor should have allocated the measurements dictionary");
-            Utils.CopyDictionary(this.properties, other.properties);
-            Utils.CopyDictionary(this.measurements, other.measurements);
-            return other;
-        }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_types.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_types.cs
@@ -105,7 +105,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
             
             target = "";
             type = "";
-            properties = new ConcurrentDictionary<string, string>();
+            
             
         }
     }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_typeslazy.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/RemoteDependencyData_typeslazy.cs
@@ -8,14 +8,12 @@
     /// </summary>
     internal partial class RemoteDependencyData
     {
-        private IDictionary<string, double> measurementsInternal;
-
 #pragma warning disable SA1300 // Element must begin with upper-case letter
         public IDictionary<string, double> measurements
 #pragma warning restore SA1300 // Element must begin with upper-case letter
         {
-            get { return System.Threading.LazyInitializer.EnsureInitialized(ref this.measurementsInternal, () => new ConcurrentDictionary<string, double>()); }
-            set { this.measurementsInternal = value; }
+            get;
+            set;
         }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.TelemetryHandler.cs
@@ -414,7 +414,11 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 if (this.EventSourceInternal.IsEnabled(EventLevel.Verbose, keywords))
                 {                    
                     var telemetryItem = item as DependencyTelemetry;
-                    CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
+                    if (item.Context.GlobalPropertiesValue != null)
+                    {
+                        Utils.CopyDictionary(item.Context.GlobalProperties, telemetryItem.Properties);
+                    }
+
                     item.Sanitize();
                     var data = telemetryItem.InternalData;
                     var extendedData = new

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/RichPayloadEventSource.cs
@@ -105,6 +105,9 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
                 }
 
                 var telemetryItem = item as DependencyTelemetry;
+                // Sanitize, Copying global properties is to be done before calling .InternalData,
+                // as InternalData returns a singleton instance, which won't be updated with changes made
+                // after .InternalData is called.
                 CopyGlobalPropertiesIfRequired(item, telemetryItem.Properties);
                 item.Sanitize();
                 this.WriteEvent(


### PR DESCRIPTION
Fix #1002
Similar to what is done for RequestTelemetry https://github.com/Microsoft/ApplicationInsights-dotnet/pull/970

The major change is avoiding creating the internal bond generated class until serialization time.
Also made the ConcurrentDictionary for Properties as lazy to help with performance.

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
