### PR TITLE
Perf fix for Metric.TryGetDataSeries by avoiding string computation except when require.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Fixed race condition in BroadcastProcessor which caused it to drop TelemetryItems](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/995)
 - [Custom Telemetry Item that implements ITelemetry is no longer dropped, bur rather serialized as EventTelemetry and handled by the channels accordingly](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/988)
 - [IExtension is now serialized into the Properties and Metrics](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1000)
+
 Perf Improvements.
 - [Improved Perf of ITelemetry JsonSerialization](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/997)
 - [Added new method on TelemetryClient to initialize just instrumentation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ Perf Improvements.
 - [RequestTelemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/969)
 - [RequestTelemetry modified to not service public fields with data class to avoid converting between types.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/965)
 - [Dependency Telemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1002)
-- [Dependency Telemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1002)
 - [Avoid string allocations in Metrics hot path](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1004)
 
 ## Version 2.8.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,16 +4,20 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 ## Version 2.9.0-beta1
 - [Remove unused reference to System.Web.Extensions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
-- [Added new method on TelemetryClient to initialize just instrumentation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
 - [PageViewTelemetry](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/8673ed1d15005713755e0bb9594acfe0ee00b869/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs) now supports [ISupportMetrics](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/39a5ef23d834777eefdd72149de705a016eb06b0/src/Microsoft.ApplicationInsights/DataContracts/ISupportMetrics.cs)
-- [RequestTelemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/969)
-- [RequestTelemetry modified to not service public fields with data class to avoid converting between types.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/965)
 - [Fixed a bug in TelemetryContext which prevented rawobject store to be not available in all sinks.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/974)
 - [Fixed a bug where TelemetryContext would have missing values on secondary sinks](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/993)
 - [Fixed race condition in BroadcastProcessor which caused it to drop TelemetryItems](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/995)
 - [Custom Telemetry Item that implements ITelemetry is no longer dropped, bur rather serialized as EventTelemetry and handled by the channels accordingly](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/988)
-- [Improved Perf of ITelemetry JsonSerialization](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/997)
 - [IExtension is now serialized into the Properties and Metrics](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1000)
+Perf Improvements.
+- [Improved Perf of ITelemetry JsonSerialization](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/997)
+- [Added new method on TelemetryClient to initialize just instrumentation. This is to be used by autocollectors to avoid calling TelemetryInitializers twice.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/966)
+- [RequestTelemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/969)
+- [RequestTelemetry modified to not service public fields with data class to avoid converting between types.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/965)
+- [Dependency Telemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1002)
+- [Dependency Telemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1002)
+- [Avoid string allocations in Metrics hot path](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1004)
 
 ## Version 2.8.1
 [Patch release addressing perf regression.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/952)

--- a/src/Microsoft.ApplicationInsights/Metric.cs
+++ b/src/Microsoft.ApplicationInsights/Metric.cs
@@ -210,10 +210,10 @@
         /// <c>False</c> if the indicated series could not be retrieved or created because a dimension cap or a metric series cap was reached.</returns>
         /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
         public bool TryGetDataSeries(
-                                out MetricSeries series, 
-                                string dimension1Value, 
-                                string dimension2Value, 
-                                string dimension3Value, 
+                                out MetricSeries series,
+                                string dimension1Value,
+                                string dimension2Value,
+                                string dimension3Value,
                                 string dimension4Value,
                                 string dimension5Value)
         {
@@ -276,11 +276,11 @@
             return this.TryGetDataSeries(
                             out series,
                             true,
-                            dimension1Value, 
-                            dimension2Value, 
-                            dimension3Value, 
-                            dimension4Value, 
-                            dimension5Value, 
+                            dimension1Value,
+                            dimension2Value,
+                            dimension3Value,
+                            dimension4Value,
+                            dimension5Value,
                             dimension6Value,
                             dimension7Value);
         }
@@ -447,7 +447,21 @@
 
             for (int d = 0; d < dimensionValues.Length; d++)
             {
-                Util.ValidateNotNullOrWhitespace(dimensionValues[d], Invariant($"{nameof(dimensionValues)}[{d}]"));
+                var value = dimensionValues[d];
+                if (value == null)
+                {
+                    throw new ArgumentNullException(Invariant($"{nameof(dimensionValues)}[{d}]"));
+                }
+
+                if (value.Length == 0)
+                {
+                    throw new ArgumentException(Invariant($"{nameof(dimensionValues)}[{d}]") + " may not be empty.");
+                }
+
+                if (String.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentException(Invariant($"{nameof(dimensionValues)}[{d}]") + " may not be whitespace only.");
+                }
             }
 
             MultidimensionalPointResult<MetricSeries> result = createIfNotExists
@@ -696,8 +710,8 @@
                                 double metricValue,
                                 string dimension1Value,
                                 string dimension2Value,
-                                string dimension3Value, 
-                                string dimension4Value, 
+                                string dimension3Value,
+                                string dimension4Value,
                                 string dimension5Value)
         {
             MetricSeries series;
@@ -838,12 +852,12 @@
         {
             MetricSeries series;
             bool canTrack = this.TryGetDataSeries(
-                                        out series, 
-                                        dimension1Value, 
-                                        dimension2Value, 
-                                        dimension3Value, 
-                                        dimension4Value, 
-                                        dimension5Value, 
+                                        out series,
+                                        dimension1Value,
+                                        dimension2Value,
+                                        dimension3Value,
+                                        dimension4Value,
+                                        dimension5Value,
                                         dimension6Value,
                                         dimension7Value);
             if (canTrack)
@@ -1197,7 +1211,7 @@
 
             return false;
         }
-       
+
         private static void EnsureConfigurationValid(
                                     int dimensionsCount,
                                     MetricConfiguration configuration)
@@ -1234,7 +1248,7 @@
         private MetricSeries CreateNewMetricSeries(string[] dimensionValues)
         {
             KeyValuePair<string, string>[] dimensionNamesAndValues = null;
-            
+
             if (dimensionValues != null)
             {
                 dimensionNamesAndValues = new KeyValuePair<string, string>[dimensionValues.Length];


### PR DESCRIPTION
Fix Issue #1004 
<Short description of the fix.>

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
