### PR TITLE
Fix dependency telemetry default ID being set to empty in ctor.

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -26,10 +26,11 @@
             Assert.IsNotNull(defaultDependencyTelemetry.Target);
             Assert.IsNotNull(defaultDependencyTelemetry.Name);
             Assert.IsNotNull(defaultDependencyTelemetry.Data);
-            Assert.IsNotNull(defaultDependencyTelemetry.ResultCode);
-            Assert.IsNotNull(defaultDependencyTelemetry.Id);
+            Assert.IsNotNull(defaultDependencyTelemetry.ResultCode);            
             Assert.IsNotNull(defaultDependencyTelemetry.Type);
-    }
+            Assert.IsNotNull(defaultDependencyTelemetry.Id);
+            Assert.IsTrue(defaultDependencyTelemetry.Id.Length >= 1);
+        }
 
         [TestMethod]
         public void DependencyTelemetryITelemetryContractConsistentlyWithOtherTelemetryTypes()

--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -38,7 +38,6 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.context = new TelemetryContext();
             this.GenerateId();
             this.Name = string.Empty;
-            this.Id = string.Empty;
             this.ResultCode = string.Empty;
             this.Duration = TimeSpan.Zero;
             this.Target = string.Empty;


### PR DESCRIPTION
Fix Issue # .
<Short description of the fix.>

- [ ] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
