### PR TITLE
Revert "Perf fix - return String.Empty for synthetic source, ip if they are Empty instead of returning nulls."

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,6 @@ Perf Improvements.
 - [RequestTelemetry modified to not service public fields with data class to avoid converting between types.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/965)
 - [Dependency Telemetry modified to lazily instantiate ConcurrentDictionary for Properties](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1002)
 - [Avoid string allocations in Metrics hot path](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1004)
-- [OperationContext's Synthetic Source field modified to return Empty string if empty instead of null.]
-- [LocaltionContext's IP field modified to return Empty string if empty instead of null.]
 
 ## Version 2.8.1
 [Patch release addressing perf regression.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/952)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/LocationContextTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/LocationContextTests.cs
@@ -23,15 +23,6 @@
         }
 
         [TestMethod]
-        public void IpIsEmptyIfSetToEmpty()
-        {
-            var location = new LocationContext();
-            location.Ip = string.Empty;
-            Assert.IsNotNull(location.Ip);
-            Assert.AreSame(string.Empty, location.Ip);
-        }
-
-        [TestMethod]
         public void IpCanBeChangedByUserToSpecifyACustomValue()
         {
             var context = new LocationContext();

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/OperationContextTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/OperationContextTest.cs
@@ -36,15 +36,6 @@
         }
 
         [TestMethod]
-        public void SyntheticSourceIsEmptyIfSetToEmpty()
-        {
-            var operation = new OperationContext();
-            operation.SyntheticSource = string.Empty;
-            Assert.IsNotNull(operation.SyntheticSource);
-            Assert.AreSame(string.Empty, operation.SyntheticSource);
-        }
-
-        [TestMethod]
         public void ParentIdIsNullByDefaultToAvoidSendingItToEndpointUnnecessarily()
         {
             var operation = new OperationContext();

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/LocationContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/LocationContext.cs
@@ -20,7 +20,7 @@
         /// </summary>
         public string Ip
         {
-            get { return this.ip; }
+            get { return string.IsNullOrEmpty(this.ip) ? null : this.ip; }
             set { this.ip = value; }
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationContext.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationContext.cs
@@ -62,7 +62,7 @@
         /// </summary>
         public string SyntheticSource
         {
-            get { return this.syntheticSource; }
+            get { return string.IsNullOrEmpty(this.syntheticSource) ? null : this.syntheticSource; }
             set { this.syntheticSource = value; }
         }
 


### PR DESCRIPTION
Reverts Microsoft/ApplicationInsights-dotnet#1007