### PR TITLE
Flatten Extension and unknown ITelemetry implementations in RichPayloadEventSource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.9.0-beta3
+- [Flatten IExtension and Unknown ITelemetry implementations for Rich Payload Event Source consumption](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1016)
+
 ## Version 2.9.0-beta2
 - [Remove unused reference to System.Web.Extensions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)
 - [PageViewTelemetry](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/8673ed1d15005713755e0bb9594acfe0ee00b869/src/Microsoft.ApplicationInsights/DataContracts/PageViewTelemetry.cs) now supports [ISupportMetrics](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/39a5ef23d834777eefdd72149de705a016eb06b0/src/Microsoft.ApplicationInsights/DataContracts/ISupportMetrics.cs)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.9.0-beta3
-- [Flatten IExtension and Unknown ITelemetry implementations for Rich Payload Event Source consumption](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1016)
+- [Flatten IExtension and Unknown ITelemetry implementations for Rich Payload Event Source consumption](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1017)
 
 ## Version 2.9.0-beta2
 - [Remove unused reference to System.Web.Extensions](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/956)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/JsonSerializerTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/JsonSerializerTest.cs
@@ -113,7 +113,7 @@
             TelemetryItem<EventTelemetry> data = obj.ToObject<TelemetryItem<EventTelemetry>>();
 
             Assert.AreEqual("Microsoft.ApplicationInsights.Event", data.name);
-            Assert.AreEqual(JsonSerializer.EventNameForUnknownTelemetry, data.data.baseData.Name);
+            Assert.AreEqual(Constants.EventNameForUnknownTelemetry, data.data.baseData.Name);
             Assert.AreEqual("testUser", data.tags["ai.user.id"]);
             Assert.IsTrue(DateTimeOffset.TryParse(data.time, out DateTimeOffset testResult));
             Assert.AreEqual(testTime, testResult);           

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -10,6 +10,7 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using System.Reflection;
     using System.Collections.ObjectModel;
+    using Microsoft.ApplicationInsights.TestFramework;
 
     /// <summary>
     /// Tests the rich payload event source tracking.
@@ -79,6 +80,19 @@
                 new EventTelemetry("TestEvent"),
                 typeof(External.EventData),
                 (client, item) => { client.TrackEvent((EventTelemetry)item); });
+        }
+
+        /// <summary>
+        /// Tests tracking unknown implementaiton of ITelemetry.
+        /// </summary>
+        [TestMethod]
+        public void RichPayloadEventSourceUnknownEventSentTest()
+        {
+            this.DoTracking(
+                RichPayloadEventSource.Keywords.Events,
+                new UnknownTelemetry() { Source = "source", Name = "name", ResponseCode = "200", Success = true }, // .NET 4.5 Event Source does not process empty values
+                typeof(External.EventData),
+                (client, item) => { client.Track((UnknownTelemetry)item); });
         }
 
         /// <summary>
@@ -424,13 +438,17 @@
                     item.Context.User.Id = "testUserId";
                     item.Context.Operation.Id = Guid.NewGuid().ToString();
 
+                    item.Extension = new MyTestExtension { myIntField = 42, myStringField = "value" };
+
                     track(client, item);
 
-#pragma warning disable CS0618 // Type or member is obsolete
-                    Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
-#pragma warning restore CS0618 // Type or member is obsolete
-
                     var actualEvent = listener.Messages.FirstOrDefault();
+#pragma warning disable CS0618 // Type or member is obsolete
+                    if (!(item is UnknownTelemetry)) // Global properties are copied directly into output properties for unknown telemetry
+                    {
+                        Assert.IsTrue(item.Context.Properties.ContainsKey("globalproperty1"), "Item Properties should contain the globalproperties as its copied before serialization");
+                    }
+#pragma warning restore CS0618 // Type or member is obsolete
 
                     Assert.IsNotNull(actualEvent);
                     Assert.AreEqual(client.InstrumentationKey, actualEvent.Payload[0]);
@@ -465,20 +483,43 @@
                     {
                         object[] properties = (object[])((IDictionary<string, object>)actualEvent.Payload[2])["properties"];
 #pragma warning disable CS0618 // Type or member is obsolete
-                        if (!(item is PerformanceCounterTelemetry))
+                        if (item is PerformanceCounterTelemetry)
 #pragma warning restore CS0618 // Type or member is obsolete
                         {
-                            // There should be 3 entries in properties
+                            // There should be 6 entries in properties
                             // 1. from item's ISupportProperties.Properties
                             // 2. from item context.GlobalProperties
-                            // 3. from item context.Properties                            
-                            Assert.AreEqual(3, properties.Length);                                                        
+                            // 3. from item context.Properties        
+                            // 4. from myInfField in item's Extension
+                            // 5. from myStringField in item's Extension
+                            // 6. PerfCounter name is a custom property.
+                            Assert.AreEqual(6, properties.Length);                                                        
+                        }
+                        else if (item is UnknownTelemetry)
+                        {
+                            // There should be 11 entries in properties, all fields are flattened into properties
+                            // 1. from item's ISupportProperties.Properties
+                            // 2. from item context.GlobalProperties
+                            // 3. from item context.Properties        
+                            // 4. from myInfField in item's Extension
+                            // 5. from myStringField in item's Extension
+                            // 6. Unknown Telemetry name.
+                            // 7. Unknown Telemetry id
+                            // 8. Unknown Telemetry responseCode
+                            // 9. Unknown Telemetry source
+                            // 10. Unknown Telemetry duration
+                            // 11. Unknown Telemetry success                            
+                            Assert.AreEqual(11, properties.Length);
                         }
                         else
                         {
-                            // There should be 4 entries in properties                            
-                            // 4. PerfCounter name is a custom property.
-                            Assert.AreEqual(4, properties.Length);
+                            // There should be 5 entries in properties
+                            // 1. from item's ISupportProperties.Properties
+                            // 2. from item context.GlobalProperties
+                            // 3. from item context.Properties        
+                            // 4. from myInfField in item's Extension
+                            // 5. from myStringField in item's Extension                            
+                            Assert.AreEqual(5, properties.Length);
                         }
                     }
 

--- a/src/Microsoft.ApplicationInsights/Constants.cs
+++ b/src/Microsoft.ApplicationInsights/Constants.cs
@@ -10,6 +10,8 @@
 
         internal const string DevModeTelemetryNamePrefix = "Microsoft.ApplicationInsights.Dev.";
 
+        internal const string EventNameForUnknownTelemetry = "ConvertedTelemetry";
+
         internal const int MaxExceptionCountToSave = 10;
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -19,8 +19,6 @@
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class JsonSerializer
     {
-        internal const string EventNameForUnknownTelemetry = "ConvertedTelemetry";
-
         private static readonly UTF8Encoding TransmissionEncoding = new UTF8Encoding(false);
 
         /// <summary>
@@ -209,7 +207,7 @@
             jsonSerializationWriter.WriteStartObject("baseData");
 
             jsonSerializationWriter.WriteProperty("ver", 2);
-            jsonSerializationWriter.WriteProperty("name", EventNameForUnknownTelemetry);
+            jsonSerializationWriter.WriteProperty("name", Constants.EventNameForUnknownTelemetry);
 
             jsonSerializationWriter.WriteProperty("properties", dictionarySerializationWriter.AccumulatedDictionary);
             jsonSerializationWriter.WriteProperty("measurements", dictionarySerializationWriter.AccumulatedMeasurements);


### PR DESCRIPTION
Addressing issues #1000 and #988 in Rich Payload Event Source serialization as well.

- [x] I ran [Unit Tests](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) locally.

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #1000 and #988
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [x] The PR will trigger build, unit test, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
