### PR TITLE
Extended SetParsedStack to handle stack traces of inner exceptions.

### DIFF
--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net45/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 Microsoft.ApplicationInsights.TelemetryClient.InitializeInstrumentationKey(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SetParsedStack(System.Diagnostics.StackFrame[] frames, int exceptionLevel) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 Microsoft.ApplicationInsights.TelemetryClient.InitializeInstrumentationKey(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SetParsedStack(System.Diagnostics.StackFrame[] frames, int exceptionLevel) -> void

--- a/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/PublicAPI/Microsoft.ApplicationInsights.dll/netstandard1.3/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 Microsoft.ApplicationInsights.TelemetryClient.InitializeInstrumentationKey(Microsoft.ApplicationInsights.Channel.ITelemetry telemetry) -> void
+Microsoft.ApplicationInsights.DataContracts.ExceptionTelemetry.SetParsedStack(System.Diagnostics.StackFrame[] frames, int exceptionLevel) -> void

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -93,7 +93,7 @@
             {
                 this.exception = source.Exception;
             }
-            
+
             this.extension = source.extension?.DeepClone();
         }
 
@@ -303,7 +303,7 @@
         {
             if (this.Exceptions != null && this.Exceptions.Count > 0)
             {
-                if(exceptionLevel < 0)
+                if (exceptionLevel < 0)
                 {
                     throw new ArgumentOutOfRangeException(nameof(exceptionLevel), exceptionLevel, "The exceptionLevel value must not be negative.");
                 }
@@ -342,7 +342,7 @@
         /// </summary>
         public void SetParsedStack(System.Diagnostics.StackFrame[] frames)
         {
-            SetParsedStack(frames, 0);
+            this.SetParsedStack(frames, 0);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -293,16 +293,19 @@
         /// <summary>
         /// Set parsedStack from an array of StackFrame objects.
         /// </summary>
-        public void SetParsedStack(System.Diagnostics.StackFrame[] frames)
+        /// <param name="frames">The new array of stack frames.</param>
+        /// <param name="exceptionLevel">Specifies which stack trace should be replaced.
+        /// 0 specifies top level exception, other value selects the respective inner exception.</param>
+        public void SetParsedStack(System.Diagnostics.StackFrame[] frames, int exceptionLevel)
         {
-            if (this.Exceptions != null && this.Exceptions.Count > 0)
+            if (this.Exceptions != null && this.Exceptions.Count > exceptionLevel)
             {
                 if (frames != null && frames.Length > 0)
                 {
                     int stackLength = 0;
 
-                    this.Exceptions[0].parsedStack = new List<Extensibility.Implementation.External.StackFrame>();
-                    this.Exceptions[0].hasFullStack = true;
+                    this.Exceptions[exceptionLevel].parsedStack = new List<Extensibility.Implementation.External.StackFrame>();
+                    this.Exceptions[exceptionLevel].hasFullStack = true;
 
                     for (int level = 0; level < frames.Length; level++)
                     {
@@ -312,14 +315,22 @@
 
                         if (stackLength > ExceptionConverter.MaxParsedStackLength)
                         {
-                            this.Exceptions[0].hasFullStack = false;
+                            this.Exceptions[exceptionLevel].hasFullStack = false;
                             break;
                         }
 
-                        this.Exceptions[0].parsedStack.Add(sf);
+                        this.Exceptions[exceptionLevel].parsedStack.Add(sf);
                     }
                 }
             }
+        }
+
+        /// <summary>
+        /// Set parsedStack from an array of StackFrame objects.
+        /// </summary>
+        public void SetParsedStack(System.Diagnostics.StackFrame[] frames)
+        {
+            SetParsedStack(frames, 0);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -298,8 +298,17 @@
         /// 0 specifies top level exception, other value selects the respective inner exception.</param>
         public void SetParsedStack(System.Diagnostics.StackFrame[] frames, int exceptionLevel)
         {
-            if (this.Exceptions != null && this.Exceptions.Count > exceptionLevel)
+            if (this.Exceptions != null && this.Exceptions.Count > 0)
             {
+                if(exceptionLevel < 0)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(exceptionLevel), exceptionLevel, "The exceptionLevel value must not be negative.");
+                }
+                else if (exceptionLevel >= this.Exceptions.Count)
+                {
+                    throw new ArgumentOutOfRangeException(nameof(exceptionLevel), exceptionLevel, $"The value of exceptionLevel {exceptionLevel} is not lower than {this.Exceptions.Count}.");
+                }
+
                 if (frames != null && frames.Length > 0)
                 {
                     int stackLength = 0;


### PR DESCRIPTION
Fix Issue Microsoft/ApplicationInsights-dotnet#1012.

The existing API allows to modify stack traces of logged exceptions in a very limited way. For example there's an option to replace the stack trace of the top level exception, but stack traces of inner exceptions cannot be modified at all. This simple change extends the existing SetParsedStack method to accept an additional parameter which specifies whether stack trace of the top most exception or it's selected inner exception should be replaced.

It would be nice to bring more of improvements described in dotnet/corefx#24627 but to do it a bigger change would be needed. Till then this modification should still help a lot.

