### PR TITLE
Replacing LicenseUrl property with license as it's deprecated

### DIFF
--- a/.vsts/linux-build.yml
+++ b/.vsts/linux-build.yml
@@ -27,7 +27,7 @@ steps:
 
 - task: DotNetCoreInstaller@0
   inputs:
-    version: $(DotNetVersion)
+    version: "1.1.5"
 
 - task: DotNetCoreCLI@1
   inputs:

--- a/.vsts/linux-build.yml
+++ b/.vsts/linux-build.yml
@@ -1,9 +1,12 @@
+variables:
+  DotNetVersion: "2.2.101"
+
 pool:
   vmImage: 'ubuntu-16.04'
 steps:
 - task: DotNetCoreInstaller@0
   inputs:
-    version: "2.0.3"
+    version: $(DotNetVersion)
 
 - task: DotNetCoreCLI@1
   inputs:
@@ -24,7 +27,7 @@ steps:
 
 - task: DotNetCoreInstaller@0
   inputs:
-    version: "1.1.5"
+    version: $(DotNetVersion)
 
 - task: DotNetCoreCLI@1
   inputs:

--- a/Nupkg.props
+++ b/Nupkg.props
@@ -15,7 +15,7 @@
     <Authors>Microsoft</Authors>
     <Owners>Microsoft,AppInsightsSdk</Owners>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://go.microsoft.com/fwlink/?LinkID=510709</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://go.microsoft.com/fwlink/?LinkId=392727</PackageProjectUrl>
     <PackageIconUrl>http://appanacdn.blob.core.windows.net/cdn/icons/aic.png</PackageIconUrl>
     <RepositoryUrl>https://github.com/Microsoft/ApplicationInsights-dotnet</RepositoryUrl>


### PR DESCRIPTION
Fix Issue #1036
LicenseUrl is deprecated. This has been replaced with license property.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.