### PR TITLE
Fix data losses in ServerTelemetryChannel.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@ This changelog will be used to generate documentation on [release notes page](ht
 
 ## Version 2.10.0-beta1
 - [Fix Transmission in NETCORE to handle partial success (206) response from backend.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1047)
-- InitialSamplingRate is now correctly applied if set in applicationInsights.config (https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1048)
+- [Fix data losses in ServerTelemetryChannel.](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1049)
+- [InitialSamplingRate is now correctly applied if set in applicationInsights.config] (https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1048)
 
 ## Version 2.9.0-beta3
 - [Flatten IExtension and Unknown ITelemetry implementations for Rich Payload Event Source consumption](https://github.com/Microsoft/ApplicationInsights-dotnet/pull/1017)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/TransmissionTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/TransmissionTest.cs
@@ -289,7 +289,7 @@
                 var handler = new HandlerForFakeHttpClient
                 {
                     InnerHandler = new HttpClientHandler(),
-                    OnSendAsync = async (req, cancellationToken) =>
+                    OnSendAsync = (req, cancellationToken) =>
                     {
                         throw new HttpRequestException();
                     }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/TransmissionTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/TransmissionTest.cs
@@ -250,28 +250,132 @@
                 }
             }
 
-            [TestMethod]
-            [Ignore("https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1049")]
+            [TestMethod]            
             public async Task SendAsyncHandlesTimeout()
             {
+                int clientTimeoutInMillisecs = 1;
+
+                //ARRANGE
                 var handler = new HandlerForFakeHttpClient
                 {
                     InnerHandler = new HttpClientHandler(),
                     OnSendAsync = async (req, cancellationToken) =>
                     {
+                        await Task.Delay(clientTimeoutInMillisecs + 10); // this ensures client timeout is hit.
                         return await Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
+                    }
+                };
+
+                using (var fakeHttpClient = new HttpClient())
+                {                    
+                    // Instantiate Transmission with the mock HttpClient and Timeout to be just 1 msec to force Timeout.
+                    Transmission transmission = new Transmission(new Uri("http://uri"), new byte[] { 1, 2, 3, 4, 5 }, fakeHttpClient, string.Empty, 
+                        string.Empty, TimeSpan.FromMilliseconds(clientTimeoutInMillisecs));
+
+                    // ACT
+                    HttpWebResponseWrapper result = await transmission.SendAsync();
+                    
+                    // VALIDATE
+                    Assert.IsNotNull(result);
+                    Assert.AreEqual((int) HttpStatusCode.RequestTimeout, result.StatusCode);
+                    Assert.IsNull(result.Content, "Content is not to be read except in partial response (206) status.");
+                }
+            }
+
+            [TestMethod]
+            public async Task SendAsyncPropogatesHttpRequestException()
+            {
+                //ARRANGE
+                var handler = new HandlerForFakeHttpClient
+                {
+                    InnerHandler = new HttpClientHandler(),
+                    OnSendAsync = async (req, cancellationToken) =>
+                    {
+                        throw new HttpRequestException();
                     }
                 };
 
                 using (var fakeHttpClient = new HttpClient())
                 {
                     // Instantiate Transmission with the mock HttpClient and Timeout to be just 1 msec to force Timeout.
-                    Transmission transmission = new Transmission(new Uri("http://uri"), new byte[] { 1, 2, 3, 4, 5 }, fakeHttpClient, string.Empty, 
-                        string.Empty, TimeSpan.FromMilliseconds(1));
+                    Transmission transmission = new Transmission(new Uri("http://uri"), new byte[] { 1, 2, 3, 4, 5 }, fakeHttpClient, string.Empty,
+                        string.Empty);
+
+                    // ACT & VALIDATE
+                    await AssertEx.ThrowsAsync<HttpRequestException>(() => transmission.SendAsync());
+                }
+            }
+
+            [TestMethod]
+            public async Task SendAsyncReturnsCorrectHttpResponseWrapperWhenNoExceptionOccurs()
+            {
+                // HttpClient.SendAsync throws HttpRequestException only on the following scenarios:
+                // "The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout."
+                // For every other case, a response is returned, and we expect Transmission.SendAsync to properly return HttpWebResponseWrapper.                
+
+                // ARRANGE
+                var handler = new HandlerForFakeHttpClient
+                {
+                    InnerHandler = new HttpClientHandler(),
+                    OnSendAsync = (req, cancellationToken) =>
+                    {
+                        HttpResponseMessage response = new HttpResponseMessage();
+                        response.StatusCode = HttpStatusCode.ServiceUnavailable;
+                        return Task.FromResult<HttpResponseMessage>(response);
+                    }
+                };
+
+                using (var fakeHttpClient = new HttpClient(handler))
+                {
+                    // Instantiate Transmission with the mock HttpClient
+                    Transmission transmission = new Transmission(new Uri("http://uri"), new byte[] { 1, 2, 3, 4, 5 }, fakeHttpClient, string.Empty, string.Empty);
 
                     // ACT
                     HttpWebResponseWrapper result = await transmission.SendAsync();
+
+                    // VALIDATE
+                    Assert.IsNotNull(result);
+                    Assert.AreEqual(503, result.StatusCode);
+                    Assert.IsNull(result.Content, "Content is not to be read except in partial response (206) status.");
                 }
+                  
+            }
+
+            [TestMethod]
+            public async Task SendAsyncReturnsCorrectHttpResponseWrapperWithRetryHeaderWhenNoExceptionOccur()
+            {
+                // HttpClient.SendAsync throws HttpRequestException only on the following scenarios:
+                // "The request failed due to an underlying issue such as network connectivity, DNS failure, server certificate validation or timeout."
+                // For every other case, a response is returned, and we expect Transmission.SendAsync to properly return HttpWebResponseWrapper.                
+
+                // ARRANGE
+                var handler = new HandlerForFakeHttpClient
+                {
+                    InnerHandler = new HttpClientHandler(),
+                    OnSendAsync = (req, cancellationToken) =>
+                    {
+                        HttpResponseMessage response = new HttpResponseMessage();
+                        response.StatusCode = HttpStatusCode.ServiceUnavailable;
+                        response.Headers.RetryAfter = new RetryConditionHeaderValue(TimeSpan.FromSeconds(5));
+                        return Task.FromResult<HttpResponseMessage>(response);
+                    }
+                };
+
+                using (var fakeHttpClient = new HttpClient(handler))
+                {
+                    // Instantiate Transmission with the mock HttpClient
+                    Transmission transmission = new Transmission(new Uri("http://uri"), new byte[] { 1, 2, 3, 4, 5 }, fakeHttpClient, string.Empty, string.Empty);
+
+                    // ACT
+                    HttpWebResponseWrapper result = await transmission.SendAsync();
+
+                    // VALIDATE
+                    Assert.IsNotNull(result);
+                    Assert.AreEqual(503, result.StatusCode);
+                    Assert.AreEqual("5", result.RetryAfterHeader);
+                    Assert.IsNull(result.Content, "Content is not to be read except in partial response (206) status.");
+                }
+
             }
         }
     }

--- a/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
+++ b/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
@@ -15,7 +15,7 @@
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.NetCore20.Tests</AssemblyName>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP2_0</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
+++ b/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
@@ -15,7 +15,7 @@
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.NetCore20.Tests</AssemblyName>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
+    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
+++ b/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
@@ -21,6 +21,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.3.2" />

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0
+﻿#if !NETCOREAPP1_1 && !NET45
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETCOREAPP2_0
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Helpers
+{
+    public sealed class LocalInProcHttpServer : IDisposable
+    {
+        private readonly IWebHost host;
+        private readonly CancellationTokenSource cts;
+
+        public RequestDelegate ServerLogic;
+
+        public LocalInProcHttpServer(string url)
+        {
+            this.cts = new CancellationTokenSource();
+            this.host = new WebHostBuilder()
+                .UseKestrel()
+                .UseUrls(url)
+                .Configure(
+                (app) =>
+                {
+                    app.Run(ServerLogic);
+                }
+                )
+                .Build();
+
+            Task.Run(() => this.host.RunAsync(this.cts.Token));
+        }
+
+        public void Dispose()
+        {
+            this.cts.Cancel(false);
+            try
+            {
+                this.host.Dispose();
+            }
+            catch (Exception)
+            {
+            }
+        }
+    }
+
+}

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,8 +1,11 @@
-﻿using System;
+﻿using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using System;
 using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.AspNetCore.Builder;
 
 namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Helpers
 {

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_1 && !NET45
+﻿#if NETCOREAPP2_0
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;
@@ -17,9 +17,10 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Helpers
 
         public RequestDelegate ServerLogic;
 
-        public LocalInProcHttpServer(string url)
+        public LocalInProcHttpServer(string url, RequestDelegate serverLogic = null)
         {
             this.cts = new CancellationTokenSource();
+            this.ServerLogic = serverLogic;
             this.host = new WebHostBuilder()
                 .UseKestrel()
                 .UseUrls(url)

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,4 +1,5 @@
-﻿using Microsoft.AspNetCore.Hosting;
+﻿#if NETSTANDARD2_0
+using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;
 using System.Collections.Generic;
@@ -47,3 +48,4 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Helpers
     }
 
 }
+#endif

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/ErrorHandlingTransmissionPolicyTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/ErrorHandlingTransmissionPolicyTest.cs
@@ -137,8 +137,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implement
                 };
 
                 var policy = new ErrorHandlingTransmissionPolicy();
-                policy.Initialize(transmitter);
-
+                policy.Initialize(transmitter);                
                 var failedTransmission = new StubTransmission();
                 transmitter.OnTransmissionSent(new TransmissionProcessedEventArgs(failedTransmission, new Exception("Error"), new HttpWebResponseWrapper() { StatusCode = ResponseStatusCodes.InternalServerError }));
                 transmitter.OnTransmissionSent(new TransmissionProcessedEventArgs(failedTransmission, new Exception("Error"), new HttpWebResponseWrapper() { StatusCode = ResponseStatusCodes.InternalServerError }));

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -1,0 +1,24 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.Channel
+{
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Threading;
+
+    [TestClass]
+    public class ServerTelemetryChannelE2ETests
+    {        
+        [TestMethod]
+        public void InitializesTransmitterWithNetworkAvailabilityPolicy()
+        {
+
+            var channel = new ServerTelemetryChannel();
+            var config = new TelemetryConfiguration("dummy");
+
+            channel.Initialize(config);
+            Thread.Sleep(50);
+
+            Assert.AreEqual(0, channel.Transmitter.Sender.Capacity);
+        }
+    }
+}

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_0
+﻿#if !NETCOREAPP1_1 && !NET45
 namespace Microsoft.ApplicationInsights.WindowsServer.Channel
 {    
     using System.Collections.Generic;

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD2_0
+﻿#if NETSTANDARD2_0
 namespace Microsoft.ApplicationInsights.WindowsServer.Channel
 {    
     using System.Collections.Generic;

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -28,6 +28,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
         private const int SleepInMilliseconds = 10000;
 
         [TestMethod]
+        [Ignore("Ignored as unstable in Test/Build machines. Run locally when making changes to ServerChannel")]
         public void ChannelSendsTransmission()
         {
             using (var localServer = new LocalInProcHttpServer(Localurl))
@@ -65,6 +66,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
         }
 
         [TestMethod]
+        [Ignore("Ignored as unstable in Test/Build machines. Run locally when making changes to ServerChannel")]
         public void ChannelLogsSuccessfulTransmission()
         {
             using (var localServer = new LocalInProcHttpServer(Localurl))
@@ -108,6 +110,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
         }
 
         [TestMethod]
+        [Ignore("Ignored as unstable in Test/Build machines. Run locally when making changes to ServerChannel")]
         public void ChannelLogsFailedTransmissionDueToServerError()
         {
             using (var localServer = new LocalInProcHttpServer(Localurl))
@@ -155,6 +158,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
         }
 
         [TestMethod]
+        [Ignore("Ignored as unstable in Test/Build machines. Run locally when making changes to ServerChannel")]
         public void ChannelHandlesFailedTransmissionDueToUnknownNetworkError()
         {
             using (var localServer = new LocalInProcHttpServer(Localurl))
@@ -198,6 +202,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
         }
 
         [TestMethod]
+        [Ignore("Ignored as unstable in Test/Build machines. Run locally when making changes to ServerChannel")]
         public void ChannelLogsResponseBodyFromTransmissionWhenVerboseEnabled()
         {
             var expectedResponseContents = "this is the expected response";

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -1,4 +1,4 @@
-﻿#if !NETCOREAPP1_1 && !NET45
+﻿#if NETCOREAPP2_0
 namespace Microsoft.ApplicationInsights.WindowsServer.Channel
 {    
     using System.Collections.Generic;
@@ -25,6 +25,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
         private const string Localurl = "http://localhost:6090";
         private const string LocalurlNotRunning = "http://localhost:6091";
         private const long AllKeywords = -1;
+        private const int SleepInMilliseconds = 10000;
 
         [TestMethod]
         public void ChannelSendsTransmission()
@@ -32,7 +33,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
             using (var localServer = new LocalInProcHttpServer(Localurl))
             {
                 IList<ITelemetry> telemetryItems = new List<ITelemetry>();
-                var telemetry = new EventTelemetry("test event name");
+                var telemetry = new EventTelemetry("test event name");    
                 telemetry.Context.InstrumentationKey = "dummy";
                 telemetryItems.Add((telemetry));
                 var serializedExpected = JsonSerializer.Serialize(telemetryItems);
@@ -94,11 +95,11 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
                     var telemetry = new EventTelemetry("test event name");
                     telemetry.Context.InstrumentationKey = "dummy";
                     channel.Send(telemetry);
-                    Thread.Sleep(5000);
+                    Thread.Sleep(SleepInMilliseconds);
 
                     // VERIFY
                     // We validate by checking SDK traces.
-                    var allTraces = listener.Messages.ToList();
+                    var allTraces = listener.Messages.ToList();    
                     // Event 22 is logged upon successful transmission.
                     var traces = allTraces.Where(item => item.EventId == 22).ToList();
                     Assert.AreEqual(1, traces.Count);                    
@@ -138,7 +139,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
                     var telemetry = new EventTelemetry("test event name");
                     telemetry.Context.InstrumentationKey = "dummy";
                     channel.Send(telemetry);
-                    Thread.Sleep(1000);
+                    Thread.Sleep(SleepInMilliseconds);
 
                     // VERIFY
                     // We validate by checking SDK traces
@@ -185,7 +186,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
                     var telemetry = new EventTelemetry("test event name");
                     telemetry.Context.InstrumentationKey = "dummy";
                     channel.Send(telemetry);
-                    Thread.Sleep(5000);
+                    Thread.Sleep(SleepInMilliseconds);
 
                     // Assert:
                     var allTraces = listener.Messages.ToList();
@@ -236,7 +237,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
                         var telemetry = new EventTelemetry("test event name");
                         telemetry.Context.InstrumentationKey = "dummy";
                         channel.Send(telemetry);
-                        Thread.Sleep(5000);
+                        Thread.Sleep(SleepInMilliseconds);
                     }
 
                     // Assert:

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -94,7 +94,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
                     var telemetry = new EventTelemetry("test event name");
                     telemetry.Context.InstrumentationKey = "dummy";
                     channel.Send(telemetry);
-                    Thread.Sleep(1000);
+                    Thread.Sleep(5000);
 
                     // VERIFY
                     // We validate by checking SDK traces.
@@ -236,7 +236,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.Channel
                         var telemetry = new EventTelemetry("test event name");
                         telemetry.Context.InstrumentationKey = "dummy";
                         channel.Send(telemetry);
-                        Thread.Sleep(1000);
+                        Thread.Sleep(5000);
                     }
 
                     // Assert:

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -1,24 +1,252 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.Channel
-{
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;
-    using Microsoft.VisualStudio.TestTools.UnitTesting;
+﻿#if !NETSTANDARD2_0
+namespace Microsoft.ApplicationInsights.WindowsServer.Channel
+{    
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;    
+    using System.Linq;
+    using System.Net;
     using System.Threading;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;        
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.TestFramework;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel;    
+    using Microsoft.ApplicationInsights.WindowsServer.Channel.Helpers;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;    
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
 
-    [TestClass]
+
+    [TestClass]      
     public class ServerTelemetryChannelE2ETests
-    {        
+    {
+        private const string Localurl = "http://localhost:6090";
+        private const string LocalurlNotRunning = "http://localhost:6091";
+        private const long AllKeywords = -1;
+
         [TestMethod]
-        public void InitializesTransmitterWithNetworkAvailabilityPolicy()
+        public void ChannelSendsTransmission()
         {
+            using (var localServer = new LocalInProcHttpServer(Localurl))
+            {
+                IList<ITelemetry> telemetryItems = new List<ITelemetry>();
+                var telemetry = new EventTelemetry("test event name");
+                telemetry.Context.InstrumentationKey = "dummy";
+                telemetryItems.Add((telemetry));
+                var serializedExpected = JsonSerializer.Serialize(telemetryItems);
 
-            var channel = new ServerTelemetryChannel();
-            var config = new TelemetryConfiguration("dummy");
+                localServer.ServerLogic = async (ctx) =>
+                {
+                    byte[] buffer = new byte[2000];
+                    await ctx.Request.Body.ReadAsync(buffer, 0, 2000);     
+                    Assert.AreEqual(serializedExpected, buffer);
+                    await ctx.Response.WriteAsync("Ok");
+                };
 
-            channel.Initialize(config);
-            Thread.Sleep(50);
+                var channel = new ServerTelemetryChannel
+                {
+                    DeveloperMode = true,
+                    EndpointAddress = Localurl
+                };
 
-            Assert.AreEqual(0, channel.Transmitter.Sender.Capacity);
+                var config = new TelemetryConfiguration("dummy")
+                {
+                    TelemetryChannel = channel
+                };
+                channel.Initialize(config);
+
+                // ACT 
+                // Data would be sent to the LocalServer which validates it.
+                channel.Send(telemetry);                    
+            }
+        }
+
+        [TestMethod]
+        public void ChannelLogsSuccessfulTransmission()
+        {
+            using (var localServer = new LocalInProcHttpServer(Localurl))
+            {                
+                localServer.ServerLogic = async (ctx) =>
+                {
+                    // Success from AI Backend.
+                    await ctx.Response.WriteAsync("Ok");
+                };
+
+                var channel = new ServerTelemetryChannel
+                {
+                    DeveloperMode = true,
+                    EndpointAddress = Localurl
+                };
+                var config = new TelemetryConfiguration("dummy")
+                {
+                    TelemetryChannel = channel
+                };
+                channel.Initialize(config);
+
+                using (var listener = new TestEventListener())
+                {
+                    listener.EnableEvents(TelemetryChannelEventSource.Log, EventLevel.LogAlways,
+                        (EventKeywords) AllKeywords);
+
+                    // ACT
+                    var telemetry = new EventTelemetry("test event name");
+                    telemetry.Context.InstrumentationKey = "dummy";
+                    channel.Send(telemetry);
+                    Thread.Sleep(1000);
+
+                    // VERIFY
+                    // We validate by checking SDK traces.
+                    var allTraces = listener.Messages.ToList();
+                    // Event 22 is logged upon successful transmission.
+                    var traces = allTraces.Where(item => item.EventId == 22).ToList();
+                    Assert.AreEqual(1, traces.Count);                    
+                }
+            }            
+        }
+
+        [TestMethod]
+        public void ChannelLogsFailedTransmissionDueToServerError()
+        {
+            using (var localServer = new LocalInProcHttpServer(Localurl))
+            {                
+                localServer.ServerLogic = async (ctx) =>
+                {
+                    // Error from AI Backend.
+                    ctx.Response.StatusCode = (int) HttpStatusCode.InternalServerError;
+                    await ctx.Response.WriteAsync("InternalError");
+                };
+
+                var channel = new ServerTelemetryChannel
+                {
+                    DeveloperMode = true,
+                    EndpointAddress = Localurl
+                };
+                var config = new TelemetryConfiguration("dummy")
+                {
+                    TelemetryChannel = channel
+                };
+                channel.Initialize(config);
+
+                using (var listener = new TestEventListener())
+                {
+                    listener.EnableEvents(TelemetryChannelEventSource.Log, EventLevel.LogAlways,
+                        (EventKeywords)AllKeywords);
+
+                    // ACT
+                    var telemetry = new EventTelemetry("test event name");
+                    telemetry.Context.InstrumentationKey = "dummy";
+                    channel.Send(telemetry);
+                    Thread.Sleep(1000);
+
+                    // VERIFY
+                    // We validate by checking SDK traces
+                    var allTraces = listener.Messages.ToList();
+                    
+                    // Event 54 is logged upon successful transmission.
+                    var traces = allTraces.Where(item => item.EventId == 54).ToList();
+                    Assert.AreEqual(1, traces.Count);
+                    // 500 is the response code.
+                    Assert.AreEqual("500", traces[0].Payload[1]);
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ChannelHandlesFailedTransmissionDueToUnknownNetworkError()
+        {
+            using (var localServer = new LocalInProcHttpServer(Localurl))
+            {
+                localServer.ServerLogic = async (ctx) =>
+                {
+                    // This code does not matter as Channel is configured to 
+                   // with an incorrect endpoint.
+                    await ctx.Response.WriteAsync("InternalError");
+                };
+
+                var channel = new ServerTelemetryChannel
+                {
+                    DeveloperMode = true,
+                    EndpointAddress = LocalurlNotRunning
+                };
+                var config = new TelemetryConfiguration("dummy")
+                {
+                    TelemetryChannel = channel
+                };
+                channel.Initialize(config);
+
+                using (var listener = new TestEventListener())
+                {
+                    listener.EnableEvents(TelemetryChannelEventSource.Log, EventLevel.LogAlways,
+                        (EventKeywords)AllKeywords);
+
+                    // ACT
+                    var telemetry = new EventTelemetry("test event name");
+                    telemetry.Context.InstrumentationKey = "dummy";
+                    channel.Send(telemetry);
+                    Thread.Sleep(5000);
+
+                    // Assert:
+                    var allTraces = listener.Messages.ToList();
+                    var traces = allTraces.Where(item => item.EventId == 54).ToList();
+                    Assert.AreEqual(1, traces.Count);
+                    Assert.IsTrue(traces[0].Payload[1].ToString().Contains("An error occurred while sending the request"));
+                }
+            }
+        }
+
+        [TestMethod]
+        public void ChannelLogsResponseBodyFromTransmissionWhenVerboseEnabled()
+        {
+            var expectedResponseContents = "this is the expected response";
+
+            using (var localServer = new LocalInProcHttpServer(Localurl))
+            {
+                localServer.ServerLogic = async (ctx) =>
+                {                                        
+                    await ctx.Response.WriteAsync(expectedResponseContents);
+                };
+
+                var channel = new ServerTelemetryChannel
+                {
+                    DeveloperMode = true,
+                    EndpointAddress = Localurl
+                };
+                var config = new TelemetryConfiguration("dummy")
+                {
+                    TelemetryChannel = channel
+                };
+                channel.Initialize(config);
+
+                using (var listener = new TestEventListener())
+                {
+                    listener.EnableEvents(TelemetryChannelEventSource.Log, EventLevel.LogAlways,
+                        (EventKeywords)AllKeywords);
+
+                    // Enable CoreEventSource as Transmission logic is in base sdk.
+                    // and it'll parse response only on Verbose enabled.
+                    using (var listenerCore = new TestEventListener())
+                    {
+                        listener.EnableEvents(CoreEventSource.Log, EventLevel.LogAlways,
+                            (EventKeywords) AllKeywords);
+
+
+                        // ACT
+                        var telemetry = new EventTelemetry("test event name");
+                        telemetry.Context.InstrumentationKey = "dummy";
+                        channel.Send(telemetry);
+                        Thread.Sleep(1000);
+                    }
+
+                    // Assert:
+                    var allTraces = listener.Messages.ToList();
+                    var traces = allTraces.Where(item => item.EventId == 70).ToList();
+                    Assert.AreEqual(1, traces.Count);
+                    Assert.IsTrue(traces[0].Payload[1].ToString().Contains(expectedResponseContents));
+                }
+            }
         }
     }
 }
+#endif

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/ServerTelemetryChannelE2ETests.cs
@@ -1,4 +1,4 @@
-﻿#if NETSTANDARD2_0
+﻿#if NETCOREAPP2_0
 namespace Microsoft.ApplicationInsights.WindowsServer.Channel
 {    
     using System.Collections.Generic;

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\BackendResponseHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\DirectoryAccessDenier.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\FileAccessDenier.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Helpers\LocalInProcHttpServer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubApplicationFolderProvider.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubApplicationLifecycle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\StubNetwork.cs" />
@@ -53,11 +54,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\TransmitterTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\WeakConcurrentRandomTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SamplingTelemetryProcessorTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ServerTelemetryChannelE2ETests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ServerTelemetryChannelTest.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\PlatformFolderTest.cs"/>
-    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ApplicationFolderProviderTest.cs"/>
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\PlatformFolderTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\ApplicationFolderProviderTest.cs" />
   </ItemGroup>
-
   <PropertyGroup>
     <IsNetCoreBuild Condition="'$(TargetFramework)' == 'netcoreapp1.1'">True</IsNetCoreBuild>
     <IsNetCoreBuild Condition="'$(TargetFramework)' == 'netcoreapp2.0'">True</IsNetCoreBuild>

--- a/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -16,7 +16,6 @@
     /// </summary>
     public class Transmission
     {
-        internal const string ContentTypeHeader = "Content-Type";
         internal const string ContentEncodingHeader = "Content-Encoding";
 
         private static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(100);
@@ -29,24 +28,9 @@
         /// </summary>
         public Transmission(Uri address, byte[] content, string contentType, string contentEncoding, TimeSpan timeout = default(TimeSpan))
         {
-            if (address == null)
-            {
-                throw new ArgumentNullException(nameof(address));
-            }
-
-            if (content == null)
-            {
-                throw new ArgumentNullException(nameof(content));
-            }
-
-            if (contentType == null)
-            {
-                throw new ArgumentNullException(nameof(contentType));
-            }
-
-            this.EndpointAddress = address;
-            this.Content = content;
-            this.ContentType = contentType;
+            this.EndpointAddress = address ?? throw new ArgumentNullException(nameof(address));
+            this.Content = content ?? throw new ArgumentNullException(nameof(content));
+            this.ContentType = contentType ?? throw new ArgumentNullException(nameof(contentType));
             this.ContentEncoding = contentEncoding;
             this.Timeout = timeout == default(TimeSpan) ? DefaultTimeout : timeout;
             this.Id = Convert.ToBase64String(BitConverter.GetBytes(WeakConcurrentRandom.Instance.Next()));
@@ -197,6 +181,7 @@
 
                                     if (CoreEventSource.IsVerboseEnabled)
                                     {
+                                        // Read the entire response body only on VerboseTracing for perf reasons.
                                         try
                                         {
                                             if (response.Content != null)

--- a/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -175,11 +175,13 @@
                                     {
                                         if (response.Content != null)
                                         {
+                                            // Read the entire response body only on PartialContent for perf reasons.
+                                            // This cannot be avoided as response tells which items are to be resubmitted.
                                             wrapper.Content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                                         }
                                     }
 
-                                    if (CoreEventSource.IsVerboseEnabled)
+                                    if (CoreEventSource.IsVerboseEnabled && response.StatusCode != HttpStatusCode.PartialContent)
                                     {
                                         // Read the entire response body only on VerboseTracing for perf reasons.
                                         try

--- a/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -189,7 +189,7 @@
                                                 wrapper.Content = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
                                             }
                                         }
-                                        catch(Exception)
+                                        catch (Exception)
                                         {
                                             // Swallow any exception here as this code is for tracing purposes only and should never throw.
                                         }
@@ -198,11 +198,11 @@
                             }
                         }
                     }
-                    catch(TaskCanceledException)
+                    catch (TaskCanceledException)
                     {                        
                         wrapper = new HttpWebResponseWrapper
                         {
-                            StatusCode = (int) HttpStatusCode.RequestTimeout
+                            StatusCode = (int)HttpStatusCode.RequestTimeout
                         };
                     }
 
@@ -214,7 +214,6 @@
                 Interlocked.Exchange(ref this.isSending, 0);
             }
         }
-
 
         /// <summary>
         /// Splits the Transmission object into two pieces using a method 

--- a/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -102,12 +102,12 @@
                 // We got unknown exception. 
                 if (e.Exception != null)
                 {
-                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(e.Transmission.Id,
+                    TelemetryChannelEventSource.Log.TransmissionDataLossWarning(e.Transmission.Id,
                         e.Exception.Message);
                 }
                 else
                 {
-                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(e.Transmission.Id,
+                    TelemetryChannelEventSource.Log.TransmissionDataLossWarning(e.Transmission.Id,
                         "Unknown Exception Message");
                 }
             }

--- a/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -57,6 +57,7 @@
                 }
             }
         }
+
         private void HandleTransmissionSentEvent(object sender, TransmissionProcessedEventArgs e)
         {
             HttpWebResponseWrapper httpWebResponseWrapper = e.Response;
@@ -100,9 +101,15 @@
                 // We are loosing data here (we did not upload failed transaction back).
                 // We got unknown exception. 
                 if (e.Exception != null)
-                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(e.Transmission.Id, e.Exception.Message);
+                {
+                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(e.Transmission.Id,
+                        e.Exception.Message);
+                }
                 else
-                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(e.Transmission.Id, "Unknown Exception Message");
+                {
+                    TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(e.Transmission.Id,
+                        "Unknown Exception Message");
+                }
             }
         }
 

--- a/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -1,9 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
-    using System.IO;
-    using System.Net;
-    using System.Net.Http;
     using System.Globalization;
     using System.Threading.Tasks;
     using ApplicationInsights.Channel.Implementation;

--- a/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -1,11 +1,10 @@
-﻿using System.Globalization;
-
-namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
     using System.IO;
     using System.Net;
     using System.Net.Http;
+    using System.Globalization;
     using System.Threading.Tasks;
     using ApplicationInsights.Channel.Implementation;
     using Extensibility.Implementation;

--- a/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -94,7 +94,7 @@
                            });
                         break;
                     default:                        
-                        // We are loosing data here but that is intentional as the response code is
+                        // We are losing data here but that is intentional as the response code is
                         // not in the whitelisted set to attempt retry.
                         TelemetryChannelEventSource.Log.TransmissionDataNotRetriedForNonWhitelistedResponse(e.Transmission.Id,
                             httpWebResponseWrapper.StatusCode.ToString(CultureInfo.InvariantCulture));
@@ -104,7 +104,7 @@
             else
             {
                 // Data loss Unknown Exception
-                // We are loosing data here (we did not upload failed transaction back).
+                // We are losing data here (we did not upload failed transaction back).
                 // We got unknown exception. 
                 if (e.Exception != null)
                 {                    

--- a/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/ErrorHandlingTransmissionPolicy.cs
@@ -66,6 +66,7 @@
                 AdditionalVerboseTracing(httpWebResponseWrapper.Content);
                 switch (httpWebResponseWrapper.StatusCode)
                 {
+                    //TODO handle 502,503,504
                     case ResponseStatusCodes.RequestTimeout:
                     case ResponseStatusCodes.ServiceUnavailable:
                     case ResponseStatusCodes.InternalServerError:
@@ -101,7 +102,7 @@
                 // We are loosing data here (we did not upload failed transaction back).
                 // We got unknown exception. 
                 if (e.Exception != null)
-                {
+                {                    
                     TelemetryChannelEventSource.Log.TransmissionDataLossWarning(e.Transmission.Id,
                         e.Exception.Message);
                 }

--- a/src/ServerTelemetryChannel/Implementation/ResponseStatusCodes.cs
+++ b/src/ServerTelemetryChannel/Implementation/ResponseStatusCodes.cs
@@ -9,6 +9,8 @@
         public const int ResponseCodeTooManyRequests = 429;
         public const int ResponseCodeTooManyRequestsOverExtendedTime = 439;
         public const int InternalServerError = 500;
+        public const int BadGateway = 502;
         public const int ServiceUnavailable = 503;
+        public const int GatewayTimeout = 504;
     }
 }

--- a/src/ServerTelemetryChannel/Implementation/ResponseStatusCodes.cs
+++ b/src/ServerTelemetryChannel/Implementation/ResponseStatusCodes.cs
@@ -5,6 +5,7 @@
         public const int Success = 200;
         public const int PartialSuccess = 206;
         public const int RequestTimeout = 408;
+        public const int UnknownNetworkError = 999;
         public const int ResponseCodeTooManyRequests = 429;
         public const int ResponseCodeTooManyRequestsOverExtendedTime = 439;
         public const int InternalServerError = 500;

--- a/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -489,6 +489,26 @@
             this.WriteEvent(68, directory, error, this.ApplicationName);
         }
 
+        [Event(69, Message = "TransmissionDataLossWarning. Telemetry items are being lost here due to unknown error. TransmissionId: {0}. Error Message: {1}.", Level = EventLevel.Warning)]
+        public void TransmissionDataLossWarning(string transmissionId, string message, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                54,
+                transmissionId ?? string.Empty,
+                message ?? string.Empty,
+                this.ApplicationName);
+        }
+
+        [Event(70, Message = "Raw response content from AI Backend for Transmission Id {0} : {1}.", Level = EventLevel.Verbose)]
+        public void RawResponseFromAIBackend(string transmissionId, string message, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                70,
+                transmissionId ?? string.Empty,
+                message ?? string.Empty,
+                this.ApplicationName);
+        }
+
         private static string GetApplicationName()
         {
             //// We want to add application name to all events BUT

--- a/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -489,8 +489,8 @@
             this.WriteEvent(68, directory, error, this.ApplicationName);
         }
 
-        [Event(69, Message = "TransmissionDataLossWarning. Telemetry items are being lost here due to unknown error. TransmissionId: {0}. Error Message: {1}.", Level = EventLevel.Error)]
-        public void TransmissionDataLossWarning(string transmissionId, string message, string appDomainName = "Incorrect")
+        [Event(69, Message = "TransmissionDataLossError. Telemetry items are being lost here due to unknown error. TransmissionId: {0}. Error Message: {1}.", Level = EventLevel.Error)]
+        public void TransmissionDataLossError(string transmissionId, string message, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 69,
@@ -506,6 +506,17 @@
                 70,
                 transmissionId ?? string.Empty,
                 message ?? string.Empty,
+                this.ApplicationName);
+        }
+
+        [Event(71, Message = "TransmissionDataLossError. Telemetry items are being lost here as the response code is not in the whitelisted set of retriable codes." +
+                             "TransmissionId: {0}. Status Code: {1}.", Level = EventLevel.Warning)]
+        public void TransmissionDataNotRetriedForNonWhitelistedResponse(string transmissionId, string status, string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(
+                71,
+                transmissionId ?? string.Empty,
+                status ?? string.Empty,
                 this.ApplicationName);
         }
 

--- a/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -489,7 +489,7 @@
             this.WriteEvent(68, directory, error, this.ApplicationName);
         }
 
-        [Event(69, Message = "TransmissionDataLossWarning. Telemetry items are being lost here due to unknown error. TransmissionId: {0}. Error Message: {1}.", Level = EventLevel.Warning)]
+        [Event(69, Message = "TransmissionDataLossWarning. Telemetry items are being lost here due to unknown error. TransmissionId: {0}. Error Message: {1}.", Level = EventLevel.Error)]
         public void TransmissionDataLossWarning(string transmissionId, string message, string appDomainName = "Incorrect")
         {
             this.WriteEvent(

--- a/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -493,7 +493,7 @@
         public void TransmissionDataLossWarning(string transmissionId, string message, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                54,
+                69,
                 transmissionId ?? string.Empty,
                 message ?? string.Empty,
                 this.ApplicationName);

--- a/src/ServerTelemetryChannel/Implementation/TransmissionProcessedEventArgs.cs
+++ b/src/ServerTelemetryChannel/Implementation/TransmissionProcessedEventArgs.cs
@@ -10,19 +10,6 @@
     {
         public TransmissionProcessedEventArgs(Transmission transmission, Exception exception = null, HttpWebResponseWrapper response = null)
         {
-            // Fix missing arguments if not passed in
-            if (exception != null && response == null && exception is WebException &&
-                ((WebException)exception).Response is HttpWebResponse)
-            {
-                HttpWebResponse exceptionResponse = (HttpWebResponse)((WebException)exception).Response;
-                response = new HttpWebResponseWrapper()
-                {
-                    StatusCode = (int)exceptionResponse.StatusCode,
-                    StatusDescription = exceptionResponse.StatusDescription,
-                    RetryAfterHeader = exceptionResponse.Headers?["Retry-After"]
-                };
-            }
-
             this.Transmission = transmission;
             this.Exception = exception;
             this.Response = response;

--- a/src/ServerTelemetryChannel/Implementation/TransmissionSender.cs
+++ b/src/ServerTelemetryChannel/Implementation/TransmissionSender.cs
@@ -1,13 +1,11 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
-    using System.Collections.Generic;
-    using System.IO;
+    using System.Globalization;
     using System.Net;
-    using System.Runtime.Serialization;
     using System.Net.Http;
     using System.Threading;
-    using System.Threading.Tasks;
+    using System.Threading.Tasks;    
     using Extensibility;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -178,7 +176,7 @@
                             }
                             else
                             {
-                                TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(acceptedTransmission.Id, responseContent.StatusCode.ToString());
+                                TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(acceptedTransmission.Id, responseContent.StatusCode.ToString(CultureInfo.InvariantCulture));
                             }
                         }                        
                     }

--- a/src/ServerTelemetryChannel/Implementation/TransmissionSender.cs
+++ b/src/ServerTelemetryChannel/Implementation/TransmissionSender.cs
@@ -136,11 +136,7 @@
 
         protected void OnTransmissionSent(TransmissionProcessedEventArgs args)
         {
-            EventHandler<TransmissionProcessedEventArgs> handler = this.TransmissionSent;
-            if (handler != null)
-            {
-                handler(this, args);
-            }
+            this.TransmissionSent?.Invoke(this, args);
         }
 
         private async Task StartSending(Transmission transmission)

--- a/src/ServerTelemetryChannel/Implementation/TransmissionSender.cs
+++ b/src/ServerTelemetryChannel/Implementation/TransmissionSender.cs
@@ -172,13 +172,22 @@
                         {
                             if (responseContent.StatusCode < 400)
                             {
-                                TelemetryChannelEventSource.Log.TransmissionSentSuccessfully(acceptedTransmission.Id, currentCapacity);
+                                TelemetryChannelEventSource.Log.TransmissionSentSuccessfully(acceptedTransmission.Id,
+                                    currentCapacity);
                             }
                             else
                             {
-                                TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(acceptedTransmission.Id, responseContent.StatusCode.ToString(CultureInfo.InvariantCulture));
+                                TelemetryChannelEventSource.Log.TransmissionSendingFailedWarning(
+                                    acceptedTransmission.Id,
+                                    responseContent.StatusCode.ToString(CultureInfo.InvariantCulture));
                             }
-                        }                        
+
+                            if (TelemetryChannelEventSource.IsVerboseEnabled)
+                            {
+                                TelemetryChannelEventSource.Log.RawResponseFromAIBackend(acceptedTransmission.Id,
+                                    responseContent.Content);
+                            }
+                        }
                     }
 
                     if (responseContent == null && exception is HttpRequestException)

--- a/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -47,6 +47,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <Reference Include="System.Web" Condition="'$(TargetFramework)' == 'net45'" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">


### PR DESCRIPTION
Fix Issue #1049 
Transmission - wraps response and returns HttpResponseWrapper . It only handles a single Exception arising from client timeout.

TransmissionSender - catches all exceptions, and populates HttpResponseWrapper for known exception. (in this case: HttpRequestException)

ErrorHandlingTransmissionPolicy
Retries for client timeouts, server error, and other network errors.

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.