### PR TITLE
Fix W3C on net46 and add tests

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/W3C/W3CActivityExtensionsTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/W3C/W3CActivityExtensionsTests.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ApplicationInsights.W3C
+﻿using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Microsoft.ApplicationInsights.W3C
 {
     using System.Diagnostics;
     using System.Linq;
@@ -249,6 +251,149 @@
                 a.SetTraceparent($"00-{TraceId}-{ParenSpanId}-{notReq}");
                 Assert.AreEqual($"00-{TraceId}-{a.GetSpanId()}-02", a.GetTraceparent(), notReq);
             }
+        }
+
+        [TestMethod]
+        public void UpdateValidRequestTelemetryWithForceFalse()
+        {
+            var traceId = W3CUtilities.GenerateTraceId();
+            var parentSpanId = W3CUtilities.GenerateSpanId();
+            var spanId = W3CUtilities.GenerateSpanId();
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.Operation.Id = traceId;
+            telemetry.Context.Operation.ParentId = $"|{traceId}.{parentSpanId}.";
+            telemetry.Id = $"|{traceId}.{spanId}.";
+
+            var a = new Activity("foo").Start();
+            a.SetTraceparent($"00-{traceId}-{spanId}-01");
+
+            a.UpdateTelemetry(telemetry, false);
+
+            Assert.AreEqual(traceId, telemetry.Context.Operation.Id);
+
+#if NET45 || NET46
+            Assert.AreEqual($"|{traceId}.{parentSpanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Id);
+#else
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{a.GetSpanId()}.", telemetry.Id);
+#endif
+        }
+
+        [TestMethod]
+        public void UpdateValidRequestTelemetryWithForceInvalidIdFalse()
+        {
+            var traceId = W3CUtilities.GenerateTraceId();
+            var parentSpanId = W3CUtilities.GenerateSpanId();
+            var spanId = W3CUtilities.GenerateSpanId();
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.Operation.Id = traceId;
+            telemetry.Context.Operation.ParentId = $"|{traceId}.{parentSpanId}.";
+            telemetry.Id = "|123.456.";
+
+            var a = new Activity("foo").Start();
+            a.SetTraceparent($"00-{traceId}-{spanId}-01");
+
+            a.UpdateTelemetry(telemetry, false);
+
+            Assert.AreEqual(traceId, telemetry.Context.Operation.Id);
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{a.GetSpanId()}.", telemetry.Id);
+        }
+
+        [TestMethod]
+        public void UpdateValidRequestTelemetryWithForceTrue()
+        {
+            var traceId = W3CUtilities.GenerateTraceId();
+            var parentSpanId = W3CUtilities.GenerateSpanId();
+            var spanId = W3CUtilities.GenerateSpanId();
+
+            var telemetry = new RequestTelemetry();
+            telemetry.Context.Operation.Id = traceId;
+            telemetry.Context.Operation.ParentId = $"|{traceId}.{parentSpanId}.";
+            telemetry.Id = $"|{traceId}.{spanId}.";
+
+            var a = new Activity("foo").Start();
+            a.SetTraceparent($"00-{traceId}-{spanId}-01");
+
+            a.UpdateTelemetry(telemetry, true);
+
+            Assert.AreEqual(traceId, telemetry.Context.Operation.Id);
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{a.GetSpanId()}.", telemetry.Id);
+        }
+
+        [TestMethod]
+        public void UpdateValidDependencyTelemetryWithForceFalse()
+        {
+            var traceId = W3CUtilities.GenerateTraceId();
+            var parentSpanId = W3CUtilities.GenerateSpanId();
+            var spanId = W3CUtilities.GenerateSpanId();
+
+            var telemetry = new DependencyTelemetry();
+            telemetry.Context.Operation.Id = traceId;
+            telemetry.Context.Operation.ParentId = $"|{traceId}.{parentSpanId}.";
+            telemetry.Id = $"|{traceId}.{spanId}.";
+
+            var a = new Activity("foo").Start();
+            a.SetTraceparent($"00-{traceId}-{spanId}-01");
+
+            a.UpdateTelemetry(telemetry, false);
+
+            Assert.AreEqual(traceId, telemetry.Context.Operation.Id);
+#if NET45 || NET46
+            Assert.AreEqual($"|{traceId}.{parentSpanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Id);
+#else
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{a.GetSpanId()}.", telemetry.Id);
+#endif
+        }
+
+        [TestMethod]
+        public void UpdateValidDependencyTelemetryWithForceInvalidIdFalse()
+        {
+            var traceId = W3CUtilities.GenerateTraceId();
+            var parentSpanId = W3CUtilities.GenerateSpanId();
+            var spanId = W3CUtilities.GenerateSpanId();
+
+            var telemetry = new DependencyTelemetry();
+            telemetry.Context.Operation.Id = traceId;
+            telemetry.Context.Operation.ParentId = $"|{traceId}.{parentSpanId}.";
+            telemetry.Id = "|123.456.";
+
+            var a = new Activity("foo").Start();
+            a.SetTraceparent($"00-{traceId}-{spanId}-01");
+
+            a.UpdateTelemetry(telemetry, false);
+
+            Assert.AreEqual(traceId, telemetry.Context.Operation.Id);
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{a.GetSpanId()}.", telemetry.Id);
+        }
+
+        [TestMethod]
+        public void UpdateValidDependencyTelemetryTelemetryWithForceTrue()
+        {
+            var traceId = W3CUtilities.GenerateTraceId();
+            var parentSpanId = W3CUtilities.GenerateSpanId();
+            var spanId = W3CUtilities.GenerateSpanId();
+
+            var telemetry = new DependencyTelemetry();
+            telemetry.Context.Operation.Id = traceId;
+            telemetry.Context.Operation.ParentId = $"|{traceId}.{parentSpanId}.";
+            telemetry.Id = $"|{traceId}.{spanId}.";
+
+            var a = new Activity("foo").Start();
+            a.SetTraceparent($"00-{traceId}-{spanId}-01");
+
+            a.UpdateTelemetry(telemetry, true);
+
+            Assert.AreEqual(traceId, telemetry.Context.Operation.Id);
+            Assert.AreEqual($"|{traceId}.{spanId}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual($"|{traceId}.{a.GetSpanId()}.", telemetry.Id);
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/W3C/W3COperationCorrelationTelemetryInitializerTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/W3C/W3COperationCorrelationTelemetryInitializerTests.cs
@@ -5,7 +5,6 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.W3C;
-    using Microsoft.ApplicationInsights.W3C;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 
     [TestClass]
@@ -218,7 +217,7 @@
         }
 
         [TestMethod]
-        public void InitializerOnSqlDepenedency()
+        public void InitializerOnSqlDependency()
         {
             Activity requestActivity = new Activity("request")
                 .Start()

--- a/src/Microsoft.ApplicationInsights/Extensibility/W3C/W3CActivityExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/W3C/W3CActivityExtensions.cs
@@ -275,7 +275,7 @@
 
             if (initializeFromCurrent)
             {
-#if NET45
+#if NET45 || NET46
                 // on .NET Fx Activities are not always reliable, this code prevents update
                 // of the telemetry that was forcibly updated during Activity lifetime
                 // ON .NET Core there is no such problem 
@@ -366,7 +366,7 @@
             return activity;
         }
 
-#if NET45
+#if NET45 || NET46
         private static bool IsValidTelemetryId(string id, string operationId)
         {
             return id.Length == 51 &&


### PR DESCRIPTION
W3C has a workaround for .NET Fx issue with Activities being lost. 

It did not respect NET46, but base if compiled against it. this change fixes it and adds tests.