### PR TITLE
fix MSBuild3030 warning. 

### DIFF
--- a/src/ServerTelemetryChannel/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets
+++ b/src/ServerTelemetryChannel/Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" >
+    <Target Name="CopyApplicationInsightsConfigToOutputDirectory" AfterTargets="CopyFilesToOutputDirectory" Condition="Exists('ApplicationInsights.config')" >
         <!--Currently we cannot set the config's "Copy to Output Directory" property to "PreserveNewest.
           Workaround is to use this targets file to manually copy into output path."-->
       


### PR DESCRIPTION
Fix #1085 

should ignore target to skip both the message and copy task