### PR TITLE
Fix two bugs in DiagnosticsEventListener

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -70,10 +70,31 @@
                 Assert.AreEqual(1, senderMock.Messages.Count);
 
                 senderMock.Messages.Clear();
-                
+
                 listener.LogLevel = EventLevel.Error;
                 CoreEventSource.Log.LogError("Logging an error");
                 Assert.AreEqual(1, senderMock.Messages.Count);
+            }
+        }
+
+        [TestMethod]
+        public void TestEventSourceLogLevelWhenEventSourceIsAlreadyCreated()
+        {
+            using (var testEventSource = new EventSource("Microsoft-ApplicationInsights-" + nameof(TestEventSourceLogLevelWhenEventSourceIsAlreadyCreated)))
+            {
+                var senderMock = new DiagnosticsSenderMock();
+                var senders = new List<IDiagnosticsSender> { senderMock };
+                using (var listener = new DiagnosticsListener(senders))
+                {
+                    // The default level is EventLevel.Error
+                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Error, EventKeywords.All));
+
+                    // So Verbose should not be enabled
+                    Assert.IsFalse(testEventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+
+                    listener.LogLevel = EventLevel.Verbose;
+                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+                }
             }
         }
     }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -80,22 +80,28 @@
         [TestMethod]
         public void TestEventSourceLogLevelWhenEventSourceIsAlreadyCreated()
         {
-            using (var testEventSource = new EventSource("Microsoft-ApplicationInsights-" + nameof(TestEventSourceLogLevelWhenEventSourceIsAlreadyCreated)))
+            using (var testEventSource = new TestEventSource())
             {
                 var senderMock = new DiagnosticsSenderMock();
                 var senders = new List<IDiagnosticsSender> { senderMock };
                 using (var listener = new DiagnosticsListener(senders))
                 {
+                    const EventKeywords AllKeyword = (EventKeywords)(-1);
                     // The default level is EventLevel.Error
-                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Error, EventKeywords.All));
+                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Error, AllKeyword));
 
                     // So Verbose should not be enabled
-                    Assert.IsFalse(testEventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+                    Assert.IsFalse(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword));
 
                     listener.LogLevel = EventLevel.Verbose;
-                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Verbose, EventKeywords.All));
+                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword));
                 }
             }
+        }
+
+        [EventSource(Name = "Microsoft-ApplicationInsights-" + nameof(TestEventSource))]
+        private class TestEventSource : EventSource
+        {
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -46,6 +46,20 @@
         [TestMethod]
         public void TestListenerWithDifferentSeverity()
         {
+            // Ensure there are no left-over DiagnosticTelemetryModules
+            // from previous tests that will mess up this one.
+            TelemetryConfiguration.Active.Dispose();
+            var modules = TelemetryModules.Instance.Modules;
+            if (modules != null)
+            {
+                foreach (var module in modules)
+                {
+                    (module as IDisposable)?.Dispose();
+                }
+
+                modules.Clear();
+            }
+
             var senderMock = new DiagnosticsSenderMock();
             var senders = new List<IDiagnosticsSender> { senderMock };
             using (var listener = new DiagnosticsListener(senders))
@@ -73,6 +87,21 @@
 
                 listener.LogLevel = EventLevel.Error;
                 CoreEventSource.Log.LogError("Logging an error");
+
+                // If you see the following assert fail, it's because another test has
+                // leaked a DiagnosticsTelemetryModule (via TelemetryConfiguration.Active
+                // for example). There will be a DiagnosticEventListener which forwards
+                // error messages to a PortalDiagnosticsSender. That listener is still
+                // getting events from EventSources. We send an Error event, which goes
+                // not only to our listener here, but also to the leaked one. The event
+                // gets forwarded to the PortalDiagnosticsSender. That turns the event
+                // into TraceTelemetry and tries to transmit it. Since we set the event
+                // level to verbose earlier, RichPayloadEventSource is is enabled and
+                // it writes the TraceTelemetry to all listeners (including us).
+                // Unfortuantely, the TraceTelemetry contains a nullable field which
+                // triggers a known .NET Core 2.0 bug inside WriteEvent. The internal
+                // exception gets reported as an error from WriteEvent resulting in another
+                // event with EventLevel.Error being reported here.
                 Assert.AreEqual(1, senderMock.Messages.Count);
             }
         }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -78,10 +78,13 @@
             string configFileContents = Configuration("<InstrumentationKey>F8474271-D231-45B6-8DD4-D344C309AE69</InstrumentationKey>");
 
             TelemetryConfiguration configuration = new TelemetryConfiguration();
-            new TestableTelemetryConfigurationFactory().Initialize(configuration, new TestableTelemetryModules(), configFileContents);
+            using (var testableTelemetryModules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(configuration, testableTelemetryModules, configFileContents);
 
-            // Assume that LoadFromXml method is called, tested separately
-            Assert.IsFalse(string.IsNullOrEmpty(configuration.InstrumentationKey));
+                // Assume that LoadFromXml method is called, tested separately
+                Assert.IsFalse(string.IsNullOrEmpty(configuration.InstrumentationKey));
+            }
         }
 
         [TestMethod]
@@ -422,24 +425,27 @@
                   "</TelemetryProcessors>");
 
             TelemetryConfiguration configuration = new TelemetryConfiguration();
-            new TestableTelemetryConfigurationFactory().Initialize(configuration, new TestableTelemetryModules(), configFileContents);
+            using (var testableTelemetryModules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(configuration, testableTelemetryModules, configFileContents);
 
-            // Assume that LoadFromXml method is called, tested separately
-            Assert.IsTrue(configuration.TelemetryProcessors != null);
-            AssertEx.IsType<StubTelemetryProcessor>(configuration.TelemetryProcessorChain.FirstTelemetryProcessor);
+                // Assume that LoadFromXml method is called, tested separately
+                Assert.IsTrue(configuration.TelemetryProcessors != null);
+                AssertEx.IsType<StubTelemetryProcessor>(configuration.TelemetryProcessorChain.FirstTelemetryProcessor);
 
-            //validate the chain linking stub1->stub2->pass through->sink
-            var tp1 = (StubTelemetryProcessor)configuration.TelemetryProcessorChain.FirstTelemetryProcessor;
-            var tp2 = (StubTelemetryProcessor2)tp1.next;
-            var passThroughProcessor = tp2.next as PassThroughProcessor;
-            Assert.IsNotNull(passThroughProcessor);
+                //validate the chain linking stub1->stub2->pass through->sink
+                var tp1 = (StubTelemetryProcessor)configuration.TelemetryProcessorChain.FirstTelemetryProcessor;
+                var tp2 = (StubTelemetryProcessor2)tp1.next;
+                var passThroughProcessor = tp2.next as PassThroughProcessor;
+                Assert.IsNotNull(passThroughProcessor);
 
-            // The sink has only a transmission processor and a default channel.
-            var sink = passThroughProcessor.Sink;
-            Assert.IsNotNull(sink);
-            Assert.AreEqual(1, sink.TelemetryProcessorChain.TelemetryProcessors.Count);
-            AssertEx.IsType<TransmissionProcessor>(sink.TelemetryProcessorChain.FirstTelemetryProcessor);
-            AssertEx.IsType<InMemoryChannel>(sink.TelemetryChannel);
+                // The sink has only a transmission processor and a default channel.
+                var sink = passThroughProcessor.Sink;
+                Assert.IsNotNull(sink);
+                Assert.AreEqual(1, sink.TelemetryProcessorChain.TelemetryProcessors.Count);
+                AssertEx.IsType<TransmissionProcessor>(sink.TelemetryProcessorChain.FirstTelemetryProcessor);
+                AssertEx.IsType<InMemoryChannel>(sink.TelemetryChannel);
+            }
         }
 
         [TestMethod]
@@ -453,23 +459,26 @@
                   "</TelemetryProcessors>");
 
             TelemetryConfiguration configuration = new TelemetryConfiguration();
-            new TestableTelemetryConfigurationFactory().Initialize(configuration, new TestableTelemetryModules(), configFileContents);
+            using (var testableTelemetryModules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(configuration, testableTelemetryModules, configFileContents);
 
-            Assert.IsTrue(configuration.TelemetryProcessors != null);
-            AssertEx.IsType<StubTelemetryProcessor>(configuration.TelemetryProcessorChain.FirstTelemetryProcessor);
+                Assert.IsTrue(configuration.TelemetryProcessors != null);
+                AssertEx.IsType<StubTelemetryProcessor>(configuration.TelemetryProcessorChain.FirstTelemetryProcessor);
 
-            //validate the chain linking stub1->stub2->pass through->sink
-            var tp1 = (StubTelemetryProcessor)configuration.TelemetryProcessorChain.FirstTelemetryProcessor;
-            var tp2 = (StubTelemetryProcessor2)tp1.next;
-            var passThroughProcessor = tp2.next as PassThroughProcessor;
-            Assert.IsNotNull(passThroughProcessor);
+                //validate the chain linking stub1->stub2->pass through->sink
+                var tp1 = (StubTelemetryProcessor)configuration.TelemetryProcessorChain.FirstTelemetryProcessor;
+                var tp2 = (StubTelemetryProcessor2)tp1.next;
+                var passThroughProcessor = tp2.next as PassThroughProcessor;
+                Assert.IsNotNull(passThroughProcessor);
 
-            // The sink has only a transmission processor and a default channel.
-            var sink = passThroughProcessor.Sink;
-            Assert.IsNotNull(sink);
-            Assert.AreEqual(1, sink.TelemetryProcessorChain.TelemetryProcessors.Count);
-            AssertEx.IsType<TransmissionProcessor>(sink.TelemetryProcessorChain.FirstTelemetryProcessor);
-            AssertEx.IsType<InMemoryChannel>(sink.TelemetryChannel);
+                // The sink has only a transmission processor and a default channel.
+                var sink = passThroughProcessor.Sink;
+                Assert.IsNotNull(sink);
+                Assert.AreEqual(1, sink.TelemetryProcessorChain.TelemetryProcessors.Count);
+                AssertEx.IsType<TransmissionProcessor>(sink.TelemetryProcessorChain.FirstTelemetryProcessor);
+                AssertEx.IsType<InMemoryChannel>(sink.TelemetryChannel);
+            }
         }
 
         [TestMethod]
@@ -647,10 +656,12 @@
                   </TelemetryModules>"
                 );
 
-            var modules = new TestableTelemetryModules();
-            new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
+            using (var modules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
 
-            Assert.AreEqual(2, modules.Modules.Count); // Diagnostics module is added by default
+                Assert.AreEqual(2, modules.Modules.Count); // Diagnostics module is added by default
+            }
         }
 
         [TestMethod]
@@ -661,11 +672,13 @@
                   </TelemetryModules>"
                 );
 
-            var modules = new TestableTelemetryModules();
-            new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
+            using (var modules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
 
-            Assert.AreEqual(1, modules.Modules.Count);
-            AssertEx.IsType<DiagnosticsTelemetryModule>(modules.Modules[0]);
+                Assert.AreEqual(1, modules.Modules.Count);
+                AssertEx.IsType<DiagnosticsTelemetryModule>(modules.Modules[0]);
+            }
         }
 
 
@@ -680,10 +693,12 @@
                   </TelemetryModules>"
                 );
 
-            var modules = new TestableTelemetryModules();
-            new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
+            using (var modules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
 
-            Assert.AreEqual(3, modules.Modules.Count); // Diagnostics module is added by default
+                Assert.AreEqual(3, modules.Modules.Count); // Diagnostics module is added by default
+            }
         }
 
         [TestMethod]
@@ -700,14 +715,16 @@
                 OnInitialize = _ => { throw new ArgumentException(); }
             };
 
-            var modules = new TestableTelemetryModules();
-            modules.Modules.Add(module);
+            using (var modules = new TestableTelemetryModules())
+            {
+                modules.Modules.Add(module);
 
-            //Assert.DoesNotThrow
-            new TestableTelemetryConfigurationFactory().Initialize(
-                new TelemetryConfiguration(),
-                modules,
-                configFileContents);
+                //Assert.DoesNotThrow
+                new TestableTelemetryConfigurationFactory().Initialize(
+                    new TelemetryConfiguration(),
+                    modules,
+                    configFileContents);
+            }
         }
 
         #endregion
@@ -1519,11 +1536,13 @@
                   </TelemetryModules>"
                 );
 
-            var modules = new TestableTelemetryModules();
-            new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
+            using (var modules = new TestableTelemetryModules())
+            {
+                new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
 
-            Assert.AreEqual(true, isInternalOperation);
-            Assert.AreEqual(false, SdkInternalOperationsMonitor.IsEntered());
+                Assert.AreEqual(true, isInternalOperation);
+                Assert.AreEqual(false, SdkInternalOperationsMonitor.IsEntered());
+            }
         }
 
         private static TelemetryConfiguration CreateTelemetryConfigurationWithDeveloperModeValue(string developerModeValue)
@@ -1548,8 +1567,15 @@
                 </ApplicationInsights>";
         }
 
-        private class TestableTelemetryModules : TelemetryModules
+        private class TestableTelemetryModules : TelemetryModules, IDisposable
         {
+            public void Dispose()
+            {
+                foreach (var module in this.Modules)
+                {
+                    (module as IDisposable)?.Dispose();
+                }
+            }
         }
 
         private class TestableTelemetryConfigurationFactory : TelemetryConfigurationFactory

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
 {
     using System;
+    using System.Collections.Generic;
     using System.Diagnostics.Tracing;
     using System.Linq;
 
@@ -9,11 +10,24 @@
         private const long AllKeyword = -1;
         private readonly EventLevel logLevel;
         private readonly DiagnosticsListener listener;
+        private readonly List<EventSource> eventSourcesDuringConstruction = new List<EventSource>();
 
         public DiagnosticsEventListener(DiagnosticsListener listener, EventLevel logLevel)
         {
             this.listener = listener;
             this.logLevel = logLevel;
+
+            List<EventSource> eventSources;
+            lock (this.eventSourcesDuringConstruction)
+            {
+                eventSources = this.eventSourcesDuringConstruction;
+                this.eventSourcesDuringConstruction = null;
+            }
+
+            foreach (var eventSource in eventSources)
+            {
+                this.EnableEvents(eventSource, this.logLevel, (EventKeywords)AllKeyword);
+            }
         }
 
         protected override void OnEventWritten(EventWrittenEventArgs eventSourceEvent)
@@ -46,6 +60,22 @@
             if (eventSource.Name.StartsWith("Microsoft-ApplicationInsights-", StringComparison.Ordinal) ||
                 eventSource.Name.Equals("Microsoft-AspNet-Telemetry-Correlation", StringComparison.Ordinal))
             {
+                // If our constructor hasn't run yet (we're in a callback from the base class
+                // constructor), just make a note of the event source. Otherwise logLevel is
+                // set to the default, which is "LogAlways".
+                var tmp = this.eventSourcesDuringConstruction;
+                if (tmp != null)
+                {
+                    lock (tmp)
+                    {
+                        if (this.eventSourcesDuringConstruction != null)
+                        {
+                            this.eventSourcesDuringConstruction.Add(eventSource);
+                            return;
+                        }
+                    }
+                }
+
                 this.EnableEvents(eventSource, this.logLevel, (EventKeywords)AllKeyword);
             }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsEventListener.cs
@@ -18,7 +18,7 @@
 
         protected override void OnEventWritten(EventWrittenEventArgs eventSourceEvent)
         {
-            if (eventSourceEvent == null)
+            if (eventSourceEvent == null || this.listener == null)
             {
                 return;
             }


### PR DESCRIPTION
Fix Issue #1106 
Check for `this.listener == null` and exit early from OnEventWritten. It can be null if the constructor hasn't finished running when an event comes in.

Fix Issue #1108 
Record interesting EventSource instances in the OnEventSourceCreated callback while the base constructor is running. Replay them in DiagnosticEventListener's constructor, so that we can enable them with the appropriate level.