### PR TITLE
Fixed local time dependency of unit test

### DIFF
--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/BackoffLogicManagerTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/BackoffLogicManagerTest.cs
@@ -127,7 +127,7 @@
             public void RetryAfterOlderThanNowCausesDefaultDelay()
             {
                 // An old date
-                string retryAfterDateString = DateTime.Now.AddMinutes(-1).ToString("R", CultureInfo.InvariantCulture);
+                string retryAfterDateString = DateTime.UtcNow.AddMinutes(-1).ToString("R", CultureInfo.InvariantCulture);
 
                 var manager = new BackoffLogicManager(TimeSpan.Zero);
                 manager.GetBackOffTimeInterval(retryAfterDateString);


### PR DESCRIPTION
Fix Issue #1109.
Switching arranged test values from using `DateTime.Now` to `DateTime.UtcNow` let's the test run successfully independent of the test runners local time zone.

- [X] I ran Unit Tests locally.