### PR TITLE
Don't add DiagnosticsTelemetryModule more than once.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## [Unreleased](https://github.com/Microsoft/ApplicationInsights-dotnet/compare/2.10.0-beta3..HEAD)
+- [Fix NullReferenceException in DiagnosticsEventListener.OnEventWritten](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1106)
+- [Fix RichPayloadEventSource can get enabled at Verbose level](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1108)
+- [Fix DiagnosticsTelemetryModule can get added more than once](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1111)
+
 ## Version 2.10.0-beta3
 - No changes. Bumping version to match WebSDK release.
 

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -676,6 +676,10 @@
             {
                 new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
 
+
+                // Initialize a 2nd TelemetryConfiguration to check that only one diagnostics module is added.
+                new TestableTelemetryConfigurationFactory().Initialize(new TelemetryConfiguration(), modules, configFileContents);
+
                 Assert.AreEqual(1, modules.Modules.Count);
                 AssertEx.IsType<DiagnosticsTelemetryModule>(modules.Modules[0]);
             }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -55,7 +55,7 @@
             {
                 SdkInternalOperationsMonitor.Enter();
 
-                if (modules != null)
+                if (modules != null && !modules.Modules.Any(module => module is DiagnosticsTelemetryModule))
                 {
                     // Create diagnostics module so configuration loading errors are reported to the portal
                     modules.Modules.Add(new DiagnosticsTelemetryModule());


### PR DESCRIPTION
Fix Issue #1111
Checks if `DiagnosticsTelemetryModule` is already in the modules list before adding it in `TelemetryConfigurationFactory.Initialize`

- [x] I ran Unit Tests locally.