### PR TITLE
Use NuGet's V3 API during build

### DIFF
--- a/NuGet.config
+++ b/NuGet.config
@@ -4,6 +4,6 @@
     <!--  See the comments in Directory.Build.props for explanations.                         -->
   <packageSources>
     <clear/>
-    <add key="nuget.org" value="https://www.nuget.org/api/v2/" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" />
   </packageSources>
 </configuration>


### PR DESCRIPTION
We strongly recommend moving to V3 API as it provides more reliable builds and [security improvements](https://blog.nuget.org/20180810/Introducing-Repository-Signatures.html).

The change is super simple:
Replace `https://www.nuget.org/api/v2/` with `https://api.nuget.org/v3/index.json`
