### PR TITLE
Catching exception when failing to read config in partial trust

### DIFF
--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -13,7 +13,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-    
+
     /// <summary>
     /// The .NET 4.0 and 4.5 implementation of the <see cref="IPlatform"/> interface.
     /// </summary>
@@ -44,9 +44,17 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
         /// </summary>
         public string ReadConfigurationXml()
         {
-            // Config file should be in the base directory of the app domain
-            string configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ApplicationInsights.config");
-
+            string configFilePath;
+            try
+            {
+                // Config file should be in the base directory of the app domain
+                configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ApplicationInsights.config");
+            }
+            catch (SecurityException)
+            {
+                CoreEventSource.Log.ApplicationInsightsConfigNotAccessibleWarning();
+                return string.Empty;
+            }
             try
             {
                 // Ensure config file actually exists
@@ -78,7 +86,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
             {
                 CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
             }
-
             return string.Empty;
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -55,6 +55,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
                 CoreEventSource.Log.ApplicationInsightsConfigNotAccessibleWarning();
                 return string.Empty;
             }
+
             try
             {
                 // Ensure config file actually exists
@@ -86,6 +87,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
             {
                 CoreEventSource.Log.ApplicationInsightsConfigNotFoundWarning(configFilePath);
             }
+
             return string.Empty;
         }
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -525,12 +525,23 @@
         }
 
         /// <summary>
-        /// Logs the detais when there operation to stop does not match the current operation.
+        /// Logs the details when there operation to stop does not match the current operation.
         /// </summary>
         [Event(44, Message = "Operation to stop does not match the current operation. Details {0}.", Level = EventLevel.Warning)]
         public void InvalidOperationToStopDetails(string details, string appDomainName = "Incorrect")
         {
             this.WriteEvent(44, details, this.nameProvider.Name);
+        }
+
+        [Event(
+        45,
+        Message = "File system containing ApplicationInsights configuration file is inaccessible.",
+        Level = EventLevel.Warning)]
+        public void ApplicationInsightsConfigNotAccessibleWarning()
+        {
+            this.WriteEvent(
+                45,
+                this.nameProvider.Name);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -537,7 +537,7 @@
         45,
         Message = "File system containing ApplicationInsights configuration file is inaccessible.",
         Level = EventLevel.Warning)]
-        public void ApplicationInsightsConfigNotAccessibleWarning()
+        public void ApplicationInsightsConfigNotAccessibleWarning(string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 45,


### PR DESCRIPTION
Fix Issue #416  .

Expand the area under try catch to allow for client initialization in partial trust scenarios, specifically as part of a Dynamics 365 plugin. 

- [x ] I ran Unit Tests locally.
