### PR TITLE
SDKVersion to hint NETCORE, other minor changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.10.0
+- SDKVersion modified to be dotnetc for NetCore. This helps identify the source of code path, as implementations are slightly different for NetCore.
+
 ## Version 2.10.0-beta4
 - [Fix NullReferenceException in DiagnosticsEventListener.OnEventWritten](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1106)
 - [Fix RichPayloadEventSource can get enabled at Verbose level](https://github.com/Microsoft/ApplicationInsights-dotnet/issues/1108)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-![Build Status](https://mseng.visualstudio.com/DefaultCollection/_apis/public/build/definitions/96a62c4a-58c2-4dbb-94b6-5979ebc7f2af/1822/badge)
+[![Build Status](https://mseng.visualstudio.com/AppInsights/_apis/build/status/ChuckNorris/AI-BaseSDK-develop-linux?branchName=develop)](https://mseng.visualstudio.com/AppInsights/_build/latest?definitionId=6237?branchName=develop)
+[![Build Status](https://mseng.visualstudio.com/AppInsights/_apis/build/status/ChuckNorris/AI-BaseSDK-GitHub-Master?branchName=develop)](https://mseng.visualstudio.com/AppInsights/_build/latest?definitionId=1822?branchName=develop)
 [![codecov.io](https://codecov.io/github/Microsoft/ApplicationInsights-dotnet/coverage.svg?branch=develop)](https://codecov.io/github/Microsoft/ApplicationInsights-dotnet?branch=develop)
 
 ## NuGet packages

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/TestUtility/TestUtil.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/TestUtility/TestUtil.cs
@@ -236,8 +236,11 @@ namespace Microsoft.ApplicationInsights.Metrics.TestUtility
             Assert.IsNotNull(versionMoniker);
 
             // Expected result example: "m-agg2:2.6.0-12552"
-
+#if NETCOREAPP1_1 || NETCOREAPP2_0
+        const string expectedPrefix = "m-agg2c:";
+#else
             const string expectedPrefix = "m-agg2:";
+#endif        
 
             string sdkRevisionComponentStr = versionMoniker.Substring(expectedPrefix.Length);
             string expectedVersion = SdkVersionUtils.GetSdkVersion(String.Empty);

--- a/Test/TestFramework/Shared/EventSourceTest.cs
+++ b/Test/TestFramework/Shared/EventSourceTest.cs
@@ -93,7 +93,7 @@ namespace Microsoft.ApplicationInsights.TestFramework
 
         private static void VerifyEventApplicationName(MethodInfo eventMethod, EventWrittenEventArgs actualEvent)
         {
-#if !NETCOREAPP
+#if !NETCOREAPP1_1
             string expectedApplicationName = AppDomain.CurrentDomain.FriendlyName;
 #else
             string expectedApplicationName = "";

--- a/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/src/Microsoft.ApplicationInsights/Managed/Shared/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -28,8 +28,12 @@
 
         /// <summary>
         /// Value for property indicating 'app insights version' related specifically to heartbeats.
-        /// </summary>
+        /// </summary>        
+#if NETSTANDARD1_3 || NETSTANDARD2_0
+        private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbnetc:");
+#else
         private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbnet:");
+#endif
 
         /// <summary>
         /// The name of the heartbeat metric item and operation context. 

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
@@ -16,7 +16,11 @@
 
         private const string FallbackParameterName = "specified parameter";
 
+#if NETSTANDARD1_3 || NETSTANDARD2_0
+        private static string sdkVersionMoniker = SdkVersionUtils.GetSdkVersion("m-agg2c:");
+#else
         private static string sdkVersionMoniker = SdkVersionUtils.GetSdkVersion("m-agg2:");
+#endif
 
         /// <summary>
         /// Parameter check for Null.

--- a/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.3</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -22,7 +22,11 @@
     /// </summary>
     public sealed class TelemetryClient
     {
+#if NETSTANDARD1_3 || NETSTANDARD2_0
+        private const string VersionPrefix = "dotnetc:";
+#else
         private const string VersionPrefix = "dotnet:";
+#endif
         private readonly TelemetryConfiguration configuration;
         private string sdkVersion;
 

--- a/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -531,7 +531,7 @@
             string name;
             try
             {
-#if !NETSTANDARD
+#if !NETSTANDARD1_3
                 name = AppDomain.CurrentDomain.FriendlyName;
 #else
                 name = string.Empty;


### PR DESCRIPTION
SDKVersion updated to hint the target is NETCORE.
Linux builds netstandard2.0 as well

- [ ] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.