### PR TITLE
Correct telemetry timestamp precision on .NET Framework

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/OperationTelemetryExtensionsTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/OperationTelemetryExtensionsTests.cs
@@ -64,6 +64,7 @@
             Assert.AreEqual(telemetry.Duration, TimeSpan.Zero);
         }
 
+#if !NETCOREAPP1_1
         /// <summary>
         /// Tests the scenario if Start assigns current *precise* time to start time.
         /// </summary>
@@ -92,6 +93,7 @@
                 Assert.IsTrue(ComputeSomethingHeavy() > 0);
             }
         }
+#endif
 
         /// <summary>
         /// Tests the scenario if Stop computes the duration of the telemetry when timestamps are supplied to Start and Stop.

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/OperationTelemetryExtensionsTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/OperationTelemetryExtensionsTests.cs
@@ -65,6 +65,35 @@
         }
 
         /// <summary>
+        /// Tests the scenario if Start assigns current *precise* time to start time.
+        /// </summary>
+        [TestMethod]
+        public void StartTimeIsPrecise()
+        {
+            double [] timeStampDiff = new double[1000];
+            DateTimeOffset prevTimestamp = DateTimeOffset.MinValue;
+            for (int i = 0; i < timeStampDiff.Length; i ++)
+            {
+                var telemetry = new DependencyTelemetry();
+                telemetry.Start();
+
+                if (i > 0)
+                {
+                    timeStampDiff[i] = telemetry.Timestamp.Subtract(prevTimestamp).TotalMilliseconds;
+                    Debug.WriteLine(timeStampDiff[i]);
+
+                    // if timestamp is NOT precise, we'll get precisely 0 which should not ever happen
+                    Assert.IsTrue(timeStampDiff[i] != 0);
+                }
+
+                prevTimestamp = telemetry.Timestamp;
+
+                // waste a bit of time, assert result to prevent any optimizations
+                Assert.IsTrue(ComputeSomethingHeavy() > 0);
+            }
+        }
+
+        /// <summary>
         /// Tests the scenario if Stop computes the duration of the telemetry when timestamps are supplied to Start and Stop.
         /// </summary>
         [TestMethod]
@@ -128,6 +157,18 @@
                 var difference = (telemetry.Duration - expectedDuration).Duration();
                 Assert.IsTrue(difference.Ticks < 10);
             }
+        }
+
+        private double ComputeSomethingHeavy()
+        {
+            var random = new Random();
+            double res = 0;
+            for (int i = 0; i < 10000; i++)
+            {
+                res += Math.Sqrt(random.NextDouble());
+            }
+
+            return res;
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -106,6 +106,35 @@
             Assert.IsTrue(telemetry.Timestamp != default(DateTimeOffset));
         }
 
+        /// <summary>
+        /// Tests the scenario if Initialize assigns current precise time to start time.
+        /// </summary>
+        [TestMethod]
+        public void StartTimeIsPrecise()
+        {
+            double[] timeStampDiff = new double[1000];
+            DateTimeOffset prevTimestamp = DateTimeOffset.MinValue;
+            for (int i = 0; i < timeStampDiff.Length; i++)
+            {
+                var telemetry = new DependencyTelemetry();
+                new TelemetryClient().Initialize(telemetry);
+
+                if (i > 0)
+                {
+                    timeStampDiff[i] = telemetry.Timestamp.Subtract(prevTimestamp).TotalMilliseconds;
+                    Debug.WriteLine(timeStampDiff[i]);
+
+                    // if timestamp is NOT precise, we'll get precisely 0 which should not ever happen
+                    Assert.IsTrue(timeStampDiff[i] != 0);
+                }
+
+                prevTimestamp = telemetry.Timestamp;
+
+                // waste a bit of time, assert result to prevent any optimizations
+                Assert.IsTrue(ComputeSomethingHeavy() > 0);
+            }
+        }
+
         [TestMethod]
         public void InitializeSetsRoleInstance()
         {
@@ -2104,6 +2133,18 @@
         private void ClearActiveTelemetryConfiguration()
         {
             TelemetryConfiguration.Active = null;
+        }
+
+        private double ComputeSomethingHeavy()
+        {
+            var random = new Random();
+            double res = 0;
+            for (int i = 0; i < 10000; i++)
+            {
+                res += Math.Sqrt(random.NextDouble());
+            }
+
+            return res;
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -106,11 +106,12 @@
             Assert.IsTrue(telemetry.Timestamp != default(DateTimeOffset));
         }
 
+#if !NETCOREAPP1_1
         /// <summary>
         /// Tests the scenario if Initialize assigns current precise time to start time.
         /// </summary>
         [TestMethod]
-        public void StartTimeIsPrecise()
+        public void TimestampIsPrecise()
         {
             double[] timeStampDiff = new double[1000];
             DateTimeOffset prevTimestamp = DateTimeOffset.MinValue;
@@ -134,6 +135,7 @@
                 Assert.IsTrue(ComputeSomethingHeavy() > 0);
             }
         }
+#endif
 
         [TestMethod]
         public void InitializeSetsRoleInstance()

--- a/Test/Microsoft.ApplicationInsights.Test/netcoreapp11/Microsoft.ApplicationInsights.netcoreapp11.Tests.csproj
+++ b/Test/Microsoft.ApplicationInsights.Test/netcoreapp11/Microsoft.ApplicationInsights.netcoreapp11.Tests.csproj
@@ -12,8 +12,8 @@
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
     <DebugType>pdbonly</DebugType> 
     <DebugSymbols>true</DebugSymbols> 
-    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP1_1</DefineConstants>
+      <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
@@ -17,11 +17,6 @@
         private static readonly PreciseTimestamp Timestamp = PreciseTimestamp.Instance;
 
         /// <summary>
-        /// Multiplier to convert Stopwatch ticks to TimeSpan ticks.
-        /// </summary>
-        private static readonly double StopwatchTicksToTimeSpanTicks = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
-
-        /// <summary>
         /// An extension to telemetry item that starts the timer for the respective telemetry.
         /// </summary>
         /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
@@ -98,7 +93,7 @@
         private static void StopImpl(OperationTelemetry telemetry, long timestamp)
         {
             long stopWatchTicksDiff = timestamp - telemetry.BeginTimeInTicks;
-            double durationInTicks = stopWatchTicksDiff * StopwatchTicksToTimeSpanTicks;
+            double durationInTicks = stopWatchTicksDiff * PreciseTimestamp.StopwatchTicksToTimeSpanTicks;
             StopImpl(telemetry, TimeSpan.FromTicks((long)Math.Round(durationInTicks)));
         }
 

--- a/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
@@ -38,7 +38,7 @@
         /// <param name="timestamp">A high-resolution timestamp from <see cref="Stopwatch"/>.</param>
         public static void Start(this OperationTelemetry telemetry, long timestamp)
         {
-            telemetry.Timestamp = DateTimeOffset.UtcNow; 
+            telemetry.Timestamp = Timestamp.GetUtcNow(); 
 
             // Begin time is used internally for calculating duration of operation at the end call,
             // and hence is stored using higher precision Clock.

--- a/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
@@ -12,6 +12,11 @@
     public static class OperationTelemetryExtensions
     {
         /// <summary>
+        /// Precise timestamp instance.
+        /// </summary>
+        private static readonly PreciseTimestamp Timestamp = PreciseTimestamp.Instance;
+
+        /// <summary>
         /// Multiplier to convert Stopwatch ticks to TimeSpan ticks.
         /// </summary>
         private static readonly double StopwatchTicksToTimeSpanTicks = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
@@ -33,7 +38,7 @@
         /// <param name="timestamp">A high-resolution timestamp from <see cref="Stopwatch"/>.</param>
         public static void Start(this OperationTelemetry telemetry, long timestamp)
         {
-            telemetry.Timestamp = DateTimeOffset.UtcNow;
+            telemetry.Timestamp = Timestamp.GetUtcNow();
 
             // Begin time is used internally for calculating duration of operation at the end call,
             // and hence is stored using higher precision Clock.
@@ -108,7 +113,7 @@
 
             if (telemetry.Timestamp == DateTimeOffset.MinValue)
             {
-                telemetry.Timestamp = DateTimeOffset.UtcNow;
+                telemetry.Timestamp = Timestamp.GetUtcNow();
             }
 
             RichPayloadEventSource.Log.ProcessOperationStop(telemetry);

--- a/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
@@ -12,11 +12,6 @@
     public static class OperationTelemetryExtensions
     {
         /// <summary>
-        /// Precise timestamp instance.
-        /// </summary>
-        private static readonly PreciseTimestamp Timestamp = PreciseTimestamp.Instance;
-
-        /// <summary>
         /// An extension to telemetry item that starts the timer for the respective telemetry.
         /// </summary>
         /// <param name="telemetry">Telemetry item object that calls this extension method.</param>
@@ -33,7 +28,7 @@
         /// <param name="timestamp">A high-resolution timestamp from <see cref="Stopwatch"/>.</param>
         public static void Start(this OperationTelemetry telemetry, long timestamp)
         {
-            telemetry.Timestamp = Timestamp.GetUtcNow(); 
+            telemetry.Timestamp = PreciseTimestamp.GetUtcNow(); 
 
             // Begin time is used internally for calculating duration of operation at the end call,
             // and hence is stored using higher precision Clock.
@@ -108,7 +103,7 @@
 
             if (telemetry.Timestamp == DateTimeOffset.MinValue)
             {
-                telemetry.Timestamp = Timestamp.GetUtcNow();
+                telemetry.Timestamp = PreciseTimestamp.GetUtcNow();
             }
 
             RichPayloadEventSource.Log.ProcessOperationStop(telemetry);

--- a/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/OperationTelemetryExtensions.cs
@@ -38,7 +38,7 @@
         /// <param name="timestamp">A high-resolution timestamp from <see cref="Stopwatch"/>.</param>
         public static void Start(this OperationTelemetry telemetry, long timestamp)
         {
-            telemetry.Timestamp = Timestamp.GetUtcNow();
+            telemetry.Timestamp = DateTimeOffset.UtcNow; 
 
             // Begin time is used internally for calculating duration of operation at the end call,
             // and hence is stored using higher precision Clock.

--- a/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
+++ b/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
@@ -13,7 +13,7 @@
         private static PreciseTimestamp instance = null;
 
 #if NET45 || NET46
-        private static TimeSync timeSync;
+        private static TimeSync timeSync = new TimeSync();
         private readonly Timer syncTimeUpdater;
 
         private PreciseTimestamp()

--- a/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
+++ b/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
@@ -1,0 +1,109 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Diagnostics.CodeAnalysis;
+#if NET45 || NET46
+    using System.Diagnostics;
+    using System.Threading;
+#endif
+
+    internal class PreciseTimestamp
+    {
+        private static readonly object Lck = new object();
+        private static PreciseTimestamp instance = null;
+
+#if NET45 || NET46
+        private static TimeSync timeSync;
+        private readonly Timer syncTimeUpdater;
+
+        private PreciseTimestamp()
+        {
+            this.syncTimeUpdater = InitializeSyncTimer();
+        }
+#endif
+
+        public static PreciseTimestamp Instance
+        {
+            get
+            {
+                if (instance == null)
+                {
+                    lock (Lck)
+                    {
+                        if (instance == null)
+                        {
+                            instance = new PreciseTimestamp();
+                        }
+                    }
+                }
+
+                return instance;
+            }
+        }
+
+        /// <summary>
+        /// Returns high resolution (1 DateTime tick) current UTC DateTime. 
+        /// </summary>
+        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Enforcing instance fields initialization.")]
+        internal DateTimeOffset GetUtcNow()
+        {
+#if NET45 || NET46
+            // DateTime.UtcNow accuracy on .NET Framework is ~16ms, this method 
+            // uses combination of Stopwatch and DateTime to calculate accurate UtcNow.
+
+            var tmp = timeSync;
+
+            // Timer ticks need to be converted to DateTime ticks
+            long dateTimeTicksDiff = (long)((Stopwatch.GetTimestamp() - tmp.SyncStopwatchTicks) * 10000000L /
+                                            (double)Stopwatch.Frequency);
+
+            // DateTime.AddSeconds (or Milliseconds) rounds value to 1 ms, use AddTicks to prevent it
+            return tmp.SyncUtcNow.AddTicks(dateTimeTicksDiff);
+#else
+            return DateTimeOffset.UtcNow;
+#endif
+        }
+
+#if NET45 || NET46
+        private static void Sync()
+        {
+            // wait for DateTime.UtcNow update to the next granular value
+            Thread.Sleep(1);
+            timeSync = new TimeSync();
+        }
+
+        private static Timer InitializeSyncTimer()
+        {
+            Timer timer;
+            // Don't capture the current ExecutionContext and its AsyncLocals onto the timer causing them to live forever
+            bool restoreFlow = false;
+            try
+            {
+                if (!ExecutionContext.IsFlowSuppressed())
+                {
+                    ExecutionContext.SuppressFlow();
+                    restoreFlow = true;
+                }
+
+                timer = new Timer(s => { Sync(); }, null, 0, 7200000);
+            }
+            finally
+            {
+                // Restore the current ExecutionContext
+                if (restoreFlow)
+                {
+                    ExecutionContext.RestoreFlow();
+                }
+            }
+
+            return timer;
+        }
+
+        private class TimeSync
+        {
+            public readonly DateTimeOffset SyncUtcNow = DateTimeOffset.UtcNow;
+            public readonly long SyncStopwatchTicks = Stopwatch.GetTimestamp();
+        }
+#endif
+    }
+}

--- a/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
+++ b/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Diagnostics;
-    using System.Diagnostics.CodeAnalysis;
 #if NET45 || NET46
+    using System.Diagnostics.CodeAnalysis;
     using System.Threading;
 #endif
 
@@ -14,43 +14,21 @@
         /// </summary>
         internal static readonly double StopwatchTicksToTimeSpanTicks = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
 
-        private static readonly object Lck = new object();
-        private static PreciseTimestamp instance = null;
-
 #if NET45 || NET46
+        private static readonly Timer SyncTimeUpdater;
         private static TimeSync timeSync = new TimeSync();
-        private readonly Timer syncTimeUpdater;
 
-        private PreciseTimestamp()
+        [SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline", Justification = "Enforcing static fields initialization.")]
+        static PreciseTimestamp()
         {
-            this.syncTimeUpdater = InitializeSyncTimer();
+            SyncTimeUpdater = InitializeSyncTimer();
         }
 #endif
-
-        public static PreciseTimestamp Instance
-        {
-            get
-            {
-                if (instance == null)
-                {
-                    lock (Lck)
-                    {
-                        if (instance == null)
-                        {
-                            instance = new PreciseTimestamp();
-                        }
-                    }
-                }
-
-                return instance;
-            }
-        }
 
         /// <summary>
         /// Returns high resolution (1 DateTime tick) current UTC DateTime. 
         /// </summary>
-        [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "Enforcing instance fields initialization.")]
-        public DateTimeOffset GetUtcNow()
+        public static DateTimeOffset GetUtcNow()
         {
 #if NET45 || NET46
             // DateTime.UtcNow accuracy on .NET Framework is ~16ms, this method 

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -23,7 +23,6 @@
     public sealed class TelemetryClient
     {
         private const string VersionPrefix = "dotnet:";
-        private static readonly PreciseTimestamp Timestamp = PreciseTimestamp.Instance;
         private readonly TelemetryConfiguration configuration;
         private string sdkVersion;
         
@@ -528,7 +527,7 @@
 
             if (telemetry.Timestamp == default(DateTimeOffset))
             {
-                telemetry.Timestamp = Timestamp.GetUtcNow();
+                telemetry.Timestamp = PreciseTimestamp.GetUtcNow();
             }
 
             // Currently backend requires SDK version to comply "name: version"

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -23,9 +23,10 @@
     public sealed class TelemetryClient
     {
         private const string VersionPrefix = "dotnet:";
+        private static readonly PreciseTimestamp Timestamp = PreciseTimestamp.Instance;
         private readonly TelemetryConfiguration configuration;
         private string sdkVersion;
-
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the active configuration, usually loaded from ApplicationInsights.config.
         /// </summary>
@@ -527,7 +528,7 @@
 
             if (telemetry.Timestamp == default(DateTimeOffset))
             {
-                telemetry.Timestamp = DateTimeOffset.UtcNow;
+                telemetry.Timestamp = Timestamp.GetUtcNow();
             }
 
             // Currently backend requires SDK version to comply "name: version"


### PR DESCRIPTION
Fix Issue https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/1175 .

Timestamp is inaccurate on .NET Fx.

 The way to correct it is described here: https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/Activity.DateTime.netfx.cs

~~There is no reasonable way to test it - I tested manually.~~