### PR TITLE
remove extra type casting in W3C TelemetryInitializer

### DIFF
--- a/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/DataContracts/DependencyTelemetry.cs
@@ -421,5 +421,23 @@ namespace Microsoft.ApplicationInsights.DataContracts
             this.Properties.SanitizeProperties();
             this.Metrics.SanitizeMeasurements();
         }
+
+        /// <summary>
+        /// Requests and dependencies are initialized from the current Activity 
+        /// (i.e. telemetry.Id = current.Id). Activity is created for such requests specifically
+        /// Traces, exceptions, events on the other side are children of current activity
+        /// There is one exception - SQL DiagnosticSource where current Activity is a parent
+        /// for dependency calls.
+        /// </summary>
+        /// <returns>boolean indicated if this telemetry item should be initialized from an activity.</returns>
+        internal override bool ShouldInitializeFromActivity()
+        {
+            const string RddDiagnosticSourcePrefix = "rdddsc";
+            const string SqlRemoteDependencyType = "SQL";
+
+            return !(this.Type == SqlRemoteDependencyType 
+                && this.Context.GetInternalContext().SdkVersion
+                .StartsWith(RddDiagnosticSourcePrefix, StringComparison.Ordinal));
+        }
     }
 }

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationTelemetry.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationTelemetry.cs
@@ -112,6 +112,16 @@
         }
 
         /// <summary>
+        /// Requests and dependencies are initialized from the current Activity 
+        /// (i.e. telemetry.Id = current.Id). Activity is created for such requests specifically
+        /// Traces, exceptions, events on the other side are children of current activity
+        /// There is one exception - SQL DiagnosticSource where current Activity is a parent
+        /// for dependency calls.
+        /// </summary>
+        /// <returns>boolean indicated if this telemetry item should be initialized from an activity.</returns>
+        internal virtual bool ShouldInitializeFromActivity() => true;
+
+        /// <summary>
         /// Allow to call OperationTelemetry.Sanitize method from child classes.
         /// </summary>
         [SuppressMessage("Microsoft.Performance", "CA1822:MarkMembersAsStatic", Justification = "This method is expected to be overloaded")]


### PR DESCRIPTION
`W3CActivityExtensions.UpdateTelemetry` is called from `W3COperationCorrelationTelemetryInitializer`.

This method is doing extra type casts (for every telemetry item) that I think are unnecessary. 
I moved the if bracket to `DependencyTelemetry` and added a method to the abstract class `OperationTelemetry`