### PR TITLE
Server telemetry channel tests: downgrade AspNetCore to 2.0 to be compatible with netcoreapp2.0 target

### DIFF
--- a/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
+++ b/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
@@ -21,11 +21,11 @@
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />


### PR DESCRIPTION
SDL build complains about package version mismatch 
```
Errors in D:\a\1\s\Test\ServerTelemetryChannel.Test\NetCore20.Tests\TelemetryChannel.netcoreapp20.Tests.csproj
    Package Microsoft.AspNetCore.Hosting 2.2.0 is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0). Package Microsoft.AspNetCore.Hosting 2.2.0 supports: netstandard2.0 (.NETStandard,Version=v2.0)
    Package Microsoft.AspNetCore.Hosting.Abstractions 2.2.0 is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0). Package Microsoft.AspNetCore.Hosting.Abstractions 2.2.0 supports: netstandard2.0 (.NETStandard,Version=v2.0)
    Package Microsoft.Extensions.DependencyInjection.Abstractions 2.2.0 is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0). Package Microsoft.Extensions.DependencyInjection.Abstractions 2.2.0 supports: netstandard2.0 (.NETStandard,Version=v2.0)
    Package Microsoft.AspNetCore.Server.Kestrel 2.2.0 is not compatible with netcoreapp2.0 (.NETCoreApp,Version=v2.0). Package Microsoft.AspNetCore.Server.Kestrel 2.2.0 supports: netstandard2.0 (.NETStandard,Version=v2.0)
    One or more packages are incompatible with .NETCoreApp,Version=v2.0.
```

https://mseng.visualstudio.com/AppInsights/_build/results?buildId=9520686&view=logs&j=fd490c07-0b22-5182-fac9-6d67fe1e939b

fixing asp.net core version to match netcoreapp2.0