### PR TITLE
Obsolete TelemetryConfiguration.Active singleton usage on .NET Core 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.11.0-beta1
+- [Deprecate TelemetryConfiguration.Active on .NET Core in favor of dependency injection pattern](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1148)
+
 ## Version 2.10.0
 - [SDKVersion modified to be dotnetc for NetCore. This helps identify the source of code path, as implementations are slightly different for NetCore.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1125)
 - [Fix telemetry timestamp precision on .NET Framework](https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1175)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
 ## Version 2.11.0-beta1
-- [Deprecate TelemetryConfiguration.Active on .NET Core in favor of dependency injection pattern](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1148)
+- [Deprecate TelemetryConfiguration.Active on .NET Core in favor of dependency injection pattern](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1152)
 
 ## Version 2.10.0
 - [SDKVersion modified to be dotnetc for NetCore. This helps identify the source of code path, as implementations are slightly different for NetCore.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1125)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/DataContracts/DependencyTelemetryTest.cs
@@ -7,6 +7,7 @@
     using System.Linq;
     using KellermanSoftware.CompareNetObjects;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -277,7 +278,7 @@
             Assert.AreEqual(detail, retrievedValue.ToString());
 
             // Clear and verify the detail is no longer present            
-            new TelemetryClient().TrackDependency(telemetry);            
+            new TelemetryClient(TelemetryConfiguration.CreateDefault()).TrackDependency(telemetry);            
             Assert.IsFalse(telemetry.TryGetOperationDetail(key, out retrievedValue));
         }
 
@@ -291,7 +292,7 @@
             Assert.IsNull(retrievedValue);
 
             // should not throw                        
-            new TelemetryClient().TrackDependency(telemetry);
+            new TelemetryClient(TelemetryConfiguration.CreateDefault()).TrackDependency(telemetry);
         }
 
         [TestMethod]

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/OperationHolderTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/OperationHolderTests.cs
@@ -27,7 +27,7 @@
         [ExpectedException(typeof(ArgumentNullException))]
         public void CreatingOperationItemWithNullTelemetryThrowsArgumentNullException()
         {
-            var operationItem = new OperationHolder<DependencyTelemetry>(new TelemetryClient(), null);
+            var operationItem = new OperationHolder<DependencyTelemetry>(new TelemetryClient(TelemetryConfiguration.CreateDefault()), null);
         }
 
         /// <summary>
@@ -36,7 +36,7 @@
         [TestMethod]
         public void CreatingOperationItemDoesNotThrowOnPassingValidArguments()
         {
-            var operationItem = new OperationHolder<DependencyTelemetry>(new TelemetryClient(), new DependencyTelemetry());
+            var operationItem = new OperationHolder<DependencyTelemetry>(new TelemetryClient(TelemetryConfiguration.CreateDefault()), new DependencyTelemetry());
         }
     }
 }

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -1,4 +1,5 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
+﻿#pragma warning disable 612, 618  // obsolete TelemetryConfigration.Active
+namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
 {
     using System;
     using System.Collections.Generic;
@@ -134,3 +135,4 @@
         }
     }
 }
+#pragma warning restore 612, 618  // obsolete TelemetryConfigration.Active

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/HeartbeatTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Tracing/HeartbeatTests.cs
@@ -102,7 +102,8 @@
         [TestMethod]
         public void InitializationOfTelemetryClientDoesntResetHeartbeat()
         {
-            TelemetryClient client = new TelemetryClient();
+            TelemetryConfiguration configuration = TelemetryConfiguration.CreateDefault();
+            TelemetryClient client = new TelemetryClient(configuration);
 
             bool origIsEnabled = true;
             string origExcludedHbProvider = "Nonsense-Test";
@@ -128,7 +129,7 @@
                 }
             }
 
-            TelemetryClient client2 = new TelemetryClient();
+            TelemetryClient client2 = new TelemetryClient(configuration);
 
             foreach (var module in TelemetryModules.Instance.Modules)
             {

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationTest.cs
@@ -80,7 +80,7 @@
         {
             Assert.IsFalse(typeof(TelemetryConfiguration).GetTypeInfo().GetDeclaredProperty("Active").GetSetMethod(true).IsPublic);
         }
-
+#pragma warning disable 612, 618
         [TestMethod]
         public void ActiveIsLazilyInitializedToDelayCostOfLoadingConfigurationFromFile()
         {
@@ -186,7 +186,7 @@
                 TelemetryConfigurationFactory.Instance = null;
             }
         }
-
+#pragma warning restore 612, 618
         #endregion
 
         #region CreateDefault

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/MetricTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/MetricTests.cs
@@ -1,8 +1,7 @@
-﻿using System;
+﻿#pragma warning disable 612, 618  // obsolete TelemetryConfigration.Active
+using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Runtime.ExceptionServices;
 
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Metrics;
@@ -1870,3 +1869,4 @@ namespace Microsoft.ApplicationInsights
         }
     }
 }
+#pragma warning restore 612, 618  // obsolete TelemetryConfigration.Active

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Extensibility/ApplicationInsightsTelemetryPipelineTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Extensibility/ApplicationInsightsTelemetryPipelineTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ApplicationInsights.Metrics.Extensibility
                     Assert.ThrowsException<ArgumentNullException>( () => new ApplicationInsightsTelemetryPipeline((TelemetryConfiguration) null) );
                 }
                 {
-                    TelemetryConfiguration defaultPipeline = TelemetryConfiguration.Active;
+                    TelemetryConfiguration defaultPipeline = TelemetryConfiguration.CreateDefault();
                     //using (defaultPipeline)
                     {
                         var pipelineAdapter = new ApplicationInsightsTelemetryPipeline(defaultPipeline);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/MetricEmissionTestsVirtualTime.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/MetricEmissionTestsVirtualTime.cs
@@ -26,7 +26,7 @@ namespace SomeCustomerNamespace
         [TestMethod]
         public void RecordNormalMetric()
         {
-            TelemetryConfiguration telemetryPipeline = TelemetryConfiguration.Active;
+            TelemetryConfiguration telemetryPipeline = TelemetryConfiguration.CreateDefault();
             //using (telemetryPipeline)
             {
                 RecordNormalMetric(telemetryPipeline);

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/MetricsExamples.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/MetricsExamples.cs
@@ -1,4 +1,4 @@
-﻿#pragma warning disable CA1716  // Namespace naming
+﻿#pragma warning disable CA1716, 612, 618  // Namespace naming, obsolete TelemetryConfigration.Active
 
 namespace User.Namespace.Example01
 {
@@ -1199,4 +1199,4 @@ namespace Microsoft.ApplicationInsights.Metrics.Examples
     }
 }
 
-#pragma warning restore CA1716  // Namespace naming
+#pragma warning restore CA1716, 612, 618  // Namespace naming, obsolete TelemetryConfigration.Active

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/TelemetryConfigurationExtensionsTests.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/TelemetryConfigurationExtensionsTests.cs
@@ -1,16 +1,13 @@
-﻿using System;
-using System.Threading;
+﻿#pragma warning disable 612, 618  // obsolete TelemetryConfigration.Active
+
+using System;
 
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.ApplicationInsights.Metrics;
 using Microsoft.ApplicationInsights.Metrics.TestUtility;
-using Microsoft.ApplicationInsights.Metrics.Extensibility;
 using Microsoft.ApplicationInsights.DataContracts;
-using Microsoft.ApplicationInsights;
-using System.Collections.Generic;
-using Microsoft.ApplicationInsights.Channel;
 
 namespace SomeCustomerNamespace
 {
@@ -139,3 +136,4 @@ namespace SomeCustomerNamespace
         //}
     }
 }
+#pragma warning restore 612, 618  // obsolete TelemetryConfigration.Active

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -2129,6 +2129,7 @@
             return client;
         }
 
+#pragma warning disable 612, 618  // obsolete TelemetryConfigration.Active
         /// <summary>
         /// Resets the TelemetryConfiguration.Active default instance to null so that the iKey auto population paths can be followed for testing.
         /// </summary>
@@ -2136,6 +2137,7 @@
         {
             TelemetryConfiguration.Active = null;
         }
+#pragma warning restore 612, 618  // obsolete TelemetryConfigration.Active
 
         private double ComputeSomethingHeavy()
         {

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/TelemetryClientTest.cs
@@ -101,7 +101,7 @@
         {
             EventTelemetry telemetry = new EventTelemetry("TestEvent");
 
-            new TelemetryClient().Initialize(telemetry);
+            new TelemetryClient(TelemetryConfiguration.CreateDefault()).Initialize(telemetry);
 
             Assert.IsTrue(telemetry.Timestamp != default(DateTimeOffset));
         }
@@ -118,7 +118,7 @@
             for (int i = 0; i < timeStampDiff.Length; i++)
             {
                 var telemetry = new DependencyTelemetry();
-                new TelemetryClient().Initialize(telemetry);
+                new TelemetryClient(TelemetryConfiguration.CreateDefault()).Initialize(telemetry);
 
                 if (i > 0)
                 {
@@ -143,7 +143,7 @@
             PlatformSingleton.Current = new StubPlatform { OnGetMachineName = () => "TestMachine" };
 
             EventTelemetry telemetry = new EventTelemetry("TestEvent");
-            new TelemetryClient().Initialize(telemetry);
+            new TelemetryClient(TelemetryConfiguration.CreateDefault()).Initialize(telemetry);
 
             Assert.AreEqual("TestMachine", telemetry.Context.Cloud.RoleInstance);
             Assert.IsNull(telemetry.Context.Internal.NodeName);
@@ -159,7 +159,7 @@
             EventTelemetry telemetry = new EventTelemetry("TestEvent");
             telemetry.Context.Cloud.RoleInstance = "MyMachineImplementation";
 
-            new TelemetryClient().Initialize(telemetry);
+            new TelemetryClient(TelemetryConfiguration.CreateDefault()).Initialize(telemetry);
 
             Assert.AreEqual("MyMachineImplementation", telemetry.Context.Cloud.RoleInstance);
             Assert.AreEqual("TestMachine", telemetry.Context.Internal.NodeName);
@@ -175,7 +175,7 @@
             EventTelemetry telemetry = new EventTelemetry("TestEvent");
             telemetry.Context.Internal.NodeName = "MyMachineImplementation";
 
-            new TelemetryClient().Initialize(telemetry);
+            new TelemetryClient(TelemetryConfiguration.CreateDefault()).Initialize(telemetry);
 
             Assert.AreEqual("TestMachine", telemetry.Context.Cloud.RoleInstance);
             Assert.AreEqual("MyMachineImplementation", telemetry.Context.Internal.NodeName);
@@ -192,7 +192,7 @@
         {
             EventTelemetry telemetry = new EventTelemetry("TestEvent");
 
-            var tc = new TelemetryClient();
+            var tc = new TelemetryClient(TelemetryConfiguration.CreateDefault());
             // Set ikey on Context
             tc.InstrumentationKey = "mykey";
             tc.InitializeInstrumentationKey(telemetry);
@@ -235,7 +235,7 @@
             EventTelemetry telemetry = new EventTelemetry("TestEvent");
             telemetry.Context.InstrumentationKey = "expectedIKey";
 
-            var tc = new TelemetryClient();
+            var tc = new TelemetryClient(TelemetryConfiguration.CreateDefault());
             tc.InstrumentationKey = "mykey";
             tc.InitializeInstrumentationKey(telemetry);
 

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -73,16 +73,16 @@
             this.telemetrySinks.Add(defaultSink);
         }
 
-#if NETSTANDARD1_3 ||  NETSTANDARD2_0
-        [Obsolete(@"We do not recommend using TelemetryConfiguration.Active on .NET Core.
-Instead we suggest using dependency injection extensions. 
-See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
-#endif
         /// <summary>
         /// Gets the active <see cref="TelemetryConfiguration"/> instance loaded from the ApplicationInsights.config file. 
         /// If the configuration file does not exist, the active configuration instance is initialized with minimum defaults 
         /// needed to send telemetry to Application Insights.
         /// </summary>
+#if NETSTANDARD1_3 || NETSTANDARD2_0
+        [Obsolete(@"We do not recommend using TelemetryConfiguration.Active on .NET Core.
+Instead we suggest using dependency injection extensions. 
+See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
+#endif 
         public static TelemetryConfiguration Active
         {
             get

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -73,6 +73,11 @@
             this.telemetrySinks.Add(defaultSink);
         }
 
+#if NETSTANDARD1_3 ||  NETSTANDARD2_0
+        [Obsolete(@"We do not recommend using TelemetryConfiguration.Active on .NET Core.
+Instead we suggest using dependency injection extensions. 
+See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
+#endif
         /// <summary>
         /// Gets the active <see cref="TelemetryConfiguration"/> instance loaded from the ApplicationInsights.config file. 
         /// If the configuration file does not exist, the active configuration instance is initialized with minimum defaults 

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -79,10 +79,7 @@
         /// needed to send telemetry to Application Insights.
         /// </summary>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
-        [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. " +
-                  "Instead we suggest using dependency injection pattern. " +
-                  "See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 " +
-                  "and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
+        [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 for more details")]
 #endif 
         public static TelemetryConfiguration Active
         {

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -79,9 +79,10 @@
         /// needed to send telemetry to Application Insights.
         /// </summary>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
-        [Obsolete(@"We do not recommend using TelemetryConfiguration.Active on .NET Core.
-Instead we suggest using dependency injection extensions. 
-See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
+        [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. " +
+                  "Instead we suggest using dependency injection pattern. " +
+                  "See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 " +
+                  "and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
 #endif 
         public static TelemetryConfiguration Active
         {

--- a/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
@@ -101,14 +101,16 @@
         /// Specifically, this will also ensure that the <see cref="TelemetryClient" /> used internally for sending extracted metrics uses
         /// the same configuration.
         /// </summary>
-        /// <param name="configuration">The telemetric configuration to be used by this extractor.</param>
+        /// <param name="configuration">The telemetry configuration to be used by this extractor.</param>
         public void Initialize(TelemetryConfiguration configuration)
         {
+#pragma warning disable 612, 618 // TelemetryConfigration.Active and TelemetryClient()
             TelemetryClient metricsClient = (configuration == null)
                                                     ? new TelemetryClient()
                                                     : new TelemetryClient(configuration);
+#pragma warning restore 612, 618 // TelemetryConfigration.Active and TelemetryClient()
 
-            if (false == String.IsNullOrWhiteSpace(MetricTerms.Autocollection.Moniker.Key))
+            if (false == string.IsNullOrWhiteSpace(MetricTerms.Autocollection.Moniker.Key))
             {
                 metricsClient.Context.GlobalProperties[MetricTerms.Autocollection.Moniker.Key] = MetricTerms.Autocollection.Moniker.Value;
             }

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -29,13 +29,15 @@
 #endif
         private readonly TelemetryConfiguration configuration;
         private string sdkVersion;
-        
+
+#pragma warning disable 612, 618
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the active configuration, usually loaded from ApplicationInsights.config.
         /// </summary>
         public TelemetryClient() : this(TelemetryConfiguration.Active)
         {
         }
+#pragma warning restore 612, 618
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the specified <paramref name="configuration"/>.
@@ -47,7 +49,9 @@
             if (configuration == null)
             {
                 CoreEventSource.Log.TelemetryClientConstructorWithNoTelemetryConfiguration();
+#pragma warning disable 612, 618
                 configuration = TelemetryConfiguration.Active;
+#pragma warning restore 612, 618
             }
 
             this.configuration = configuration;

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -30,14 +30,20 @@
         private readonly TelemetryConfiguration configuration;
         private string sdkVersion;
 
-#pragma warning disable 612, 618
+#pragma warning disable 612, 618 // TelemetryConfiguration.Active
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the active configuration, usually loaded from ApplicationInsights.config.
         /// </summary>
+#if NETSTANDARD1_3 || NETSTANDARD2_0
+        [Obsolete("TelemetryClient parameterless constructor uses TelemetryConfiguration.Active singleton. " +
+                  "We do not recommend using TelemetryConfiguration.Active on .NET Core. " + 
+                  "Instead we suggest using dependency injection pattern. " + 
+                  "See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 " + 
+                  "and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
+#endif
         public TelemetryClient() : this(TelemetryConfiguration.Active)
         {
         }
-#pragma warning restore 612, 618
 
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the specified <paramref name="configuration"/>.
@@ -49,9 +55,7 @@
             if (configuration == null)
             {
                 CoreEventSource.Log.TelemetryClientConstructorWithNoTelemetryConfiguration();
-#pragma warning disable 612, 618
                 configuration = TelemetryConfiguration.Active;
-#pragma warning restore 612, 618
             }
 
             this.configuration = configuration;
@@ -61,6 +65,7 @@
                 throw new ArgumentException("The specified configuration does not have a telemetry channel.", nameof(configuration));
             }
         }
+#pragma warning restore 612, 618 // TelemetryConfiguration.Active
 
         /// <summary>
         /// Gets the current context that will be used to augment telemetry you send.

--- a/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -35,11 +35,7 @@
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the active configuration, usually loaded from ApplicationInsights.config.
         /// </summary>
 #if NETSTANDARD1_3 || NETSTANDARD2_0
-        [Obsolete("TelemetryClient parameterless constructor uses TelemetryConfiguration.Active singleton. " +
-                  "We do not recommend using TelemetryConfiguration.Active on .NET Core. " + 
-                  "Instead we suggest using dependency injection pattern. " + 
-                  "See https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2 " + 
-                  "and https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core for more info")]
+        [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 for more details")]
 #endif
         public TelemetryClient() : this(TelemetryConfiguration.Active)
         {


### PR DESCRIPTION
We have a stream of issues and support requests coming from confusion around `TelemetryConfiguration.Active` on ASP.NET Core.

We DO NOT recommend using `TelemetryConfiguration.Active` - instead we recommend using DI from [Microsoft.Extensions.DependencyInjection](https://docs.microsoft.com/en-us/aspnet/core/fundamentals/dependency-injection?view=aspnetcore-2.2). 

In the case of ASP.NET Core or generic host applications, here is an instruction on how to use/configure `TelemetryConfiguration`:  https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-core

This change makes Active obsolete on .NET Core to further discourage its usage there.