### PR TITLE
Update GlobalStaticVersion.props

### DIFF
--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -17,7 +17,7 @@
       as it will restart file versions so 2.4.0-beta1 may have higher 
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
-    <SemanticVersionDate>2019-01-31</SemanticVersionDate>
+    <SemanticVersionDate>2019-07-08</SemanticVersionDate>
     <!--
       Pre-release version is used to distinguish internally built NuGet packages.
       Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16 (max 65535 = ~7 months).

--- a/GlobalStaticVersion.props
+++ b/GlobalStaticVersion.props
@@ -18,7 +18,10 @@
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
     <SemanticVersionDate>2019-01-31</SemanticVersionDate>
-
+    <!--
+      Pre-release version is used to distinguish internally built NuGet packages.
+      Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16 (max 65535 = ~7 months).
+    -->
     <PreReleaseVersion Condition="'$(PreReleaseVersion)'==''">$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(SemanticVersionDate)))).TotalMinutes), 5).ToString('F0'))</PreReleaseVersion>
   </PropertyGroup>
 


### PR DESCRIPTION
- adding missing comment (from other repos).

@cijothomas looks like Dmitry forgot to update the version date when he built Beta 1.
Should we change it now? I expect we will have to change it before we reach Stable.