### PR TITLE
Tilee/sampling includes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## VNext
+- [Fix: Emit warning if user sets both Sampling IncludedTypes and ExcludedTypes. Excluded will take precedence.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1166)
+
 ## Version 2.11.0-beta1
 - [Performance fixes: Support Head Sampling; Remove NewGuid(); Sampling Flags; etc... ](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1158)
 - [Deprecate TelemetryConfiguration.Active on .NET Core in favor of dependency injection pattern](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1152)

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingInternals/SamplingIncludesUtilityTests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingInternals/SamplingIncludesUtilityTests.cs
@@ -8,18 +8,6 @@
     public class SamplingIncludesUtilityTests
     {
         [TestMethod]
-        public void VerifySplitInput()
-        {
-            string input = "A;B;C;;";
-            string[] expected = { "A", "B", "C" };
-
-            var test = SamplingIncludesUtility.SplitInput(input);
-
-            Assert.AreEqual(3, test.Length);
-            CollectionAssert.AreEqual(expected, test);
-        }
-
-        [TestMethod]
         public void VerifyIncludes()
         {
             string input = "DEPENDENCY;EVENT";
@@ -43,6 +31,36 @@
 
             Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.RemoteDependency));
             Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Event));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Exception));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.PageView));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Request));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Message));
+        }
+
+        [TestMethod]
+        public void VerifyIncludesBehaviorWhenBadConfig()
+        {
+            string input = "car;truck;train;";
+
+            var test = SamplingIncludesUtility.CalculateFromIncludes(input);
+
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.RemoteDependency));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Event));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Exception));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.PageView));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Request));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Message));
+        }
+
+        [TestMethod]
+        public void VerifyExcludesBehaviorWhenBadConfig()
+        {
+            string input = "car;truck;train;";
+
+            var test = SamplingIncludesUtility.CalculateFromExcludes(input);
+
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.RemoteDependency));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Event));
             Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Exception));
             Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.PageView));
             Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Request));

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingInternals/SamplingIncludesUtilityTests.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/SamplingInternals/SamplingIncludesUtilityTests.cs
@@ -1,0 +1,52 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation.SamplingInternals
+{
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.SamplingInternals;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class SamplingIncludesUtilityTests
+    {
+        [TestMethod]
+        public void VerifySplitInput()
+        {
+            string input = "A;B;C;;";
+            string[] expected = { "A", "B", "C" };
+
+            var test = SamplingIncludesUtility.SplitInput(input);
+
+            Assert.AreEqual(3, test.Length);
+            CollectionAssert.AreEqual(expected, test);
+        }
+
+        [TestMethod]
+        public void VerifyIncludes()
+        {
+            string input = "DEPENDENCY;EVENT";
+
+            var test = SamplingIncludesUtility.CalculateFromIncludes(input);
+
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.RemoteDependency));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Event));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Exception));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.PageView));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Request));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Message));
+        }
+
+        [TestMethod]
+        public void VerifyExcludes()
+        {
+            string input = "DEPENDENCY;EVENT";
+
+            var test = SamplingIncludesUtility.CalculateFromExcludes(input);
+
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.RemoteDependency));
+            Assert.IsFalse(test.HasFlag(SamplingTelemetryItemTypes.Event));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Exception));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.PageView));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Request));
+            Assert.IsTrue(test.HasFlag(SamplingTelemetryItemTypes.Message));
+        }
+    }
+}

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -334,8 +334,8 @@
                     telemetryProcessors.Process(new RequestTelemetry());
                     return 2;
                 },
-                "pageview;request",
-                "exception;request");
+                excludedTypes: "pageview;request",
+                includedTypes: "exception;request");
         }
 
         [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/SamplingTelemetryProcessorTest.cs
@@ -334,8 +334,8 @@
                     telemetryProcessors.Process(new RequestTelemetry());
                     return 2;
                 },
-                excludedTypes: "pageview;request",
-                includedTypes: "exception;request");
+                "pageview;request",
+                "exception;request");
         }
 
         [TestMethod]

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Shared.Tests.projitems
@@ -40,6 +40,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\NetworkAvailabilityTransmissionPolicyTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\PartialSuccessTransmissionPolicyTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\PlatformFileTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Implementation\SamplingInternals\SamplingIncludesUtilityTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SamplingPercentageEstimatorSettingsTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\SamplingScoreGeneratorTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Implementation\TelemetryBufferTest.cs" />

--- a/src/ServerTelemetryChannel/Implementation/SamplingInternals/SamplingIncludesUtility.cs
+++ b/src/ServerTelemetryChannel/Implementation/SamplingInternals/SamplingIncludesUtility.cs
@@ -1,0 +1,63 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.SamplingInternals
+{
+    using System;
+    using System.Collections.Generic;
+    using Microsoft.ApplicationInsights.DataContracts;
+
+    internal static class SamplingIncludesUtility
+    {
+        private const string DependencyTelemetryName = "DEPENDENCY";
+        private const string EventTelemetryName = "EVENT";
+        private const string ExceptionTelemetryName = "EXCEPTION";
+        private const string PageViewTelemetryName = "PAGEVIEW";
+        private const string RequestTelemetryName = "REQUEST";
+        private const string TraceTelemetryName = "TRACE";
+
+        private static readonly char[] ListSeparators = { ';' };
+        private static readonly IDictionary<string, SamplingTelemetryItemTypes> AllowedTypes;
+
+        static SamplingIncludesUtility()
+        {
+            AllowedTypes = new Dictionary<string, SamplingTelemetryItemTypes>(6, StringComparer.OrdinalIgnoreCase)
+            {
+                { DependencyTelemetryName, SamplingTelemetryItemTypes.RemoteDependency }, //DependencyTelemetry
+                { EventTelemetryName, SamplingTelemetryItemTypes.Event }, //EventTelemetry
+                { ExceptionTelemetryName, SamplingTelemetryItemTypes.Exception }, //ExceptionTelemetry
+                { PageViewTelemetryName, SamplingTelemetryItemTypes.PageView }, //PageViewTelemetry
+                { RequestTelemetryName, SamplingTelemetryItemTypes.Request }, //RequestTelemetry
+                { TraceTelemetryName, SamplingTelemetryItemTypes.Message }, //TraceTelemetry
+            };
+        }
+
+        public static SamplingTelemetryItemTypes CalculateFromIncludes(string includesString)
+        {
+            return Calculate(operation: IncludeOperator, flags: SamplingTelemetryItemTypes.None, input: includesString);
+        }
+
+        public static SamplingTelemetryItemTypes CalculateFromExcludes(string excludesString)
+        {
+            return Calculate(operation: ExcludeOperator, flags: ~SamplingTelemetryItemTypes.None, input: excludesString);
+        }
+
+        private static SamplingTelemetryItemTypes Calculate(Func<SamplingTelemetryItemTypes, SamplingTelemetryItemTypes, SamplingTelemetryItemTypes> operation, SamplingTelemetryItemTypes flags, string input)
+        {
+            if (!string.IsNullOrEmpty(input))
+            {
+                foreach (string item in SplitInput(input))
+                {
+                    if (AllowedTypes.TryGetValue(item, out SamplingTelemetryItemTypes value))
+                    {
+                        flags = operation(flags, value);
+                    }
+                }
+            }
+
+            return flags;
+        }
+
+        public static SamplingTelemetryItemTypes IncludeOperator(SamplingTelemetryItemTypes flags, SamplingTelemetryItemTypes value) => flags |= value;
+        public static SamplingTelemetryItemTypes ExcludeOperator(SamplingTelemetryItemTypes flags, SamplingTelemetryItemTypes value) => flags &= ~value;
+
+        internal static string[] SplitInput(string input) => input.Split(ListSeparators, StringSplitOptions.RemoveEmptyEntries);
+    }
+}

--- a/src/ServerTelemetryChannel/Implementation/SamplingInternals/SamplingIncludesUtility.cs
+++ b/src/ServerTelemetryChannel/Implementation/SamplingInternals/SamplingIncludesUtility.cs
@@ -2,8 +2,12 @@
 {
     using System;
     using System.Collections.Generic;
+
     using Microsoft.ApplicationInsights.DataContracts;
 
+    /// <summary>
+    /// This utility will calculate the IncludedTypes bitmask based on the delimited input string.
+    /// </summary>
     internal static class SamplingIncludesUtility
     {
         private const string DependencyTelemetryName = "DEPENDENCY";
@@ -14,38 +18,51 @@
         private const string TraceTelemetryName = "TRACE";
 
         private static readonly char[] ListSeparators = { ';' };
-        private static readonly IDictionary<string, SamplingTelemetryItemTypes> AllowedTypes;
 
-        static SamplingIncludesUtility()
-        {
-            AllowedTypes = new Dictionary<string, SamplingTelemetryItemTypes>(6, StringComparer.OrdinalIgnoreCase)
-            {
-                { DependencyTelemetryName, SamplingTelemetryItemTypes.RemoteDependency }, //DependencyTelemetry
-                { EventTelemetryName, SamplingTelemetryItemTypes.Event }, //EventTelemetry
-                { ExceptionTelemetryName, SamplingTelemetryItemTypes.Exception }, //ExceptionTelemetry
-                { PageViewTelemetryName, SamplingTelemetryItemTypes.PageView }, //PageViewTelemetry
-                { RequestTelemetryName, SamplingTelemetryItemTypes.Request }, //RequestTelemetry
-                { TraceTelemetryName, SamplingTelemetryItemTypes.Message }, //TraceTelemetry
-            };
-        }
-
+        /// <summary>
+        /// Calculate an Included Bitmask based on the input string.
+        /// Starts with Enum.None value and adds types.
+        /// </summary>
+        /// <param name="includesString">Delimited string of types to be included.</param>
+        /// <returns>Bitmask representing types to include.</returns>
         public static SamplingTelemetryItemTypes CalculateFromIncludes(string includesString)
         {
             return Calculate(operation: IncludeOperator, flags: SamplingTelemetryItemTypes.None, input: includesString);
         }
 
+        /// <summary>
+        /// Calculate an Included Bitmask based on the input string.
+        /// Starts with Enum.ALL (~None) and removes types.
+        /// </summary>
+        /// <param name="excludesString">Delimited string of types to be excluded.</param>
+        /// <returns>Bitmask representing types to include.</returns>
         public static SamplingTelemetryItemTypes CalculateFromExcludes(string excludesString)
         {
             return Calculate(operation: ExcludeOperator, flags: ~SamplingTelemetryItemTypes.None, input: excludesString);
+        }
+
+        private static IDictionary<string, SamplingTelemetryItemTypes> GetAllowedTypes()
+        {
+            return new Dictionary<string, SamplingTelemetryItemTypes>(6, StringComparer.OrdinalIgnoreCase)
+            {
+                { DependencyTelemetryName, SamplingTelemetryItemTypes.RemoteDependency }, // DependencyTelemetry
+                { EventTelemetryName, SamplingTelemetryItemTypes.Event }, // EventTelemetry
+                { ExceptionTelemetryName, SamplingTelemetryItemTypes.Exception }, // ExceptionTelemetry
+                { PageViewTelemetryName, SamplingTelemetryItemTypes.PageView }, // PageViewTelemetry
+                { RequestTelemetryName, SamplingTelemetryItemTypes.Request }, // RequestTelemetry
+                { TraceTelemetryName, SamplingTelemetryItemTypes.Message }, // TraceTelemetry
+            };
         }
 
         private static SamplingTelemetryItemTypes Calculate(Func<SamplingTelemetryItemTypes, SamplingTelemetryItemTypes, SamplingTelemetryItemTypes> operation, SamplingTelemetryItemTypes flags, string input)
         {
             if (!string.IsNullOrEmpty(input))
             {
+                var allowedTypes = GetAllowedTypes();
+
                 foreach (string item in SplitInput(input))
                 {
-                    if (AllowedTypes.TryGetValue(item, out SamplingTelemetryItemTypes value))
+                    if (allowedTypes.TryGetValue(item, out SamplingTelemetryItemTypes value))
                     {
                         flags = operation(flags, value);
                     }
@@ -55,9 +72,10 @@
             return flags;
         }
 
-        public static SamplingTelemetryItemTypes IncludeOperator(SamplingTelemetryItemTypes flags, SamplingTelemetryItemTypes value) => flags |= value;
-        public static SamplingTelemetryItemTypes ExcludeOperator(SamplingTelemetryItemTypes flags, SamplingTelemetryItemTypes value) => flags &= ~value;
+        private static string[] SplitInput(string input) => input.Split(ListSeparators, StringSplitOptions.RemoveEmptyEntries);
 
-        internal static string[] SplitInput(string input) => input.Split(ListSeparators, StringSplitOptions.RemoveEmptyEntries);
+        private static SamplingTelemetryItemTypes IncludeOperator(SamplingTelemetryItemTypes flags, SamplingTelemetryItemTypes value) => flags |= value;
+
+        private static SamplingTelemetryItemTypes ExcludeOperator(SamplingTelemetryItemTypes flags, SamplingTelemetryItemTypes value) => flags &= ~value;
     }
 }

--- a/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -526,6 +526,12 @@
             this.WriteEvent(72, telemetryType ?? string.Empty, this.ApplicationName);
         }
 
+        [Event(73, Message = "Configuration Error: Cannot specify both Included and Excluded types in the sampling processor. Included will be ignored.", Level = EventLevel.Warning)]
+        public void SamplingConfigErrorBothTypes(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(73, this.ApplicationName);
+        }
+
         private static string GetApplicationName()
         {
             //// We want to add application name to all events BUT


### PR DESCRIPTION
Fix Issue #1166.

## Problem:
When configuring Sampling, we allow users to set both the Include and Exclude properties.
This is a logical fallacy because this is a binary decision. An item cannot be both included and excluded.

In our current implementation, the Excluded types will always win over the Included types.
(we actually have a test to guarantee this behavior).

## Solution:
I want to simplify our internal types and codify the assumptions we're making in our evaluation method.

- Store only one list of `includedTypes`
- If a user sets Include **or** Exclude, no change. (This is correct.)
- If a user sets **both** Include **and** Exclude in their config (This is incorrect.)
   - Setting Exclude will always take priority over Include (no change to behavior).
   - New: emit a new event source warning: "_Configuration Error: Exclude will take precedence over Include._".


----------
- [ ] I ran Unit Tests locally.
For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.