### PR TITLE
replace GetEnVar with TryGetEnVar

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Platform/PlatformImplementationTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Platform/PlatformImplementationTest.cs
@@ -55,7 +55,9 @@
             {
                 permission.PermitOnly();
                 PlatformImplementation platform = new PlatformImplementation();
-                Assert.IsNull(platform.GetEnvironmentVariable("PATH"));
+
+                Assert.IsFalse(platform.TryGetEnvironmentVariable("PATH", out string value));
+                Assert.IsNull(value);
                 permission = null;
             }
             finally

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Platform/PlatformImplementationTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/Platform/PlatformImplementationTest.cs
@@ -55,7 +55,6 @@
             {
                 permission.PermitOnly();
                 PlatformImplementation platform = new PlatformImplementation();
-
                 Assert.IsFalse(platform.TryGetEnvironmentVariable("PATH", out string value));
                 Assert.IsNull(value);
                 permission = null;

--- a/Test/TestFramework/Shared/StubPlatform.cs
+++ b/Test/TestFramework/Shared/StubPlatform.cs
@@ -1,11 +1,9 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework
 {
     using System;
-    using System.Collections.Generic;
-    using Microsoft.ApplicationInsights.Channel;
+
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
     internal class StubPlatform : IPlatform
     {
@@ -23,9 +21,10 @@
             return this.OnGetDebugOutput();
         }
 
-        public string GetEnvironmentVariable(string name)
+        public bool TryGetEnvironmentVariable(string name, out string value)
         {
-            return Environment.GetEnvironmentVariable(name);
+            value = Environment.GetEnvironmentVariable(name);
+            return !string.IsNullOrEmpty(value);
         }
 
         public string GetMachineName()

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs
@@ -1,10 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
-    using System;
-    using System.Collections.Generic;
-    using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
 
     /// <summary>
     /// Encapsulates platform-specific functionality required by the API.
@@ -24,8 +20,13 @@
         /// </summary>
         IDebugOutput GetDebugOutput();
 
-        // Read environment variable.
-        string GetEnvironmentVariable(string name);
+        /// <summary>
+        /// Find an environment variable by name. Will evaluate if that variable is empty.
+        /// </summary>
+        /// <param name="name">Name of environment variable.</param>
+        /// <param name="value">Contains the value of the specified name.</param>
+        /// <returns>Returns true if a non-empty value was found.</returns>
+        bool TryGetEnvironmentVariable(string name, out string value);
 
         /// <summary>
         /// Returns the machine name.

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -99,15 +99,22 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
             return this.debugOutput ?? (this.debugOutput = new TelemetryDebugWriter());
         }
 
-        public string GetEnvironmentVariable(string name)
+        /// <inheritdoc />
+        public bool TryGetEnvironmentVariable(string name, out string value)
         {
             if (string.IsNullOrWhiteSpace(name))
             {
                 throw new ArgumentNullException(nameof(name));
             }
 
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentNullException(nameof(name));
+            }
+
             object resultObj = this.environmentVariables?[name];
-            return resultObj != null ? resultObj.ToString() : null;
+            value = resultObj?.ToString();
+            return !string.IsNullOrEmpty(value);
         }
 
         /// <summary>
@@ -181,9 +188,11 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
             return this.debugOutput;
         }
 
-        public string GetEnvironmentVariable(string name)
+        /// <inheritdoc />
+        public bool TryGetEnvironmentVariable(string name, out string value)
         {
-            return Environment.GetEnvironmentVariable(name);
+            value = Environment.GetEnvironmentVariable(name);
+            return !string.IsNullOrEmpty(value);
         }
 
         /// <summary>

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -78,8 +78,7 @@
                 }
 
                 // If an environment variable exists with an instrumentation key then use it (instead) for the "blackfield" scenario.
-                string environmentInstrumentationKey = PlatformSingleton.Current.GetEnvironmentVariable(InstrumentationKeyWebSitesEnvironmentVariable);
-                if (!string.IsNullOrEmpty(environmentInstrumentationKey))
+                if (PlatformSingleton.Current.TryGetEnvironmentVariable(InstrumentationKeyWebSitesEnvironmentVariable, out string environmentInstrumentationKey))
                 {
                     configuration.InstrumentationKey = environmentInstrumentationKey;
                 }


### PR DESCRIPTION
The current implementation requires every caller to check if the value is null.
We have more environment variables coming so I want to improve this.

These are `internal` classes so no change to our public api.