### PR TITLE
improve config exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Metric Aggregator background thread safeguards added to never throw unhandled exception.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1179)
 - [Updated version of System.Diagnostics.DiagnosticSource to 4.6.0-preview7.19362.9. Also remove marking SDK as CLS-Compliant](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1183)
 - [Make BaseSDK use W3C Trace Context based correlation by default. Set TelemetryConfiguration.EnableW3CCorrelation=false to disable this.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1193)
-- [Enhancement: TelemetryConfiguration will specify the name of the property that could not be parsed from a config file.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1194)
+- [Enhancement: Exceptions thrown by the TelemetryConfiguration will now specify the exact name of the property that could not be parsed from a config file.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1194)
 
 ## Version 2.11.0-beta1
 - [Performance fixes: Support Head Sampling; Remove NewGuid(); Sampling Flags; etc... ](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Metric Aggregator background thread safeguards added to never throw unhandled exception.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1179)
 - [Updated version of System.Diagnostics.DiagnosticSource to 4.6.0-preview7.19362.9. Also remove marking SDK as CLS-Compliant](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1183)
 - [Make BaseSDK use W3C Trace Context based correlation by default. Set TelemetryConfiguration.EnableW3CCorrelation=false to disable this.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1193)
+- [Enhancement: TelemetryConfiguration will specify the name of the property that could not be parsed from a config file.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1194)
 
 ## Version 2.11.0-beta1
 - [Performance fixes: Support Head Sampling; Remove NewGuid(); Sampling Flags; etc... ](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1158)

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -275,6 +275,7 @@
         }
 
         [TestMethod]
+        [ExpectedExceptionWithMessage(typeof(ArgumentException), "Failed to parse configuration value. Property: 'TimeSpanProperty' Reason: String was not recognized as a valid TimeSpan.")]
         public void LoadInstanceSetsInstancePropertiesOfTimeSpanTypeFromChildElementValuesOfDefinitionWithInvalidFormatThrowsException()
         {
             var definition = new XElement(
@@ -282,7 +283,7 @@
                 new XAttribute("Type", typeof(StubClassWithProperties).AssemblyQualifiedName),
                 new XElement("TimeSpanProperty", "TestValue"));
 
-            AssertEx.Throws<FormatException>(() => TestableTelemetryConfigurationFactory.LoadInstance(definition, typeof(StubClassWithProperties), null, null));
+            TestableTelemetryConfigurationFactory.LoadInstance(definition, typeof(StubClassWithProperties), null, null);
         }
 
         [TestMethod]
@@ -913,6 +914,23 @@
             TestableTelemetryConfigurationFactory.LoadProperties(definition, instance, null);
 
             Assert.AreEqual(42, instance.Int32Property);
+        }
+
+        [TestMethod]
+        [ExpectedExceptionWithMessage(typeof(ArgumentException), "Failed to parse configuration value. Property: 'IntegerProperty' Reason: Input string was not in a correct format.")]
+        public void LoadPropertiesThrowsExceptionWithPropertyName()
+        {
+            // parsing this integer will throw "System.FormatException: Input string was not in a correct format."
+            // This is not useful without also specifying the errant property name.
+
+            XElement definition = XDocument.Parse(Configuration(
+                @"<TelemetryChannel Type=""" + typeof(StubTelemetryChannel).AssemblyQualifiedName + @""">
+                    <IntegerProperty>123a</IntegerProperty>
+                 </TelemetryChannel>")).Root;
+
+            var instance = new TelemetryConfiguration();
+
+            TestableTelemetryConfigurationFactory.LoadProperties(definition, instance, null);
         }
 
         [TestMethod]

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -934,6 +934,18 @@
         }
 
         [TestMethod]
+        [ExpectedExceptionWithMessage(typeof(ArgumentException), "Failed to parse configuration value. Property: 'IntegerProperty' Reason: Input string was not in a correct format.")]
+        public void LoadProperties_TelemetryClientThrowsException()
+        {
+            string testConfig = Configuration(
+                @"<TelemetryChannel Type=""" + typeof(StubTelemetryChannel).AssemblyQualifiedName + @""">
+                    <IntegerProperty>123a</IntegerProperty>
+                 </TelemetryChannel>");
+
+            new TelemetryClient(TelemetryConfiguration.CreateFromConfiguration(testConfig));
+        }
+
+        [TestMethod]
         public void LoadPropertiesIgnoresNamespaceDeclarationWhenLoadingFromAttributes()
         {
             var definition = new XElement("Definition", new XAttribute("xmlns", "http://somenamespace"));

--- a/Test/TestFramework/Shared/ExpectedExceptionWithMessageAttribute.cs
+++ b/Test/TestFramework/Shared/ExpectedExceptionWithMessageAttribute.cs
@@ -1,0 +1,43 @@
+﻿namespace Microsoft.ApplicationInsights.TestFramework
+{
+    using System;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+
+    /// <summary>
+    /// Extension of <see cref="ExpectedExceptionAttribute"/> class to validate a test based on both the exception type and message.
+    /// </summary>
+    /// <remarks>
+    /// Inspired by StackOverflow answer: https://stackoverflow.com/a/16945443/1466768
+    /// </remarks>
+    public class ExpectedExceptionWithMessageAttribute : ExpectedExceptionBaseAttribute
+    {
+        private readonly Type exceptionType;
+        private readonly string expectedMessage;
+
+        public ExpectedExceptionWithMessageAttribute(Type exceptionType) : this(exceptionType, null)
+        {
+        }
+
+        public ExpectedExceptionWithMessageAttribute(Type exceptionType, string expectedMessage)
+        {
+            this.exceptionType = exceptionType;
+            this.expectedMessage = expectedMessage;
+        }
+
+        protected override void Verify(Exception ex)
+        {
+            if (ex.GetType() != this.exceptionType)
+            {
+                Assert.Fail($"Test method threw exception {this.exceptionType.FullName}, but exception {ex.GetType().FullName} was expected. Exception message: {ex.Message}");
+            }
+
+            if (this.expectedMessage != null && this.expectedMessage != ex.Message)
+            {
+                Assert.Fail($"Test method threw the expected exception type, but with an unexpected message: {ex.Message}");
+            }
+
+            Console.Write("ExpectedExceptionWithMessageAttribute:" + ex.Message);
+        }
+    }
+}

--- a/Test/TestFramework/Shared/StubTelemetryChannel.cs
+++ b/Test/TestFramework/Shared/StubTelemetryChannel.cs
@@ -33,6 +33,11 @@
         /// Gets or sets a value indicating whether to throw an error.
         /// </summary>
         public bool ThrowError { get; set; }
+
+        /// <summary>
+        /// Gets or sets an integer value. This field exists to test config parsing.
+        /// </summary>
+        public int IntegerProperty { get; set; }
     
         /// <summary>
         /// Gets or sets the callback invoked by the <see cref="Send"/> method.

--- a/Test/TestFramework/Shared/TestFramework.Shared.projitems
+++ b/Test/TestFramework/Shared/TestFramework.Shared.projitems
@@ -14,6 +14,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)AsyncTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DeterministicTaskScheduler.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)EventSourceTest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ExpectedExceptionWithMessageAttribute.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MockProcessorModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubException.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubSynchronizationContext.cs" />

--- a/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -426,6 +426,10 @@
             {
                 CoreEventSource.Log.LoadInstanceFromValueConfigurationError(definition.Name.LocalName, definition.Value, e.Message);
             }
+            catch (Exception ex)
+            {
+                throw new ArgumentException($"Failed to parse configuration value. Property: '{definition.Name.LocalName}' Reason: {ex.Message}", ex);
+            }
         }
 
         private static Type GetType(string typeName)


### PR DESCRIPTION
Fix Issue #1194

Change to `TelemetryConfigurationFactory` to throw an exception message specifying the name of the property that could not be parsed.
This is to improve supportability. We know at run time the exact property that could not be parsed and we should specify that for users.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [x] Changes in public surface reviewed
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.