### PR TITLE
Fix ServerTelemetryChannel constructor exception when network info API throws

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Metric Aggregator background thread safeguards added to never throw unhandled exception.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1179)
 - [Updated version of System.Diagnostics.DiagnosticSource to 4.6.0-preview7.19362.9. Also remove marking SDK as CLS-Compliant](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1183)
 - [Enhancement: Exceptions thrown by the TelemetryConfiguration will now specify the exact name of the property that could not be parsed from a config file.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1194)
+- [Fix: ServerTelemetryChannel constructor exception when network info API throws.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1184)
 - [Make BaseSDK use W3C Trace Context based correlation by default. Set TelemetryConfiguration.EnableW3CCorrelation=false to disable this.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1193)
 - [Removed TelemetryConfiguration.EnableW3CCorrelation. Users should do Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical; Activity.ForceDefaultIdFormat = true; to disable W3C Format](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1198)
 

--- a/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/NetworkAvailabilityTransmissionPolicyTest.cs
+++ b/Test/ServerTelemetryChannel.Test/Shared.Tests/Implementation/NetworkAvailabilityTransmissionPolicyTest.cs
@@ -59,6 +59,25 @@
             }
 
             [TestMethod]
+            public void InitializeCatchAllExceptionsAndDoesNotSetCapacity()
+            {
+                var network = new StubNetwork { OnIsAvailable = () => { throw new Exception("error"); } };
+                var policy = new NetworkAvailabilityTransmissionPolicy(network);
+
+                try
+                {
+                    policy.Initialize(new StubTransmitter());
+                }
+                catch(Exception ex)
+                {
+                    Assert.Fail("No exception should have been thrown from Initialize. Exception thrown: " + ex.ToString());
+                }
+
+                Assert.IsNull(policy.MaxSenderCapacity);
+                Assert.IsNull(policy.MaxBufferCapacity);
+            }
+
+            [TestMethod]
             public void DoesNotSetMaxSenderAndBufferCapacitiesToZeroWhenNetworkIsAvailable()
             {
                 var network = new StubNetwork { OnIsAvailable = () => true };

--- a/src/ServerTelemetryChannel/Implementation/NetworkAvailabilityTransmissionPolicy.cs
+++ b/src/ServerTelemetryChannel/Implementation/NetworkAvailabilityTransmissionPolicy.cs
@@ -98,6 +98,10 @@
             {
                 TelemetryChannelEventSource.Log.SubscribeToNetworkFailureWarning(nie.ToString());
             }
+            catch (Exception ex)
+            {
+                TelemetryChannelEventSource.Log.SubscribeToNetworkFailureWarning(ex.ToString());
+            }
 
             return result;
         }


### PR DESCRIPTION
Fix Issue #1184  .
<Short description of the fix.> - Catches generic Exception, along with other well defined exception.

- [x] I ran Unit Tests locally.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.
- [ ] The PR will trigger build, unit tests, and functional tests automatically. If your PR was submitted from fork - mention one of committers to initiate the build for you.
	  If you want to to re-run the build/tests, the easiest way is to simply Close and Re-Open this same PR. (Just click 'close pull request' followed by 'open pull request' buttons at the bottom of the PR)

- Please follow [these] (https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.