### PR TITLE
Set tracestate if available on requests and dependencies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Make BaseSDK use W3C Trace Context based correlation by default. Set TelemetryConfiguration.EnableW3CCorrelation=false to disable this.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1193)
 - [Removed TelemetryConfiguration.EnableW3CCorrelation. Users should do Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical; Activity.ForceDefaultIdFormat = true; to disable W3C Format](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1198)
 - [Enable sampling based on upstream sampling decision for adaptive sampling](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1200)
+- [Set tracestate if available on requests and dependencies](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1207)
 
 ## Version 2.11.0-beta1
 - [Performance fixes: Support Head Sampling; Remove NewGuid(); Sampling Flags; etc... ](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1158)

--- a/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility
 {
-    using System;
     using System.Diagnostics;
 
     using Microsoft.ApplicationInsights;
@@ -15,6 +14,8 @@
     /// </summary>
     public class OperationCorrelationTelemetryInitializer : ITelemetryInitializer
     {
+        private const string TracestatePropertyKey = "tracestate";
+
         /// <summary>
         /// Initializes/Adds operation context to the existing telemetry item.
         /// </summary>
@@ -43,6 +44,15 @@
                         if (string.IsNullOrEmpty(itemOperationContext.ParentId))
                         {
                             itemOperationContext.ParentId = W3CUtilities.FormatTelemetryId(itemOperationContext.Id, currentActivity.SpanId.ToHexString());
+                        }
+
+                        // we are going to set tracestate property on requests and dependencies only
+                        if (!string.IsNullOrEmpty(currentActivity.TraceStateString) &&
+                            telemetryItem is OperationTelemetry &&
+                            telemetryProp != null &&
+                            !telemetryProp.Properties.ContainsKey(TracestatePropertyKey))
+                        {
+                            telemetryProp.Properties.Add(TracestatePropertyKey, currentActivity.TraceStateString);
                         }
                     }
                     else


### PR DESCRIPTION
Tracestate is an optional internal tracing systems context. ApplicationInsights does not parse key-value pairs and blindly propagates context without modification.

In some cases other vendors may be interested in extracting AppInsights data from the backend or intercepting it in other way. For this case, we are going to populate it on request and dependency telemtery only. 