### PR TITLE
Fix StartOperation(Activity) for legacy ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Enable sampling based on upstream sampling decision for adaptive sampling](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1200)
 - [Fix: StartOperation ignores user-provided custom Ids in scope of Activity](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1205)
 - [Set tracestate if available on requests and dependencies](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1207)
+- [Fix: StartOperation(Activity) does not check for Ids compatibility()]
 
 ## Version 2.11.0-beta1
 - [Performance fixes: Support Head Sampling; Remove NewGuid(); Sampling Flags; etc... ](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1158)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This changelog will be used to generate documentation on [release notes page](http://azure.microsoft.com/documentation/articles/app-insights-release-notes-dotnet/).
 
+## Version 2.11.0
+- [Fix: StartOperation(Activity) does not check for Ids compatibility](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1213)
+
 ## Version 2.11.0-beta2
 - [Fix: Emit warning if user sets both Sampling IncludedTypes and ExcludedTypes. Excluded will take precedence.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1166)
 - [Minor perf improvement by reading Actity.Tag only if required.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1170)
@@ -15,7 +18,6 @@ This changelog will be used to generate documentation on [release notes page](ht
 - [Enable sampling based on upstream sampling decision for adaptive sampling](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1200)
 - [Fix: StartOperation ignores user-provided custom Ids in scope of Activity](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1205)
 - [Set tracestate if available on requests and dependencies](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1207)
-- [Fix: StartOperation(Activity) does not check for Ids compatibility()]
 
 ## Version 2.11.0-beta1
 - [Performance fixes: Support Head Sampling; Remove NewGuid(); Sampling Flags; etc... ](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1158)

--- a/Common.props
+++ b/Common.props
@@ -11,6 +11,10 @@
     <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
   </PropertyGroup>
 
+  <PropertyGroup>
+    <LangVersion>7.3</LangVersion>
+  </PropertyGroup>
+ 
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>

--- a/Common.props
+++ b/Common.props
@@ -12,7 +12,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
  
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">

--- a/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
@@ -311,7 +311,7 @@
             {
                 // if parent is not  W3C
                 if (activity.ParentId != null &&
-                    !activity.ParentId.StartsWith("00-"))
+                    !activity.ParentId.StartsWith("00-", StringComparison.Ordinal))
                 {
                     // save parent
                     legacyParent = activity.ParentId;

--- a/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
@@ -305,8 +305,42 @@
                 originalActivity = Activity.Current;
             }
 
+            string legacyRoot = null;
+            string legacyParent = null;
+            if (Activity.DefaultIdFormat == ActivityIdFormat.W3C)
+            {
+                // if parent is not  W3C
+                if (activity.ParentId != null &&
+                    !activity.ParentId.StartsWith("00-"))
+                {
+                    // save parent
+                    legacyParent = activity.ParentId;
+
+                    if (W3CUtilities.IsCompatibleW3CTraceId(activity.RootId))
+                    {
+                        // reuse root id when compatible with trace ID
+                        activity = CopyFromCompatibleRoot(activity);
+                    }
+                    else
+                    {
+                        // or store legacy root in custom property
+                        legacyRoot = activity.RootId;
+                    }
+                }
+            }
+
             activity.Start();
             T operationTelemetry = ActivityToTelemetry<T>(activity);
+
+            if (legacyRoot != null)
+            {
+                operationTelemetry.Properties.Add(W3CConstants.LegacyRootIdProperty, legacyRoot);
+            }
+
+            if (legacyParent != null)
+            {
+                operationTelemetry.Context.Operation.ParentId = legacyParent;
+            }
 
             // We initialize telemetry here AND in Track method because of RichPayloadEventSource.
             // It sends Start and Stop events for OperationTelemetry. During Start event telemetry
@@ -332,15 +366,22 @@
 
             OperationContext operationContext = telemetry.Context.Operation;
             operationContext.Name = activity.GetOperationName();            
-            operationContext.ParentId = activity.ParentId;
+            
             if (activity.IdFormat == ActivityIdFormat.W3C)
             {
-                operationContext.Id = activity.TraceId.ToHexString();                
+                operationContext.Id = activity.TraceId.ToHexString();
                 telemetry.Id = W3CUtilities.FormatTelemetryId(operationContext.Id, activity.SpanId.ToHexString());
+
+                if (string.IsNullOrEmpty(operationContext.ParentId) && activity.ParentSpanId != default)
+                {
+                    operationContext.ParentId =
+                        W3CUtilities.FormatTelemetryId(operationContext.Id, activity.ParentSpanId.ToHexString());
+                }
             }
             else
             {
                 operationContext.Id = activity.RootId;
+                operationContext.ParentId = activity.ParentId;
                 telemetry.Id = activity.Id;
             }
 
@@ -361,6 +402,27 @@
             }
 
             return telemetry;
+        }
+
+        private static Activity CopyFromCompatibleRoot(Activity from)
+        {
+            var copy = new Activity(from.OperationName);
+            copy.SetParentId(ActivityTraceId.CreateFromString(from.RootId.AsSpan()),
+                default(ActivitySpanId), from.ActivityTraceFlags);
+
+            foreach (var tag in from.Tags)
+            {
+                copy.AddTag(tag.Key, tag.Value);
+            }
+
+            foreach (var baggage in from.Baggage)
+            {
+                copy.AddBaggage(baggage.Key, baggage.Value);
+            }
+
+            copy.TraceStateString = from.TraceStateString;
+
+            return copy;
         }
     }
 }


### PR DESCRIPTION
`StartOperation(Activity)` did not check for Id compatibility with W3C and also set wrong parentId.