### PR TITLE
Bug fix in TelemetryConfiguration + ConnectionStrings

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -123,6 +123,44 @@
 
         [TestMethod]
         [TestCategory("ConnectionString")]
+        public void NewTest()
+        {
+
+            string ikeyConfig = "00000000-0000-0000-1111-000000000000";
+            string ikeyConfigConnectionString = "00000000-0000-0000-2222-000000000000";
+
+            // SETUP CONFIG FILE
+            string configString = @"<InstrumentationKey>00000000-0000-0000-1111-000000000000</InstrumentationKey>
+  <TelemetryChannel Type=""Microsoft.ApplicationInsights.Channel.InMemoryChannel, Microsoft.ApplicationInsights"">
+    <EndpointAddress>http://10.0.0.0/v2/track</EndpointAddress>
+    <DeveloperMode>true</DeveloperMode>
+  </TelemetryChannel>";
+
+            string configFileContents = Configuration(configString);
+            TelemetryConfiguration configuration = new TelemetryConfiguration();
+            new TestableTelemetryConfigurationFactory().Initialize(configuration, null, configFileContents);
+
+            Assert.AreEqual(ikeyConfig, configuration.InstrumentationKey);
+            Assert.AreEqual(true, configuration.TelemetryChannel.DeveloperMode);
+            Assert.AreEqual("http://10.0.0.0/v2/track", configuration.TelemetryChannel.EndpointAddress, "failed to set Channel Endpoint to config value");
+
+            TelemetryConfiguration.Active = configuration;
+
+
+
+            TelemetryConfiguration.Active.ConnectionString = $"InstrumentationKey={ikeyConfigConnectionString};IngestionEndpoint=https://localhost:63029/";
+
+            var client = new TelemetryClient();
+
+            Assert.AreEqual(string.Empty, client.InstrumentationKey);
+            Assert.AreEqual(ikeyConfigConnectionString, client.TelemetryConfiguration.InstrumentationKey);
+            Assert.AreEqual("https://localhost:63029/v2/track", client.TelemetryConfiguration.TelemetryChannel.EndpointAddress);
+
+        }
+
+
+        [TestMethod]
+        [TestCategory("ConnectionString")]
         public void VerifySelectInstrumentationKeyChooses_EnVarConnectionString()
         {
             // SETUP

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -125,6 +125,7 @@
         [TestCategory("ConnectionString")]
         public void VerifyChannelEndpointsAreSetWhenParsingFromConfigFile()
         {
+#pragma warning disable CS0618 // Type or member is obsolete
             // PART 1 - CONFIGURATION FACTORY IS EXPECTED TO CREATE A CONFIG THAT MATCHES THE XML
             string ikeyConfig = "00000000-0000-0000-1111-000000000000";
             string ikeyConfigConnectionString = "00000000-0000-0000-2222-000000000000";
@@ -153,7 +154,7 @@
             Assert.AreEqual(string.Empty, client.InstrumentationKey);
             Assert.AreEqual(ikeyConfigConnectionString, client.TelemetryConfiguration.InstrumentationKey);
             Assert.AreEqual("https://localhost:63029/v2/track", client.TelemetryConfiguration.TelemetryChannel.EndpointAddress);
-
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [TestMethod]

--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -123,7 +123,7 @@
 
         [TestMethod]
         [TestCategory("ConnectionString")]
-        public void NewTest()
+        public void VerifyChannelEndpointsAreSetWhenParsingFromConfigFile()
         {
             // PART 1 - CONFIGURATION FACTORY IS EXPECTED TO CREATE A CONFIG THAT MATCHES THE XML
             string ikeyConfig = "00000000-0000-0000-1111-000000000000";
@@ -156,17 +156,9 @@
 
         }
 
-        /// <summary>
-        /// This fails because of a change to Channels.
-        /// Channels previously held a default endpoint value.
-        /// I changed that to read from the TelemetryConfiguration.EndpointContainer.
-        /// EndpointContainer now holds the default values unless overwritten by setting a ConnectionString.
-        /// In this example, No ConnectionString is in use and the Channel holds a custom Endpoint.
-        /// This custom Endpoint is being overwritten by the TelemetryConfiguration.EndpointContainer which is an error.
-        /// </summary>
         [TestMethod]
         [TestCategory("ConnectionString")]
-        public void NewTest2()
+        public void VerifyThatChannelEndpointIsNotOverwrittenIfManuallyConfigured()
         {
             var configuration = new TelemetryConfiguration();
             Assert.AreEqual("https://dc.services.visualstudio.com/", configuration.EndpointContainer.Ingestion.AbsoluteUri);

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -91,7 +91,7 @@
         {
             this.instrumentationKey = instrumentationKey ?? throw new ArgumentNullException(nameof(instrumentationKey));
 
-            SetTelemetryChannelEndpoint(channel, this.EndpointContainer.FormattedIngestionEndpoint);
+            SetTelemetryChannelEndpoint(channel, this.EndpointContainer.FormattedIngestionEndpoint, force: true);
             var defaultSink = new TelemetrySink(this, channel);
             defaultSink.Name = "default";
             this.telemetrySinks.Add(defaultSink);
@@ -296,11 +296,11 @@
                     // UPDATE TELEMETRY CHANNEL
                     foreach (var tSink in this.TelemetrySinks)
                     {
-                        SetTelemetryChannelEndpoint(tSink.TelemetryChannel, this.EndpointContainer.FormattedIngestionEndpoint);
+                        SetTelemetryChannelEndpoint(tSink.TelemetryChannel, this.EndpointContainer.FormattedIngestionEndpoint, force: true);
                     }
 
                     // UPDATE APPLICATION ID PROVIDER
-                    SetApplicationIdEndpoint(this.ApplicationIdProvider, this.EndpointContainer.FormattedApplicationIdEndpoint);
+                    SetApplicationIdEndpoint(this.ApplicationIdProvider, this.EndpointContainer.FormattedApplicationIdEndpoint, force: true);
                 }
                 catch (Exception ex)
                 {
@@ -427,19 +427,25 @@
         /// </summary>
         /// <param name="applicationIdProvider">ApplicationIdProvider to set.</param>
         /// <param name="endpoint">Endpoint value to set.</param>
-        private static void SetApplicationIdEndpoint(IApplicationIdProvider applicationIdProvider, string endpoint)
+        private static void SetApplicationIdEndpoint(IApplicationIdProvider applicationIdProvider, string endpoint, bool force = false)
         {
             if (applicationIdProvider != null)
             {
                 if (applicationIdProvider is ApplicationInsightsApplicationIdProvider applicationInsightsApplicationIdProvider)
                 {
-                    applicationInsightsApplicationIdProvider.ProfileQueryEndpoint = endpoint;
+                    if (force || applicationInsightsApplicationIdProvider.ProfileQueryEndpoint == null)
+                    {
+                        applicationInsightsApplicationIdProvider.ProfileQueryEndpoint = endpoint;
+                    }
                 }
                 else if (applicationIdProvider is DictionaryApplicationIdProvider dictionaryApplicationIdProvider)
                 {
                     if (dictionaryApplicationIdProvider.Next is ApplicationInsightsApplicationIdProvider innerApplicationIdProvider)
                     {
-                        innerApplicationIdProvider.ProfileQueryEndpoint = endpoint;
+                        if (force || innerApplicationIdProvider.ProfileQueryEndpoint == null)
+                        {
+                            innerApplicationIdProvider.ProfileQueryEndpoint = endpoint;
+                        }
                     }
                 }
             }
@@ -451,13 +457,16 @@
         /// </summary>
         /// <param name="channel">TelemetryChannel to set.</param>
         /// <param name="endpoint">Endpoint value to set.</param>
-        private static void SetTelemetryChannelEndpoint(ITelemetryChannel channel, string endpoint)
+        private static void SetTelemetryChannelEndpoint(ITelemetryChannel channel, string endpoint, bool force = false)
         {
             if (channel != null)
             {
                 if (channel is InMemoryChannel || channel.GetType().FullName == "Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel")
                 {
-                    channel.EndpointAddress = endpoint;
+                    if (force || channel.EndpointAddress == null)
+                    {
+                        channel.EndpointAddress = endpoint;
+                    }
                 }
             }
         }

--- a/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -427,6 +427,7 @@
         /// </summary>
         /// <param name="applicationIdProvider">ApplicationIdProvider to set.</param>
         /// <param name="endpoint">Endpoint value to set.</param>
+        /// <param name="force">When the ConnectionString is set, ApplicationId Endpoint should be forced to update. If the ApplicationId has been set separately, we will only set endpoint if it is null.</param>
         private static void SetApplicationIdEndpoint(IApplicationIdProvider applicationIdProvider, string endpoint, bool force = false)
         {
             if (applicationIdProvider != null)
@@ -457,6 +458,7 @@
         /// </summary>
         /// <param name="channel">TelemetryChannel to set.</param>
         /// <param name="endpoint">Endpoint value to set.</param>
+        /// /// <param name="force">When the ConnectionString is set, Channel Endpoint should be forced to update. If the Channel has been set separately, we will only set endpoint if it is null.</param>
         private static void SetTelemetryChannelEndpoint(ITelemetryChannel channel, string endpoint, bool force = false)
         {
             if (channel != null)


### PR DESCRIPTION
Related to #1221

**The Cause**
Channels previously held a default endpoint value.
I changed that to read from the TelemetryConfiguration.EndpointContainer.
EndpointContainer now holds the default values unless overwritten by setting a ConnectionString.
In this example, No ConnectionString is in use and the Channel holds a custom Endpoint.
This custom Endpoint is being overwritten by the TelemetryConfiguration.EndpointContainer which is an error.

**The fix**
I introduced a `force` parameter.
If a Channel has had it's endpoint set before adding to the Configuration, it will not be overwritten.
However, anytime the ConnectionString is set, the Channel will always be overwritten.
