### PR TITLE
fix Transmission Tests

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/TransmissionTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Channel/TransmissionTest.cs
@@ -29,62 +29,57 @@
         }
 
         [TestClass]
-        public class Constructor : TransmissionTest
+        public class Constructor
         {
+            private readonly Uri testUri = new Uri("https://127.0.0.1/");
+
             [TestMethod]
             public void SetsEndpointAddressPropertyToSpecifiedValue()
             {
-                var expectedAddress = new Uri("expected://uri");
-                var transmission = new Transmission(expectedAddress, new byte[1], "content/type", "content/encoding");
-                Assert.AreEqual(expectedAddress, transmission.EndpointAddress);
+                var transmission = new Transmission(testUri, new byte[1], "content/type", "content/encoding");
+                Assert.AreEqual(testUri, transmission.EndpointAddress);
             }
 
             [TestMethod]
-            public void ThrowsArgumentNullExceptionWhenEndpointAddressIsNull()
-            {
-                AssertEx.Throws<ArgumentNullException>(() => new Transmission(null, new byte[1], "content/type", "content/encoding"));
-            }
+            [ExpectedException(typeof(ArgumentNullException))]
+            public void ThrowsArgumentNullExceptionWhenEndpointAddressIsNull() => new Transmission(null, new byte[1], "content/type", "content/encoding");
 
             [TestMethod]
             public void SetsContentPropertyToSpecifiedValue()
             {
                 var expectedContent = new byte[42];
-                var transmission = new Transmission(new Uri("http://address"), expectedContent, "content/type", "content/encoding");
+                var transmission = new Transmission(testUri, expectedContent, "content/type", "content/encoding");
                 Assert.AreSame(expectedContent, transmission.Content);
             }
 
             [TestMethod]
-            public void ThrowsArgumentNullExceptionWhenContentIsNull()
-            {
-                AssertEx.Throws<ArgumentNullException>(() => new Transmission(new Uri("http://address"), (byte[])null, "content/type", "content/encoding"));
-            }
+            [ExpectedException(typeof(ArgumentNullException))]
+            public void ThrowsArgumentNullExceptionWhenContentIsNull() => new Transmission(testUri, (byte[])null, "content/type", "content/encoding");
 
             [TestMethod]
             public void SetsContentTypePropertyToSpecifiedValue()
             {
                 string expectedContentType = "TestContentType123";
-                var transmission = new Transmission(new Uri("http://address"), new byte[1], expectedContentType, "content/encoding");
+                var transmission = new Transmission(testUri, new byte[1], expectedContentType, "content/encoding");
                 Assert.AreSame(expectedContentType, transmission.ContentType);
             }
 
             [TestMethod]
-            public void ThrowsArgumentNullExceptionWhenContentTypeIsNull()
-            {
-                AssertEx.Throws<ArgumentNullException>(() => new Transmission(new Uri("http://address"), new byte[1], null, "content/encoding"));
-            }
+            [ExpectedException(typeof(ArgumentNullException))]
+            public void ThrowsArgumentNullExceptionWhenContentTypeIsNull() => new Transmission(testUri, new byte[1], null, "content/encoding");
 
             [TestMethod]
             public void SetContentEncodingPropertyToSpecifiedValue()
             {
                 string expectedContentEncoding = "gzip";
-                var transmission = new Transmission(new Uri("http://address"), new byte[1], "any/content", expectedContentEncoding);
+                var transmission = new Transmission(testUri, new byte[1], "any/content", expectedContentEncoding);
                 Assert.AreSame(expectedContentEncoding, transmission.ContentEncoding);
             }
 
             [TestMethod]
             public void SetsTimeoutTo100SecondsByDefaultToMatchHttpWebRequest()
             {
-                var transmission = new Transmission(new Uri("http://address"), new byte[1], "content/type", "content/encoding");
+                var transmission = new Transmission(testUri, new byte[1], "content/type", "content/encoding");
                 Assert.AreEqual(TimeSpan.FromSeconds(100), transmission.Timeout);
             }
 
@@ -92,7 +87,7 @@
             public void SetsTimeoutToSpecifiedValue()
             {
                 var expectedValue = TimeSpan.FromSeconds(42);
-                var transmission = new Transmission(new Uri("http://address"), new byte[1], "content/type", "content/encoding", expectedValue);
+                var transmission = new Transmission(testUri, new byte[1], "content/type", "content/encoding", expectedValue);
                 Assert.AreEqual(expectedValue, transmission.Timeout);
             }
         }


### PR DESCRIPTION
**SetsEndpointAddressPropertyToSpecifiedValue**.

This test has failed 44 times in the last 30 days, but the code is literally verifying that the constructor sets a public property!!!!????

This test failed two days ago:
_“Error calling Test Cleanup method for test class Microsoft.ApplicationInsights.Channel.TransmissionTest+Constructor: System.Net.Http.HttpRequestException: Error while copying content to a stream. ---> System.IO.IOException: Unable to read data from the transport connection: An existing connection was forcibly closed by the remote host. ---> System.Net.Sockets.SocketException: An existing connection was forcibly closed by the remote host”_

This is suspicious because this test doesn’t invoke any network operations.
Taking a closer look, this test class inherits some base classes. Reading the comments these seem to only exist to support testing Async operations in .Net 3.5 !!!!
Soooo….. I’m going to remove some of these complicated test dependencies.


**Changes**
- I removed the dependency on the subclasses. This test is literally only testing the constructor. All this extra stuff is not needed.
- I replaced the test Uri with localhost. The Uri class does some non-trivial validation so only creating one should reduce some of the work. Also, IF for some reason this tries to make an outbound test, it should only ping the local host and fail fast.
- I removed the dependenc8y on the AssertEx utility class. This is unnecessary, the MSTest framework is more than capable of catching expected exceptions.