### PR TITLE
Metrics: Support auto-fallback to magic dim value when dim-cap is reached.

### DIFF
--- a/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractorTest.cs
+++ b/Test/Microsoft.ApplicationInsights.Test/Shared/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractorTest.cs
@@ -521,7 +521,7 @@
             //// 8)  Unknown, false: 3
 
             Assert.AreEqual(27 + 8, telemetrySentToChannel.Count);
-            for (int i = 0; i < 35; i++)
+            for (int i = 0; i < telemetrySentToChannel.Count; i++)
             {
                 Assert.IsNotNull(telemetrySentToChannel[i]);
                 if (i == 0 || i == 14)

--- a/src/Microsoft.ApplicationInsights/Metric.cs
+++ b/src/Microsoft.ApplicationInsights/Metric.cs
@@ -58,10 +58,38 @@
                     dimensionValuesCountLimits[d] = configuration.GetValuesPerDimensionLimit(d + 1);
                 }
 
-                this.metricSeries = new MultidimensionalCube2<MetricSeries>(
-                            totalPointsCountLimit: configuration.SeriesCountLimit - 1,
-                            pointsFactory: this.CreateNewMetricSeries,
-                            dimensionValuesCountLimits: dimensionValuesCountLimits);
+                if (configuration.TryGetUnsafeDimCapFallbackDimensionValues(out IEnumerable<string> unsafeDimCapFallbackDimensionValues))
+                {
+                    string[] unsafeDimensionValuesCapFallbackValues = new string[metricIdentifier.DimensionsCount];
+                    int d = 0;
+
+                    foreach (string unsafeFallbackDimValue in unsafeDimCapFallbackDimensionValues)
+                    {
+                        unsafeDimensionValuesCapFallbackValues[d] = unsafeFallbackDimValue;
+                        if (++d == metricIdentifier.DimensionsCount)
+                        {
+                            break;
+                        }
+                    }
+
+                    while (d < metricIdentifier.DimensionsCount)
+                    {
+                        unsafeDimensionValuesCapFallbackValues[d] = null;
+                    }
+
+                    this.metricSeries = new MultidimensionalCube2<MetricSeries>(
+                                                totalPointsCountLimit: configuration.SeriesCountLimit - 1,
+                                                pointsFactory: this.CreateNewMetricSeries,
+                                                dimensionValuesCountLimits: dimensionValuesCountLimits,
+                                                unsafeDimensionValuesCapFallbackValues: unsafeDimensionValuesCapFallbackValues);
+                }
+                else
+                {
+                    this.metricSeries = new MultidimensionalCube2<MetricSeries>(
+                                                totalPointsCountLimit: configuration.SeriesCountLimit - 1,
+                                                pointsFactory: this.CreateNewMetricSeries,
+                                                dimensionValuesCountLimits: dimensionValuesCountLimits);
+                }
 
                 this.zeroDimSeriesList = null;
             }

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalCube2.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalCube2.cs
@@ -348,6 +348,20 @@
                 return result;
             }
 
+            // If we have fallen back to the default dimension value at any time, we may have an existing point:
+
+            if (appliedUnsafeDimensionValuesCapFallback)
+            {
+                pointMoniker = BuildPointMoniker(coordinates);
+
+                hasPoint = this.points.TryGetValue(pointMoniker, out point);
+                if (hasPoint)
+                {
+                    var result = new MultidimensionalPointResult<TPoint>(MultidimensionalPointResultCodes.Success_ExistingPointRetrieved, point);
+                    return result;
+                }
+            }
+
             // Create new point:
 
             try
@@ -370,17 +384,12 @@
             }
 
             { 
-                if (appliedUnsafeDimensionValuesCapFallback)
-                {
-                    pointMoniker = BuildPointMoniker(coordinates);
-                }
-
                 bool added = this.points.TryAdd(pointMoniker, point);
                 if (false == added)
                 {
                     throw new InvalidOperationException(Invariant($"Internal SDK bug. Please report this! (pointMoniker: {pointMoniker})")
                                                       + Invariant($" Info: Failed to add a point to the {nameof(this.points)}-collection in")
-                                                      + Invariant($" class {nameof(MultidimensionalCube2<TPoint>)} despite passing all the cerfification checks."));
+                                                      + Invariant($" class {nameof(MultidimensionalCube2<TPoint>)} despite passing all the certification checks."));
                 }
             }
 

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalCube2.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalCube2.cs
@@ -349,6 +349,7 @@
             }
 
             // If we have fallen back to the default dimension value at any time, we may have an existing point:
+            // (recall, we are still under lock, so there will be no race surprises)
 
             if (appliedUnsafeDimensionValuesCapFallback)
             {

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalPointResult.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalPointResult.cs
@@ -39,7 +39,11 @@
 
         public bool IsPointCreatedNew
         {
-            get { return (this.ResultCode & MultidimensionalPointResultCodes.Success_NewPointCreated) != 0; }
+            get
+            {
+                return ((this.ResultCode & MultidimensionalPointResultCodes.Success_NewPointCreated) != 0)
+                          || ((this.ResultCode & MultidimensionalPointResultCodes.Success_NewPointCreatedAboveDimCapLimit) != 0);
+            }
         }
 
         public bool IsSuccess
@@ -47,7 +51,8 @@
             get
             {
                 return ((this.ResultCode & MultidimensionalPointResultCodes.Success_NewPointCreated) != 0)
-                          || ((this.ResultCode & MultidimensionalPointResultCodes.Success_ExistingPointRetrieved) != 0);
+                          || ((this.ResultCode & MultidimensionalPointResultCodes.Success_ExistingPointRetrieved) != 0)
+                          || ((this.ResultCode & MultidimensionalPointResultCodes.Success_NewPointCreatedAboveDimCapLimit) != 0);
             }
         }
 

--- a/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalPointResultCodes.cs
+++ b/src/Microsoft.ApplicationInsights/Metrics/Implementation/ConcurrentDatastructures/MultidimensionalPointResultCodes.cs
@@ -20,6 +20,12 @@
         Success_ExistingPointRetrieved = 2,
 
         /// <summary>
+        /// A new point was created and returned in this result.
+        /// The newly created point unsafely crosses the specified dimension values count limit for one or more dimensions.
+        /// </summary>
+        Success_NewPointCreatedAboveDimCapLimit = 4,
+
+        /// <summary>
         /// A point could not be created becasue the sub-dimsnions count was reached.
         /// </summary>
         Failure_SubdimensionsCountLimitReached = 8,


### PR DESCRIPTION
Hey @cijothomas 

After we spoke I realized that you were right - one would likely need to touch the Cube to add support for auto-fallback to a special dimension name when the cap is reached.

I looked over the code and I think it would look something like this.

I created this PR for your convenience - please feel free to use it or not as you see fit. If it's useful, please feel free to take over the Metrics.DimCapAPI branch and to add whatever else you feel is necessary to ship this.. Please let me know if you need a code review or any other kind of feedback.

Thanks! 