### PR TITLE
fix Platform tests for netcore3.0

### DIFF
--- a/BASE/Test/ServerTelemetryChannel.Test/net45.Shared.Tests/Implementation/PlatformFileTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/net45.Shared.Tests/Implementation/PlatformFileTest.cs
@@ -249,8 +249,24 @@
             [TestMethod]
             public void ThrowsIOExceptionWhenDesiredFileNameIsTooLong()
             {
-                var file = new PlatformFile(this.platformFile);
-                AssertEx.Throws<PathTooLongException>(() => file.Rename(new string('F', 1024)));
+                bool expectedException = false;
+
+                try
+                {
+                    var file = new PlatformFile(this.platformFile);
+                    file.Rename(new string('F', 1024));
+                }
+                catch (PathTooLongException)
+                {
+                    expectedException = true;
+                }
+                catch (IOException)
+                {
+                    // NET CORE 3.0 changed the exception that can be thrown.
+                    expectedException = true;
+                }
+
+                Assert.IsTrue(expectedException);
             }
 
             [TestMethod]

--- a/BASE/Test/ServerTelemetryChannel.Test/net45.Shared.Tests/Implementation/PlatformFolderTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/net45.Shared.Tests/Implementation/PlatformFolderTest.cs
@@ -168,8 +168,24 @@
             [TestMethod]
             public void ThrowsIOExceptionWhenDesiredFileNameIsTooLong()
             {
-                var folder = new PlatformFolder(this.storageFolder);
-                AssertEx.Throws<PathTooLongException>(() => folder.CreateFile(new string('F', 1024)));
+                bool expectedException = false;
+
+                try
+                {
+                    var folder = new PlatformFolder(this.storageFolder);
+                    folder.CreateFile(new string('F', 1024));
+                }
+                catch (PathTooLongException)
+                {
+                    expectedException = true;
+                }
+                catch (IOException)
+                {
+                    // NET CORE 3.0 changed the exception that can be thrown.
+                    expectedException = true;
+                }
+
+                Assert.IsTrue(expectedException);
             }
 
             [TestMethod]


### PR DESCRIPTION
Discovered while working on #1214

DotNet 3.0 changed the exception that is thrown when a file name is too long.