### PR TITLE
ApplicationInsights logging in NLog and log4net should include ExceptionTelemetry.Message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## VNext
+- [Log4Net includes Message for ExceptionTelemetry](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1315)
+- [NLog includes Message for ExceptionTelemetry](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1315)
 
 ## Version 2.12.0-beta3
 - [Standard Metric extractor for Dependency) add Dependency.ResultCode dimension.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1233)

--- a/LOGGING/src/Log4NetAppender/ApplicationInsightsAppender.cs
+++ b/LOGGING/src/Log4NetAppender/ApplicationInsightsAppender.cs
@@ -186,17 +186,16 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
                 var exceptionTelemetry = new ExceptionTelemetry(loggingEvent.ExceptionObject)
                 {
                     SeverityLevel = GetSeverityLevel(loggingEvent.Level),
+                    Message = $"{loggingEvent.ExceptionObject.GetType().ToString()}: {loggingEvent.ExceptionObject.Message}",
                 };
 
-                string message = null;
                 if (loggingEvent.RenderedMessage != null)
                 {
-                    message = this.RenderLoggingEvent(loggingEvent);
-                }
-
-                if (!string.IsNullOrEmpty(message))
-                {
-                    exceptionTelemetry.Properties.Add("Message", message);
+                    var message = this.RenderLoggingEvent(loggingEvent); 
+                    if (!string.IsNullOrEmpty(message))
+                    {
+                        exceptionTelemetry.Properties.Add("Message", message);
+                    }
                 }
 
                 BuildCustomProperties(loggingEvent, exceptionTelemetry);
@@ -212,7 +211,6 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender
         {
             try
             {
-                loggingEvent.GetProperties();
                 string message = loggingEvent.RenderedMessage != null ? this.RenderLoggingEvent(loggingEvent) : "Log4Net Trace";
 
                 var trace = new TraceTelemetry(message)

--- a/LOGGING/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/LOGGING/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -325,6 +325,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             }
 
             ExceptionTelemetry telemetry = (ExceptionTelemetry)this.appendableLogger.SentItems.First();
+            Assert.IsTrue(telemetry.Message.Contains("Test logging exception"));
             Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message", StringComparison.Ordinal));
         }
 

--- a/LOGGING/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
+++ b/LOGGING/test/Log4NetAppender.Net45.Tests/ApplicationInsightsAppenderTests.cs
@@ -325,7 +325,7 @@ namespace Microsoft.ApplicationInsights.Log4NetAppender.Tests
             }
 
             ExceptionTelemetry telemetry = (ExceptionTelemetry)this.appendableLogger.SentItems.First();
-            Assert.IsTrue(telemetry.Message.Contains("Test logging exception"));
+            Assert.AreEqual("System.Exception: Test logging exception", telemetry.Message);
             Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message", StringComparison.Ordinal));
         }
 

--- a/LOGGING/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/LOGGING/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -305,7 +305,7 @@
             }
 
             var telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
-            Assert.IsTrue(telemetry.Message.Contains("Test logging exception"));
+            Assert.AreEqual("System.Exception: Test logging exception", telemetry.Message);
             Assert.AreEqual(expectedException.Message, telemetry.Exception.Message);
         }
 
@@ -325,7 +325,7 @@
             }
 
             ExceptionTelemetry telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
-            Assert.IsTrue(telemetry.Message.Contains("Test logging exception"));
+            Assert.AreEqual("System.Exception: Test logging exception", telemetry.Message);
             Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message", StringComparison.Ordinal));
         }
 

--- a/LOGGING/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
+++ b/LOGGING/test/NLogTarget.Net45.Tests/NLogTargetTests.cs
@@ -305,6 +305,7 @@
             }
 
             var telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
+            Assert.IsTrue(telemetry.Message.Contains("Test logging exception"));
             Assert.AreEqual(expectedException.Message, telemetry.Exception.Message);
         }
 
@@ -324,6 +325,7 @@
             }
 
             ExceptionTelemetry telemetry = (ExceptionTelemetry)this.adapterHelper.Channel.SentItems.First();
+            Assert.IsTrue(telemetry.Message.Contains("Test logging exception"));
             Assert.IsTrue(telemetry.Properties["Message"].StartsWith("custom message", StringComparison.Ordinal));
         }
 


### PR DESCRIPTION
Non-breaking change for log4net and NLog.

Will improve this screenshot to include Message-details for Exceptions:

![image](https://user-images.githubusercontent.com/11509660/68999914-d0a1cc00-08c7-11ea-97d0-92b260bd96f9.png)
