### PR TITLE
Fix IndexOutOfRange in W3CUtilities.TryParseTraceId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## VNext
+- [Fix IndexOutOfRangeException in W3CUtilities.TryGetTraceId](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1327)
+
 ## Version 2.12.0-beta4
 - [Add support for collecting convention-based Azure SDK activities.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1300)
 - [Log4Net includes Message for ExceptionTelemetry](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1315)

--- a/WEB/Src/Common/W3C/W3CUtilities.cs
+++ b/WEB/Src/Common/W3C/W3CUtilities.cs
@@ -29,7 +29,7 @@
             Debug.Assert(!string.IsNullOrEmpty(legacyId), "diagnosticId must not be null or empty");
 
             traceId = default;
-            if (legacyId[0] == '|' && legacyId.Length >= 33 && legacyId[33] == '.')
+            if (legacyId[0] == '|' && legacyId.Length > 33 && legacyId[33] == '.')
             {
                 for (int i = 1; i < 33; i++)
                 {

--- a/WEB/Src/Web/Web.Net45.Tests/W3CUtilitiesTests.cs
+++ b/WEB/Src/Web/Web.Net45.Tests/W3CUtilitiesTests.cs
@@ -1,0 +1,33 @@
+﻿namespace Microsoft.ApplicationInsights
+{
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class W3CUtilitiesTests
+    {
+        [TestMethod]
+        public void ParseCompatibleTraceIdParent()
+        {
+            Assert.IsTrue(W3C.Internal.W3CUtilities.TryGetTraceId("|0123456789abcdef0123456789abcdef.1.2.3.54.", out var traceId));
+            Assert.AreEqual("0123456789abcdef0123456789abcdef", traceId.ToString());
+        }
+
+        [TestMethod]
+        public void ParseIncompatibleTraceIdParent_Not32HexChars()
+        {
+            Assert.IsFalse(W3C.Internal.W3CUtilities.TryGetTraceId("|0123456789abcdef.1.2.3.54.", out _));
+        }
+
+        [TestMethod]
+        public void ParseIncompatibleTraceIdParent_NotDotAt33()
+        {
+            Assert.IsFalse(W3C.Internal.W3CUtilities.TryGetTraceId("|0123456789abcdef0123456789abcdefx.1.2.3.54.", out _));
+        }
+
+        [TestMethod]
+        public void ParseIncompatibleTraceIdParent_33Length()
+        {
+            Assert.IsFalse(W3C.Internal.W3CUtilities.TryGetTraceId("|0123456789abcdef0123456789abcdef", out _));
+        }
+    }
+}

--- a/WEB/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/WEB/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -133,6 +133,7 @@
     <Compile Include="RequestTrackingTelemetryModuleTest.Net45.cs" />
     <Compile Include="RequestTrackingUtilitiesTest.cs" />
     <Compile Include="SdkVersionUtilsTest.cs" />
+    <Compile Include="W3CUtilitiesTests.cs" />
     <Compile Include="WebApiExceptionLoggerTests.cs" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
Fixes 

```
AI (Internal): [Microsoft-ApplicationInsights-Extensibility-Web] Unknown error, message System.IndexOutOfRangeException: Index was outside the bounds of the array.
   at Microsoft.ApplicationInsights.W3C.Internal.W3CUtilities.TryGetTraceId(String legacyId, ReadOnlySpan`1& traceId)
   at Microsoft.ApplicationInsights.Web.Implementation.RequestTrackingExtensions.CreateRequestTelemetryPrivate(HttpContext platformContext)
   at Microsoft.ApplicationInsights.Web.Implementation.RequestTrackingExtensions.ReadOrCreateRequestTelemetryPrivate(HttpContext platformContext)
   at Microsoft.ApplicationInsights.Web.RequestTrackingTelemetryModule.OnBeginRequest(HttpContext context)
  at Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule.AspNetEventObserver.OnNext(KeyValuePair`2 value)
```