### PR TITLE
fix UpdateRequestTelemetryFromRequest throwing UriFormatException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [Fix IndexOutOfRangeException in W3CUtilities.TryGetTraceId](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1327)
+- [Fix UpdateRequestTelemetryFromRequest throwing UriFormatException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1328)
 
 ## Version 2.12.0-beta4
 - [Add support for collecting convention-based Azure SDK activities.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1300)

--- a/WEB/Src/Common/Common.projitems
+++ b/WEB/Src/Common/Common.projitems
@@ -30,7 +30,4 @@
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard1.6' ">
     <Compile Include="$(MSBuildThisFileDirectory)WebHeaderCollectionExtensions.cs" />
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' and ('$(MSBuildProjectName)' == 'Perf' or '$(MSBuildProjectName)' == 'Web') ">
-    <Compile Include="$(MSBuildThisFileDirectory)RequestTrackingUtilities.cs" />
-  </ItemGroup>
 </Project>

--- a/WEB/Src/Common/RequestTrackingUtilities.cs
+++ b/WEB/Src/Common/RequestTrackingUtilities.cs
@@ -26,7 +26,15 @@ namespace Microsoft.ApplicationInsights.Common
 
             if (requestTelemetry.Url == null)
             {
-                requestTelemetry.Url = request.Unvalidated.Url;
+                try
+                {
+                    requestTelemetry.Url = request.Unvalidated.Url;
+                }
+                catch
+                {
+                    // "AI (Internal): Unknown error, message System.UriFormatException: Invalid URI: The hostname could not be parsed."
+                    // Do nothing here. We cannot force an invalid value into the Uri object.
+                }
             }
 
             if (string.IsNullOrEmpty(requestTelemetry.Source))

--- a/WEB/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/WEB/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -513,7 +513,7 @@
         }
 
         [Event(52, Message = "Failed to set RequestTelemetry URL. RawUrl: '{0}' Exception: '{1}'", Level = EventLevel.Warning)]
-        public void FailedToSetRequestTelemetryUrl(string rawUrl, string exception) => this.WriteEvent(52, rawUrl, exception, this.applicationNameProvider.Name);
+        public void FailedToSetRequestTelemetryUrl(string rawUrl, string exception, string appDomainName = "Incorrect") => this.WriteEvent(52, rawUrl, exception, this.applicationNameProvider.Name);
 
         /// <summary>
         /// Keywords for the PlatformEventSource. Those keywords should match keywords in Core.

--- a/WEB/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
+++ b/WEB/Src/Web/Web.Shared.Net/Implementation/WebEventSource.cs
@@ -502,7 +502,7 @@
 
         [Event(51,
     Keywords = Keywords.Diagnostics,
-    Message = "An error has occured in AzureAppServiceRoleNameFromHostNameHeaderInitializer. Exception: '{0}'",
+    Message = "An error has occurred in AzureAppServiceRoleNameFromHostNameHeaderInitializer. Exception: '{0}'",
     Level = EventLevel.Warning)]
         public void LogAzureAppServiceRoleNameFromHostNameHeaderInitializerWarning(string exception, string appDomainName = "Incorrect")
         {
@@ -511,6 +511,9 @@
                 exception,
                 this.applicationNameProvider.Name);
         }
+
+        [Event(52, Message = "Failed to set RequestTelemetry URL. RawUrl: '{0}' Exception: '{1}'", Level = EventLevel.Warning)]
+        public void FailedToSetRequestTelemetryUrl(string rawUrl, string exception) => this.WriteEvent(52, rawUrl, exception, this.applicationNameProvider.Name);
 
         /// <summary>
         /// Keywords for the PlatformEventSource. Those keywords should match keywords in Core.

--- a/WEB/Src/Web/Web.Shared.Net/RequestTrackingUtilities.cs
+++ b/WEB/Src/Web/Web.Shared.Net/RequestTrackingUtilities.cs
@@ -1,11 +1,13 @@
-namespace Microsoft.ApplicationInsights.Common
+namespace Microsoft.ApplicationInsights.Web
 {
     using System;
     using System.Collections.Specialized;
     using System.Web;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Web.Implementation;
 
     /// <summary>
     /// This class encapsulates setting tracking properties on RequestTelemetry.
@@ -30,10 +32,11 @@ namespace Microsoft.ApplicationInsights.Common
                 {
                     requestTelemetry.Url = request.Unvalidated.Url;
                 }
-                catch
+                catch (Exception ex)
                 {
                     // "AI (Internal): Unknown error, message System.UriFormatException: Invalid URI: The hostname could not be parsed."
                     // Do nothing here. We cannot force an invalid value into the Uri object.
+                    WebEventSource.Log.FailedToSetRequestTelemetryUrl(request.RawUrl, ex.ToInvariantString());
                 }
             }
 

--- a/WEB/Src/Web/Web.Shared.Net/Web.Shared.Net.projitems
+++ b/WEB/Src/Web/Web.Shared.Net/Web.Shared.Net.projitems
@@ -36,6 +36,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ExceptionTrackingTelemetryModule.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)OperationNameTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RequestTrackingTelemetryModule.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RequestTrackingUtilities.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SessionTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)WebTestTelemetryInitializer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)SyntheticUserAgentTelemetryInitializer.cs" />


### PR DESCRIPTION
#1328 


RequestTrackingUtilities was throwing an exception when trying to read an "invalid" URI from HttpRequest.
This adds a try/catch and ETW logging around that exception.

Also, I moved the class RequestTrackingUtilities from the Common sharedproject to the Web project.
No other projects were referencing this class, and this class needed access to Web's EventSource class.