### PR TITLE
add etw log for missing instrumentation key

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Common/InterlockedThrottleTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Common/InterlockedThrottleTests.cs
@@ -15,19 +15,19 @@
 
             var its = new InterlockedThrottle(TimeSpan.FromSeconds(testInterval));
 
-            its.Eval(() => counter++);
-            its.Eval(() => counter++);
-            its.Eval(() => counter++);
-            its.Eval(() => counter++);
+            its.PerformThrottledAction(() => counter++);
+            its.PerformThrottledAction(() => counter++);
+            its.PerformThrottledAction(() => counter++);
+            its.PerformThrottledAction(() => counter++);
 
             Assert.AreEqual(1, counter);
 
             Thread.Sleep(TimeSpan.FromSeconds(testInterval +1));
 
-            its.Eval(() => counter++);
-            its.Eval(() => counter++);
-            its.Eval(() => counter++);
-            its.Eval(() => counter++);
+            its.PerformThrottledAction(() => counter++);
+            its.PerformThrottledAction(() => counter++);
+            its.PerformThrottledAction(() => counter++);
+            its.PerformThrottledAction(() => counter++);
 
             Assert.AreEqual(2, counter);
         }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Common/InterlockedThrottleTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Common/InterlockedThrottleTests.cs
@@ -1,0 +1,35 @@
+﻿namespace Microsoft.ApplicationInsights.Common
+{
+    using System;
+    using System.Threading;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class InterlockedThrottleTests
+    {
+        [TestMethod]
+        public void VerifyInterlockedWorksAsExpected()
+        {
+            int testInterval = 10;
+            var counter = 0;
+
+            var its = new InterlockedThrottle(TimeSpan.FromSeconds(testInterval));
+
+            its.Eval(() => counter++);
+            its.Eval(() => counter++);
+            its.Eval(() => counter++);
+            its.Eval(() => counter++);
+
+            Assert.AreEqual(1, counter);
+
+            Thread.Sleep(TimeSpan.FromSeconds(testInterval +1));
+
+            its.Eval(() => counter++);
+            its.Eval(() => counter++);
+            its.Eval(() => counter++);
+            its.Eval(() => counter++);
+
+            Assert.AreEqual(2, counter);
+        }
+    }
+}

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Microsoft.ApplicationInsights.Shared.Tests.projitems
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Microsoft.ApplicationInsights.Shared.Tests.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)ActivityExtensionsTests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Common\InterlockedThrottleTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)DataContracts\PageViewPerformanceTelemetryTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\DictionarySerializationWriterTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensibility\Implementation\Endpoints\EndpointContainerTests.cs" />

--- a/BASE/src/Common/Common/Common.projitems
+++ b/BASE/src/Common/Common/Common.projitems
@@ -10,5 +10,6 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\ExceptionExtensions.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)InterlockedThrottle.cs" />
   </ItemGroup>
 </Project>

--- a/BASE/src/Common/Common/InterlockedThrottle.cs
+++ b/BASE/src/Common/Common/InterlockedThrottle.cs
@@ -1,0 +1,34 @@
+﻿namespace Microsoft.ApplicationInsights.Common
+{
+    using System;
+    using System.Threading;
+
+    /// <summary>
+    /// This class will hold a timestamp and will perform a given action only if the current time has exceeded an interval.
+    /// </summary>
+    internal class InterlockedThrottle
+    {
+        private readonly TimeSpan interval;
+        private long timeStamp = DateTimeOffset.MinValue.Ticks;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="InterlockedThrottle"/> class.
+        /// </summary>
+        /// <param name="interval">Defines the time period to perform some action.</param>
+        public InterlockedThrottle(TimeSpan interval) => this.interval = interval;
+
+        /// <summary>
+        /// Will execute the action only if the time period has elapsed.
+        /// </summary>
+        /// <param name="action">Action to be executed.</param>
+        public void Eval(Action action)
+        {
+            var now = DateTimeOffset.UtcNow;
+            if (now.Ticks > Interlocked.Read(ref this.timeStamp))
+            {
+                Interlocked.Exchange(ref this.timeStamp, now.Add(this.interval).Ticks);
+                action();
+            }
+        }
+    }
+}

--- a/BASE/src/Common/Common/InterlockedThrottle.cs
+++ b/BASE/src/Common/Common/InterlockedThrottle.cs
@@ -21,7 +21,7 @@
         /// Will execute the action only if the time period has elapsed.
         /// </summary>
         /// <param name="action">Action to be executed.</param>
-        public void Eval(Action action)
+        public void PerformThrottledAction(Action action)
         {
             var now = DateTimeOffset.UtcNow;
             if (now.Ticks > Interlocked.Read(ref this.timeStamp))

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
@@ -148,7 +148,7 @@
                 {
                     if (!Debugger.IsAttached)
                     {
-                        throttleEmptyIkeyLog.PerformThrottledAction(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
+                        this.throttleEmptyIkeyLog.PerformThrottledAction(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
                     }
                 }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Channel
 {
     using System;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
@@ -11,6 +12,9 @@
     {
         private readonly TelemetryBuffer buffer;
         private readonly InMemoryTransmitter transmitter;
+
+        private readonly InterlockedThrottle throttleEmptyIkeyLog = new InterlockedThrottle(interval: TimeSpan.FromSeconds(30));
+
         private bool? developerMode = false;
         private int bufferSize;
 
@@ -138,6 +142,10 @@
                 if (CoreEventSource.IsVerboseEnabled)
                 {
                     CoreEventSource.Log.ItemRejectedNoInstrumentationKey(item.ToString());
+                }
+                else
+                {
+                    throttleEmptyIkeyLog.Eval(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
                 }
 
                 return;

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Channel
 {
     using System;
+    using System.Diagnostics;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
@@ -145,7 +146,10 @@
                 }
                 else
                 {
-                    throttleEmptyIkeyLog.PerformThrottledAction(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
+                    if (!Debugger.IsAttached)
+                    {
+                        throttleEmptyIkeyLog.PerformThrottledAction(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
+                    }
                 }
 
                 return;

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/InMemoryChannel.cs
@@ -145,7 +145,7 @@
                 }
                 else
                 {
-                    throttleEmptyIkeyLog.Eval(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
+                    throttleEmptyIkeyLog.PerformThrottledAction(() => CoreEventSource.Log.TelemetryChannelNoInstrumentationKey());
                 }
 
                 return;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -584,6 +584,9 @@
         [Event(56, Message = "TelemetryConfigurationFactory could not find an InstrumentationKey. This needs to be manually set.", Level = EventLevel.Warning, Keywords = Keywords.UserActionable)]
         public void TelemetryConfigurationFactoryNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(56, this.nameProvider.Name);
 
+        [Event(57, Message = "TransmissionProcessor found a telemetryItem without an InstrumentationKey. This is a required field.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
+        public void TransmissionProcessorNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(57, this.nameProvider.Name);
+
         /// <summary>
         /// Keywords for the PlatformEventSource.
         /// </summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -584,8 +584,8 @@
         [Event(56, Message = "TelemetryConfigurationFactory did not find an InstrumentationKey in your config file. This needs to be set in either your config file or at application startup.", Level = EventLevel.Warning, Keywords = Keywords.UserActionable)]
         public void TelemetryConfigurationFactoryNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(56, this.nameProvider.Name);
 
-        [Event(57, Message = "TransmissionProcessor found a telemetry item without an InstrumentationKey. This is a required field and must be set in either your config file or at application startup.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
-        public void TransmissionProcessorNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(57, this.nameProvider.Name);
+        [Event(57, Message = "TelemetryChannel found a telemetry item without an InstrumentationKey. This is a required field and must be set in either your config file or at application startup.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
+        public void TelemetryChannelNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(57, this.nameProvider.Name);
 
         /// <summary>
         /// Keywords for the PlatformEventSource.

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -581,10 +581,10 @@
         [Event(55, Message = "TelemetryConfigurationFactory overwrote the InstrumentationKey with a value from an Environment Variable: {0}", Level = EventLevel.Informational)]
         public void TelemetryConfigurationFactoryFoundInstrumentationKeyEnvironmentVariable(string variableName, string appDomainName = "Incorrect") => this.WriteEvent(55, variableName, this.nameProvider.Name);
 
-        [Event(56, Message = "TelemetryConfigurationFactory could not find an InstrumentationKey. This needs to be manually set.", Level = EventLevel.Warning, Keywords = Keywords.UserActionable)]
+        [Event(56, Message = "TelemetryConfigurationFactory did not find an InstrumentationKey in your config file. This needs to be set in either your config file or at application startup.", Level = EventLevel.Warning, Keywords = Keywords.UserActionable)]
         public void TelemetryConfigurationFactoryNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(56, this.nameProvider.Name);
 
-        [Event(57, Message = "TransmissionProcessor found a telemetryItem without an InstrumentationKey. This is a required field.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
+        [Event(57, Message = "TransmissionProcessor found a telemetry item without an InstrumentationKey. This is a required field and must be set in either your config file or at application startup.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void TransmissionProcessorNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(57, this.nameProvider.Name);
 
         /// <summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TransmissionProcessor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TransmissionProcessor.cs
@@ -3,6 +3,7 @@
     using System;
 
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// An <see cref="ITelemetryProcessor"/> that act as a proxy to the Transmission of telemetry"/>.
@@ -28,6 +29,11 @@
         public void Process(ITelemetry item)
         {
             TelemetryDebugWriter.WriteTelemetry(item);
+
+            if (string.IsNullOrWhiteSpace(item.Context.InstrumentationKey))
+            {
+                CoreEventSource.Log.TransmissionProcessorNoInstrumentationKey();
+            }
 
             this.sink.TelemetryChannel.Send(item);
         }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TransmissionProcessor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TransmissionProcessor.cs
@@ -3,7 +3,6 @@
     using System;
 
     using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// An <see cref="ITelemetryProcessor"/> that act as a proxy to the Transmission of telemetry"/>.
@@ -29,11 +28,6 @@
         public void Process(ITelemetry item)
         {
             TelemetryDebugWriter.WriteTelemetry(item);
-
-            if (string.IsNullOrWhiteSpace(item.Context.InstrumentationKey))
-            {
-                CoreEventSource.Log.TransmissionProcessorNoInstrumentationKey();
-            }
 
             this.sink.TelemetryChannel.Send(item);
         }

--- a/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -532,6 +532,13 @@
             this.WriteEvent(73, this.ApplicationName);
         }
 
+        [Event(74, Message = "TelemetryChannel found a telemetry item without an InstrumentationKey. This is a required field and must be set in either your config file or at application startup.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
+        public void TelemetryChannelNoInstrumentationKey(string appDomainName = "Incorrect")
+        {
+            this.WriteEvent(74, this.ApplicationName);
+        }
+
+
         private static string GetApplicationName()
         {
             //// We want to add application name to all events BUT

--- a/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -538,7 +538,6 @@
             this.WriteEvent(74, this.ApplicationName);
         }
 
-
         private static string GetApplicationName()
         {
             //// We want to add application name to all events BUT

--- a/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
+++ b/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
@@ -2,6 +2,7 @@
 {
     using System;
     using System.ComponentModel;
+    using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
@@ -274,7 +275,10 @@
                     }
                     else
                     {
-                        emptyIkeyLogTimestamp.Eval(() => TelemetryChannelEventSource.Log.TelemetryChannelNoInstrumentationKey());
+                        if (!Debugger.IsAttached)
+                        {
+                            this.throttleEmptyIkeyLog.PerformThrottledAction(() => TelemetryChannelEventSource.Log.TelemetryChannelNoInstrumentationKey());
+                        }
                     }
 
                     return;

--- a/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
+++ b/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
@@ -5,6 +5,7 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 
@@ -16,6 +17,8 @@
         internal TelemetrySerializer TelemetrySerializer;
         internal TelemetryBuffer TelemetryBuffer;
         internal Transmitter Transmitter;
+
+        private readonly InterlockedThrottle throttleEmptyIkeyLog = new InterlockedThrottle(interval: TimeSpan.FromSeconds(30));
 
         private bool? developerMode;
         private int telemetryBufferCapacity;
@@ -268,6 +271,10 @@
                     if (TelemetryChannelEventSource.IsVerboseEnabled)
                     {
                         TelemetryChannelEventSource.Log.ItemRejectedNoInstrumentationKey(item.ToString());
+                    }
+                    else
+                    {
+                        emptyIkeyLogTimestamp.Eval(() => TelemetryChannelEventSource.Log.TelemetryChannelNoInstrumentationKey());
                     }
 
                     return;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - [Fix IndexOutOfRangeException in W3CUtilities.TryGetTraceId](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1327)
 - [Fix UpdateRequestTelemetryFromRequest throwing UriFormatException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1328)
+- [Add ETW log for missing Instrumentation Key](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1331)
 
 ## Version 2.12.0-beta4
 - [Add support for collecting convention-based Azure SDK activities.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1300)


### PR DESCRIPTION
#1260 

If I telemetry item has made it all the way to the TelemetryChannel without an Ikey, it is safe to assume than an Ikey was never configured.
Here I want to emit a UserActionable ETW Error. 


Note that ETW Event 56 is a config time warning, whereas ETW Event 57 is a channel time error.