### PR TITLE
Even if a telemetry module is disabled, its still added to DI

### DIFF
--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -120,20 +120,7 @@
                     AddCommonInitializers(services);
 
                     // Request Tracking.
-                    services.AddSingleton<ITelemetryModule>(provider =>
-                    {
-                        var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-                        var appIdProvider = provider.GetService<IApplicationIdProvider>();
-
-                        if (options.EnableRequestTrackingTelemetryModule)
-                        {
-                            return new RequestTrackingTelemetryModule(appIdProvider);
-                        }
-                        else
-                        {
-                            return new NoOpTelemetryModule();
-                        }
-                    });
+                    services.AddSingleton<ITelemetryModule, RequestTrackingTelemetryModule>();
 
                     services.ConfigureTelemetryModule<RequestTrackingTelemetryModule>((module, options) =>
                     {

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/RequestTrackingTelemetryModule.cs
@@ -29,7 +29,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore
         private TelemetryClient telemetryClient;
         private ConcurrentBag<IDisposable> subscriptions;
         private HostingDiagnosticListener diagnosticListener;
-        private bool isInitialized = false;
+        internal bool isInitialized = false;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="RequestTrackingTelemetryModule"/> class.

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -309,77 +309,14 @@
 
         private static void AddCommonTelemetryModules(IServiceCollection services)
         {
-            services.AddSingleton<ITelemetryModule>(provider =>
-                {
-                    var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-
-                    if (options.EnablePerformanceCounterCollectionModule)
-                    {
-                        return new PerformanceCollectorModule();
-                    }
-                    else
-                    {
-                        return new NoOpTelemetryModule();
-                    }
-                });
-
-            services.AddSingleton<ITelemetryModule>(provider =>
-            {
-                var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-
-                if (options.EnableAppServicesHeartbeatTelemetryModule)
-                {
-                    return new AppServicesHeartbeatTelemetryModule();
-                }
-                else
-                {
-                    return new NoOpTelemetryModule();
-                }
-            });
-
-            services.AddSingleton<ITelemetryModule>(provider =>
-            {
-                var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-
-                if (options.EnableAzureInstanceMetadataTelemetryModule)
-                {
-                    return new AzureInstanceMetadataTelemetryModule();
-                }
-                else
-                {
-                    return new NoOpTelemetryModule();
-                }
-            });
-
-            services.AddSingleton<ITelemetryModule>(provider =>
-            {
-                var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-
-                if (options.EnableQuickPulseMetricStream)
-                {
-                    return new QuickPulseTelemetryModule();
-                }
-                else
-                {
-                    return new NoOpTelemetryModule();
-                }
-            });
+            services.AddSingleton<ITelemetryModule, PerformanceCollectorModule>();
+            services.AddSingleton<ITelemetryModule, AppServicesHeartbeatTelemetryModule>();
+            services.AddSingleton<ITelemetryModule, AzureInstanceMetadataTelemetryModule>();
+            services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
 
             AddAndConfigureDependencyTracking(services);
 #if NETSTANDARD2_0
-            services.AddSingleton<ITelemetryModule>(provider =>
-            {
-                var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-
-                if (options.EnableEventCounterCollectionModule)
-                {
-                    return new EventCounterCollectionModule();
-                }
-                else
-                {
-                    return new NoOpTelemetryModule();
-                }
-            });
+            services.AddSingleton<ITelemetryModule, EventCounterCollectionModule>();
 #endif
         }
 
@@ -405,19 +342,7 @@
 
         private static void AddAndConfigureDependencyTracking(IServiceCollection services)
         {
-            services.AddSingleton<ITelemetryModule>(provider =>
-            {
-                var options = provider.GetRequiredService<IOptions<ApplicationInsightsServiceOptions>>().Value;
-
-                if (options.EnableDependencyTrackingTelemetryModule)
-                {
-                    return new DependencyTrackingTelemetryModule();
-                }
-                else
-                {
-                    return new NoOpTelemetryModule();
-                }
-            });
+            services.AddSingleton<ITelemetryModule, DependencyTrackingTelemetryModule>();
 
             services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module, o) =>
             {

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
@@ -120,7 +120,8 @@
         public bool EnableHeartbeat { get; set; }
 
         /// <summary>
-        /// Gets or sets a value indicating whether AutoCollectedMetricExtractor are added or not.
+        /// Gets or sets a value indicating whether AutoCollectedMetricExtractors are added or not.
+        /// Defaults to <value>true</value>.
         /// </summary>
         public bool AddAutoCollectedMetricExtractor { get; set; }
 

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -659,7 +659,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<PerformanceCollectorModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<PerformanceCollectorModule>());
+
+                // TODO add unit test to validate that module.isInitialized is false.
+                // similar to being done in UserCanDisableRequestCounterCollectorModule
+                // It requires some restructuring as internals are not accessible
+                // to this test project
             }
 
 #if NETCOREAPP2_0
@@ -675,7 +681,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<EventCounterCollectionModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<EventCounterCollectionModule>());
+
+                // TODO add unit test to validate that module.isInitialized is false.
+                // similar to being done in UserCanDisableRequestCounterCollectorModule
+                // It requires some restructuring as internals are not accessible
+                // to this test project
             }
 #endif
 
@@ -691,7 +703,12 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<RequestTrackingTelemetryModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<RequestTrackingTelemetryModule>());
+                var req = modules.OfType<RequestTrackingTelemetryModule>().First();
+
+                // But the module will not be initialized.
+                Assert.False(req.isInitialized);
             }
 
             [Fact]
@@ -706,7 +723,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<DependencyTrackingTelemetryModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<DependencyTrackingTelemetryModule>());
+
+                // TODO add unit test to validate that module.isInitialized is false.
+                // similar to being done in UserCanDisableRequestCounterCollectorModule
+                // It requires some restructuring as internals are not accessible
+                // to this test project
             }
 
             [Fact]
@@ -721,7 +744,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<QuickPulseTelemetryModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<QuickPulseTelemetryModule>());
+
+                // TODO add unit test to validate that module.isInitialized is false.
+                // similar to being done in UserCanDisableRequestCounterCollectorModule
+                // It requires some restructuring as internals are not accessible
+                // to this test project
             }
 
             [Fact]
@@ -736,7 +765,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<AppServicesHeartbeatTelemetryModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<AppServicesHeartbeatTelemetryModule>());
+
+                // TODO add unit test to validate that module.isInitialized is false.
+                // similar to being done in UserCanDisableRequestCounterCollectorModule
+                // It requires some restructuring as internals are not accessible
+                // to this test project
             }
 
             [Fact]
@@ -751,7 +786,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
-                Assert.Empty(modules.OfType<AzureInstanceMetadataTelemetryModule>());
+                // Even if a module is disabled its still added to DI.
+                Assert.NotEmpty(modules.OfType<AzureInstanceMetadataTelemetryModule>());
+
+                // TODO add unit test to validate that module.isInitialized is false.
+                // similar to being done in UserCanDisableRequestCounterCollectorModule
+                // It requires some restructuring as internals are not accessible
+                // to this test project
             }
 
             [Fact]

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -700,6 +700,8 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 services.AddApplicationInsightsTelemetry(aiOptions);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
+                // Get telemetry client to trigger TelemetryConfig setup.
+                var tc = serviceProvider.GetService<TelemetryClient>();
                 var modules = serviceProvider.GetServices<ITelemetryModule>();
                 Assert.NotNull(modules);
 
@@ -720,7 +722,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 services.AddApplicationInsightsTelemetry(aiOptions);
 
                 IServiceProvider serviceProvider = services.BuildServiceProvider();
-                var modules = serviceProvider.GetServices<ITelemetryModule>();
+                var modules = serviceProvider.GetServices<ITelemetryModule>();                
                 Assert.NotNull(modules);
 
                 // Even if a module is disabled its still added to DI.

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
@@ -28,10 +28,9 @@
             {
                 return builder.ConfigureServices(services =>
                 {
-                    var aiOptions = new ApplicationInsightsServiceOptions();
+                    services.AddApplicationInsightsTelemetry();
                     // disable Dependency tracking (i.e. header injection)
-                    aiOptions.EnableDependencyTrackingTelemetryModule = false;
-                    services.AddApplicationInsightsTelemetry(aiOptions);
+                    services.Remove(services.FirstOrDefault(sd => sd.ImplementationType == typeof(DependencyTrackingTelemetryModule)));                    
                 });
             }
 


### PR DESCRIPTION
But they are not initialized. This is done to maintain backward compatibility as customers might be removing a module by removing it from DI.

Fix: #1282 