### PR TITLE
Trim W3C ids to parent/span Id

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/OperationHolderTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/Implementation/OperationHolderTests.cs
@@ -56,7 +56,7 @@
             var operation = new OperationHolder<DependencyTelemetry>(client, new DependencyTelemetry(), originalActivity);
 
             var newActivity = new Activity("new").SetParentId("detached-parent").Start();
-            operation.Telemetry.Id = $"|{newActivity.TraceId.ToHexString()}.{newActivity.SpanId.ToHexString()}.";
+            operation.Telemetry.Id = newActivity.SpanId.ToHexString();
 
             operation.Dispose();
             Assert.AreEqual(Activity.Current, originalActivity);
@@ -71,7 +71,7 @@
             var operation = new OperationHolder<DependencyTelemetry>(client, new DependencyTelemetry(), null);
 
             var newActivity = new Activity("new").SetParentId("detached-parent").Start();
-            operation.Telemetry.Id = $"|{newActivity.TraceId.ToHexString()}.{newActivity.SpanId.ToHexString()}.";
+            operation.Telemetry.Id = newActivity.SpanId.ToHexString();
 
             operation.Dispose();
             Assert.IsNull(Activity.Current);
@@ -87,7 +87,7 @@
 
             // child of original
             var newActivity = new Activity("new").Start();
-            operation.Telemetry.Id = $"|{newActivity.TraceId.ToHexString()}.{newActivity.SpanId.ToHexString()}.";
+            operation.Telemetry.Id = newActivity.SpanId.ToHexString();
             operation.Dispose();
             Assert.AreEqual(Activity.Current, originalActivity);
         }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -70,8 +70,7 @@
 
             // Validate
             Assert.AreEqual(activity.TraceId.ToHexString(), telemetry.Context.Operation.Id, "OperationCorrelationTelemetryInitializer is expected to populate OperationID from Activity");
-            Assert.AreEqual(W3CUtilities.FormatTelemetryId(activity.TraceId.ToHexString(), activity.SpanId.ToHexString()), 
-                telemetry.Context.Operation.ParentId,
+            Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId,
                 "OperationCorrelationTelemetryInitializer is expected to populate Operation ParentID as |traceID.SpanId. from Activity");
             Assert.AreEqual(originalTelemetryId, telemetry.Id, "OperationCorrelationTelemetryInitializer is not expected to modify Telemetry ID");
             activity.Stop();
@@ -256,7 +255,7 @@
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
             Assert.AreEqual(currentActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-            Assert.AreEqual(W3CUtilities.FormatTelemetryId(currentActivity.TraceId.ToHexString(), currentActivity.SpanId.ToHexString()), telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(currentActivity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
 
             Assert.AreEqual(3, telemetry.Properties.Count);
@@ -278,7 +277,7 @@
             (new OperationCorrelationTelemetryInitializer()).Initialize(telemetry);
 
             Assert.AreEqual(currentActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-            Assert.AreEqual(W3CUtilities.FormatTelemetryId(currentActivity.TraceId.ToHexString(), currentActivity.SpanId.ToHexString()), telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(currentActivity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
 
             Assert.AreEqual("operation", telemetry.Context.Operation.Name);
             Assert.AreEqual(1, telemetry.Properties.Count);

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/StartOperationActivityTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Shared/StartOperationActivityTests.cs
@@ -169,7 +169,7 @@
             var request = this.sendItems.Single() as RequestTelemetry;
             Assert.IsNotNull(request);
             Assert.AreEqual(activity.TraceId.ToHexString(), request.Context.Operation.Id);
-            Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", request.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), request.Id);
             Assert.AreEqual("parentId", request.Context.Operation.ParentId);
         }
 
@@ -203,7 +203,7 @@
             var request = this.sendItems.Single() as RequestTelemetry;
             Assert.IsNotNull(request);
             Assert.AreEqual(activity.TraceId.ToHexString(), request.Context.Operation.Id);
-            Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", request.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), request.Id);
         }
 
         /// <summary>
@@ -419,18 +419,13 @@
         private void ValidateTelemetry<T>(T telemetry, Activity activity, bool isW3C = true, string legacyParentId = null) where T : OperationTelemetry
         {
             Assert.AreEqual(activity.OperationName, telemetry.Name);
-            Assert.AreEqual(
-                isW3C
-                    ? W3CUtilities.FormatTelemetryId(activity.TraceId.ToHexString(), activity.SpanId.ToHexString())
-                    : activity.Id, telemetry.Id);
+            Assert.AreEqual(isW3C ? activity.SpanId.ToHexString() : activity.Id, telemetry.Id);
 
             if (isW3C)
             {
                 if (activity.ParentSpanId != default && activity.ParentSpanId.ToHexString() != "0000000000000000")
                 {
-                    Assert.AreEqual(
-                        W3CUtilities.FormatTelemetryId(activity.TraceId.ToHexString(),
-                            activity.ParentSpanId.ToHexString()), telemetry.Context.Operation.ParentId);
+                    Assert.AreEqual(activity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 }
                 else
                 {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationHolder.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationHolder.cs
@@ -78,7 +78,7 @@
                             var currentActivity = Activity.Current;
                             if (currentActivity == null 
                             || (Activity.DefaultIdFormat != ActivityIdFormat.W3C && operationTelemetry.Id != currentActivity.Id) 
-                            || (Activity.DefaultIdFormat == ActivityIdFormat.W3C && operationTelemetry.Id != W3CUtilities.FormatTelemetryId(currentActivity.TraceId.ToHexString(), currentActivity.SpanId.ToHexString())))
+                            || (Activity.DefaultIdFormat == ActivityIdFormat.W3C && operationTelemetry.Id != currentActivity.SpanId.ToHexString()))
                             {
                                 // W3COperationCorrelationTelemetryInitializer changes Id
                                 // but keeps an original one in 'ai_legacyRequestId' property

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -7,7 +7,6 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Extensibility.W3C;
 
     /// <summary>
     /// Telemetry initializer that populates OperationContext for the telemetry item from Activity.
@@ -64,14 +63,10 @@
                             // itemOperationContext.Id = currentActivity.RootId; // check if this can be used
                             itemOperationContext.Id = currentActivity.TraceId.ToHexString();
 
-                            // Set OperationParentID to ID of parent, constructed as !traceid.spanid.
-                            // ID for auto collected Request,Dependency are constructed as !traceid.spanid, so parentid must be set to the same format.
-                            // While it is possible to set SpanID as the ID for auto collected Request,Dependency we have to stick to this format
-                            // to maintain compatibility. This limitation may go away in the future.
+
                             if (string.IsNullOrEmpty(itemOperationContext.ParentId))
                             {
-                                itemOperationContext.ParentId = W3CUtilities.FormatTelemetryId(itemOperationContext.Id,
-                                    currentActivity.SpanId.ToHexString());
+                                itemOperationContext.ParentId = currentActivity.SpanId.ToHexString();
                             }
                         }
                         else

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -63,7 +63,6 @@
                             // itemOperationContext.Id = currentActivity.RootId; // check if this can be used
                             itemOperationContext.Id = currentActivity.TraceId.ToHexString();
 
-
                             if (string.IsNullOrEmpty(itemOperationContext.ParentId))
                             {
                                 itemOperationContext.ParentId = currentActivity.SpanId.ToHexString();

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/W3C/W3CUtilities.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/W3C/W3CUtilities.cs
@@ -29,16 +29,6 @@
         }
 
         /// <summary>
-        /// Constructs a Telemetry ID from given traceid and span id in the format |traceid.spanid.
-        /// This is the format used by Application Insights.        
-        /// </summary>
-        /// <returns>constructed Telemetry ID.</returns>
-        internal static string FormatTelemetryId(string traceId, string spanId)
-        {
-            return string.Concat("|", traceId, ".", spanId, ".");
-        }
-
-        /// <summary>
         /// Checks if the given string is a valid trace-id as per W3C Specs.
         /// https://github.com/w3c/distributed-tracing/blob/master/trace_context/HTTP_HEADER_FORMAT.md#trace-id .
         /// </summary>

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
@@ -188,9 +188,7 @@
                         telemetryContext.Id = operationActivity.TraceId.ToHexString();
                     }
 
-                    // ID takes the form |TraceID.SpanId. 
-                    // TelemetryContext.Id used instead of TraceID.ToHexString() for perf.
-                    operationTelemetry.Id = W3CUtilities.FormatTelemetryId(telemetryContext.Id, operationActivity.SpanId.ToHexString());
+                    operationTelemetry.Id = operationActivity.SpanId.ToHexString();
                 }
                 else
                 {
@@ -370,12 +368,11 @@
             if (activity.IdFormat == ActivityIdFormat.W3C)
             {
                 operationContext.Id = activity.TraceId.ToHexString();
-                telemetry.Id = W3CUtilities.FormatTelemetryId(operationContext.Id, activity.SpanId.ToHexString());
+                telemetry.Id = activity.SpanId.ToHexString();
 
                 if (string.IsNullOrEmpty(operationContext.ParentId) && activity.ParentSpanId != default)
                 {
-                    operationContext.ParentId =
-                        W3CUtilities.FormatTelemetryId(operationContext.Id, activity.ParentSpanId.ToHexString());
+                    operationContext.ParentId = activity.ParentSpanId.ToHexString();
                 }
             }
             else

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [Upgraded FxCop and fixed several issues related to null checks and disposing objects.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1499)
+- [Switch to compact Id format in W3C mode](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1498)
 
 ## Version 2.12.0
 - [Fix IndexOutOfRangeException in W3CUtilities.TryGetTraceId](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1327)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -289,8 +289,7 @@
 
                 var requestTelemetry = this.InitializeRequestTelemetry(httpContext, currentActivity, Stopwatch.GetTimestamp(), legacyRootId);
 
-                requestTelemetry.Context.Operation.ParentId =
-                    GetParentId(currentActivity, originalParentId, requestTelemetry.Context.Operation.Id);
+                requestTelemetry.Context.Operation.ParentId = GetParentId(currentActivity, originalParentId);
 
                 this.AddAppIdToResponseIfRequired(httpContext, requestTelemetry);
             }
@@ -380,8 +379,7 @@
                 ReadCorrelationContext(requestHeaders, activity);
                 var requestTelemetry = this.InitializeRequestTelemetry(httpContext, activity, timestamp, legacyRootId);
 
-                requestTelemetry.Context.Operation.ParentId =
-                    GetParentId(activity, originalParentId, requestTelemetry.Context.Operation.Id);
+                requestTelemetry.Context.Operation.ParentId = GetParentId(activity, originalParentId);
 
                 this.AddAppIdToResponseIfRequired(httpContext, requestTelemetry);
             }
@@ -575,7 +573,7 @@
         {
         }
 
-        private static string GetParentId(Activity activity, string originalParentId, string operationId)
+        private static string GetParentId(Activity activity, string originalParentId)
         {
             if (activity.IdFormat == ActivityIdFormat.W3C && activity.ParentSpanId != default)
             {

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -582,7 +582,7 @@
                 var parentSpanId = activity.ParentSpanId.ToHexString();
                 if (parentSpanId != "0000000000000000")
                 {
-                    return FormatTelemetryId(operationId, parentSpanId);
+                    return parentSpanId;
                 }
             }
 
@@ -638,11 +638,6 @@
                 result = null;
                 return false;
             }
-        }
-
-        private static string FormatTelemetryId(string traceId, string spanId)
-        {
-            return string.Concat("|", traceId, ".", spanId, ".");
         }
 
         private static void ReadCorrelationContext(IHeaderDictionary requestHeaders, Activity activity)
@@ -763,7 +758,7 @@
             if (activity.IdFormat == ActivityIdFormat.W3C)
             {
                 var traceId = activity.TraceId.ToHexString();
-                requestTelemetry.Id = FormatTelemetryId(traceId, activity.SpanId.ToHexString());
+                requestTelemetry.Id = activity.SpanId.ToHexString();
                 requestTelemetry.Context.Operation.Id = traceId;
                 AspNetCoreEventSource.Instance.RequestTelemetryCreated("W3C", requestTelemetry.Id, traceId);
             }

--- a/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -104,7 +104,7 @@
                 var requestTelemetry = actual.OfType<TelemetryItem<RequestData>>().FirstOrDefault();
                 Assert.NotNull(requestTelemetry);
 
-                Assert.Contains(requestTelemetry.tags["ai.operation.id"], dependencyTelemetry.tags["ai.operation.parentId"]);
+                Assert.Equal(requestTelemetry.data.baseData.id, dependencyTelemetry.tags["ai.operation.parentId"]);
             }
         }
     }

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -507,7 +507,7 @@
                 if (isW3C)
                 {
                     // parentid populated only in W3C mode
-                    ValidateRequestTelemetry(requestTelemetry, activity, true, expectedParentId: "|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.", expectedSource: null);
+                    ValidateRequestTelemetry(requestTelemetry, activity, true, expectedParentId: "e2a5f830c0ee2c46", expectedSource: null);
                     Assert.Equal("value1", requestTelemetry.Properties["prop1"]);
                     Assert.Equal("value2", requestTelemetry.Properties["prop2"]);
                 }
@@ -603,7 +603,7 @@
                 if (IsW3C)
                 {
                     Assert.Equal("4e3083444c10254ba40513c7316332eb", requestTelemetry.Context.Operation.Id);
-                    ValidateRequestTelemetry(requestTelemetry, activity, IsW3C, expectedParentId: "|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.", expectedSource:null);
+                    ValidateRequestTelemetry(requestTelemetry, activity, IsW3C, expectedParentId: "e2a5f830c0ee2c46", expectedSource:null);
                 }
                 else
                 {
@@ -1184,7 +1184,7 @@
                 var requestTelemetry = context.Features.Get<RequestTelemetry>();
                 Assert.NotNull(requestTelemetry);
                 Assert.NotEqual(SamplingDecision.SampledOut, requestTelemetry.ProactiveSamplingDecision);
-                ValidateRequestTelemetry(requestTelemetry, Activity.Current, true, "|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.");
+                ValidateRequestTelemetry(requestTelemetry, Activity.Current, true, "e2a5f830c0ee2c46");
             }
         }
 
@@ -1327,11 +1327,6 @@
             }
         }
 
-        private static string FormatTelemetryId(string traceId, string spanId)
-        {
-            return string.Concat("|", traceId, ".", spanId, ".");
-        }
-
         private void ValidateRequestTelemetry(RequestTelemetry requestTelemetry, Activity activity, bool isW3C, string expectedParentId = null, string expectedSource = null)
         {
             Assert.NotNull(requestTelemetry);
@@ -1339,7 +1334,7 @@
             Assert.Equal(expectedSource, requestTelemetry.Source);
             if (isW3C)
             {
-                Assert.Equal(requestTelemetry.Id, FormatTelemetryId(activity.TraceId.ToHexString(), activity.SpanId.ToHexString()));
+                Assert.Equal(requestTelemetry.Id, activity.SpanId.ToHexString());
                 Assert.Equal(requestTelemetry.Context.Operation.Id, activity.TraceId.ToHexString());
             }
             else

--- a/NETCORE/test/TestApp30.Tests/BasicTestWithCorrelation.cs
+++ b/NETCORE/test/TestApp30.Tests/BasicTestWithCorrelation.cs
@@ -27,7 +27,7 @@ namespace TestApp30.Tests
 
         [Fact]
         public async Task RequestSuccessWithTraceParent()
-        {            
+        {
             // Arrange
             var client = _factory.CreateClient();
             var url = "Home/Index";
@@ -43,11 +43,11 @@ namespace TestApp30.Tests
 
             // Assert
             response.EnsureSuccessStatusCode();
-            
+
             this.output.WriteLine(await response.Content.ReadAsStringAsync());
-            
+
             WaitForTelemetryToArrive();
-            
+
             var items = _factory.sentItems;
             PrintItems(items);
             // 1 Trace from Ilogger, 1 Request
@@ -63,9 +63,8 @@ namespace TestApp30.Tests
             Assert.NotNull(trace);
 
             Assert.Equal("4e3083444c10254ba40513c7316332eb", req.Context.Operation.Id);
-            Assert.Equal("|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.", req.Context.Operation.ParentId);
+            Assert.Equal("e2a5f830c0ee2c46", req.Context.Operation.ParentId);
             Assert.Equal("4e3083444c10254ba40513c7316332eb", trace.Context.Operation.Id);
-            Assert.Contains("|4e3083444c10254ba40513c7316332eb.", req.Id);
             Assert.Equal(req.Id, trace.Context.Operation.ParentId);
 
             Assert.Equal("http://localhost/" + url, req.Url.ToString());
@@ -109,9 +108,8 @@ namespace TestApp30.Tests
 
             Assert.Equal("4e3083444c10254ba40513c7316332eb", req.Context.Operation.Id);
             Assert.Equal("4e3083444c10254ba40513c7316332eb", exception.Context.Operation.Id);
-            Assert.Equal("|4e3083444c10254ba40513c7316332eb.e2a5f830c0ee2c46.", req.Context.Operation.ParentId);
+            Assert.Equal("e2a5f830c0ee2c46", req.Context.Operation.ParentId);
             Assert.Equal(req.Id, exception.Context.Operation.ParentId);
-            Assert.Contains("|4e3083444c10254ba40513c7316332eb.", req.Id);
 
             Assert.Equal("http://localhost/" + url, req.Url.ToString());
             Assert.False(req.Success);
@@ -157,7 +155,6 @@ namespace TestApp30.Tests
             Assert.Equal("40d1a5a08a68c0998e4a3b7c91915ca6", trace.Context.Operation.Id);
 
             Assert.Equal("|40d1a5a08a68c0998e4a3b7c91915ca6.b9e41c35_1.", req.Context.Operation.ParentId);
-            Assert.Contains("|40d1a5a08a68c0998e4a3b7c91915ca6.", req.Id);
             Assert.Equal(req.Id, trace.Context.Operation.ParentId);
 
             Assert.Equal("http://localhost/" + url, req.Url.ToString());
@@ -201,14 +198,12 @@ namespace TestApp30.Tests
 
             Assert.Equal("40d1a5a08a68c0998e4a3b7c91915ca6", req.Context.Operation.Id);
             Assert.Equal("40d1a5a08a68c0998e4a3b7c91915ca6", exception.Context.Operation.Id);
-            
+
             Assert.Equal(req.Id, exception.Context.Operation.ParentId);
             Assert.Equal("|40d1a5a08a68c0998e4a3b7c91915ca6.b9e41c35_1.", req.Context.Operation.ParentId);
-            Assert.Contains("|40d1a5a08a68c0998e4a3b7c91915ca6.", req.Id);
-
             Assert.Equal("http://localhost/" + url, req.Url.ToString());
             Assert.False(req.Success);
-        }        
+        }
 
         [Fact]
         public async Task RequestSuccessWithNonW3CCompatibleRequestId()
@@ -224,7 +219,7 @@ namespace TestApp30.Tests
                 };
             var request = CreateRequestMessage(requestHeaders);
             request.RequestUri = new Uri(client.BaseAddress + url);
-            
+
             var response = await client.SendAsync(request);
 
             // Assert
@@ -250,7 +245,6 @@ namespace TestApp30.Tests
             Assert.NotEqual("noncompatible", trace.Context.Operation.Id);
 
             Assert.Equal("|noncompatible.b9e41c35_1.", req.Context.Operation.ParentId);
-            Assert.Contains($"|{req.Context.Operation.Id}.", req.Id);
             Assert.Equal(req.Id, trace.Context.Operation.ParentId);
             Assert.Equal("noncompatible", req.Properties["ai_legacyRootId"]);
 
@@ -287,11 +281,11 @@ namespace TestApp30.Tests
         private List<T> GetTelemetryOfType<T>(ConcurrentBag<ITelemetry> items)
         {
             List<T> foundItems = new List<T>();
-            foreach(var item in items)
+            foreach (var item in items)
             {
-                if(item is T)
+                if (item is T)
                 {
-                    foundItems.Add((T) item);
+                    foundItems.Add((T)item);
                 }
             }
 
@@ -303,7 +297,7 @@ namespace TestApp30.Tests
             int i = 1;
             foreach (var item in items)
             {
-                this.output.WriteLine("Item " + (i++) + ".");                
+                this.output.WriteLine("Item " + (i++) + ".");
 
                 if (item is RequestTelemetry req)
                 {

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
@@ -94,7 +94,7 @@
                 var actualRequest = this.ValidateRequestWithHeaders(server, RequestPath, headers, expectedRequestTelemetry);
 
                 Assert.Equal("8ee8641cbdd8dd280d239fa2121c7e4e", actualRequest.tags["ai.operation.id"]);
-                Assert.Contains("|8ee8641cbdd8dd280d239fa2121c7e4e.df07da90a5b27d93.", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("|8ee8641cbdd8dd280d239fa2121c7e4e.df07da90a5b27d93.", actualRequest.tags["ai.operation.parentId"]);
                 Assert.Equal("v1", actualRequest.data.baseData.properties["k1"]);
                 Assert.Equal("v2", actualRequest.data.baseData.properties["k2"]);
             }
@@ -135,7 +135,7 @@
                 var actualRequest = this.ValidateRequestWithHeaders(server, RequestPath, headers, expectedRequestTelemetry);
 
                 Assert.NotEqual("noncompatible", actualRequest.tags["ai.operation.id"]);
-                Assert.Contains("|noncompatible.df07da90a5b27d93.", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("|noncompatible.df07da90a5b27d93.", actualRequest.tags["ai.operation.parentId"]);
                 Assert.Equal("noncompatible", actualRequest.data.baseData.properties["ai_legacyRootId"]);
                 Assert.Equal("v1", actualRequest.data.baseData.properties["k1"]);
                 Assert.Equal("v2", actualRequest.data.baseData.properties["k2"]);
@@ -177,7 +177,7 @@
                 var actualRequest = this.ValidateRequestWithHeaders(server, RequestPath, headers, expectedRequestTelemetry);
 
                 Assert.NotEqual("noncompatible", actualRequest.tags["ai.operation.id"]);
-                Assert.Contains("somerandomidnotinanyformat", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("somerandomidnotinanyformat", actualRequest.tags["ai.operation.parentId"]);
                 Assert.Equal("somerandomidnotinanyformat", actualRequest.data.baseData.properties["ai_legacyRootId"]);
                 Assert.Equal("v1", actualRequest.data.baseData.properties["k1"]);
                 Assert.Equal("v2", actualRequest.data.baseData.properties["k2"]);
@@ -218,7 +218,7 @@
                 var actualRequest = this.ValidateRequestWithHeaders(server, RequestPath, headers, expectedRequestTelemetry);
 
                 Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", actualRequest.tags["ai.operation.id"]);
-                Assert.Equal("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("00f067aa0ba902b7", actualRequest.tags["ai.operation.parentId"]);
 
                 // Correlation-Context will be read if either Request-Id or TraceParent available.
                 Assert.True(actualRequest.data.baseData.properties.ContainsKey("k1"));
@@ -265,7 +265,7 @@
 
                 Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", actualRequest.tags["ai.operation.id"]);
                 Assert.NotEqual("8ee8641cbdd8dd280d239fa2121c7e4e", actualRequest.tags["ai.operation.id"]);
-                Assert.Equal("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", actualRequest.tags["ai.operation.parentId"]);
+                Assert.Equal("00f067aa0ba902b7", actualRequest.tags["ai.operation.parentId"]);
 
                 // Correlation-Context will be read if either Request-Id or traceparent is present.
                 Assert.True(actualRequest.data.baseData.properties.ContainsKey("k1"));
@@ -318,7 +318,7 @@
 
                     Assert.Equal("8ee8641cbdd8dd280d239fa2121c7e4e", actualRequest.tags["ai.operation.id"]);
                     Assert.NotEqual("4bf92f3577b34da6a3ce929d0e0e4736", actualRequest.tags["ai.operation.id"]);
-                    Assert.Contains("|8ee8641cbdd8dd280d239fa2121c7e4e.df07da90a5b27d93.", actualRequest.tags["ai.operation.parentId"]);
+                    Assert.Contains("df07da90a5b27d93", actualRequest.tags["ai.operation.parentId"]);
 
                     // Correlation-Context should be read and populated.
                     Assert.True(actualRequest.data.baseData.properties.ContainsKey("k1"));

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestDependencyCorrelationTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestDependencyCorrelationTests.cs
@@ -7,7 +7,6 @@
     using Microsoft.ApplicationInsights.AspNetCore;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility.W3C;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
     using Xunit.Abstractions;
@@ -73,12 +72,12 @@
                     .Start();
 
                 var (request, dependency) = this.ValidateBasicDependency(server, RequestPath, expected);
-                string expectedTraceId = activity.GetTraceId();
-                string expectedParentSpanId = activity.GetSpanId();
+                string expectedTraceId = activity.TraceId.ToHexString();
+                string expectedParentSpanId = activity.SpanId.ToHexString();
 
                 Assert.Equal(expectedTraceId, request.tags["ai.operation.id"]);
                 Assert.Equal(expectedTraceId, dependency.tags["ai.operation.id"]);
-                Assert.Equal($"|{expectedTraceId}.{expectedParentSpanId}.", dependency.tags["ai.operation.parentId"]);
+                Assert.Equal(expectedParentSpanId, dependency.tags["ai.operation.parentId"]);
             }
         }
 

--- a/WEB/Src/Common/StringUtilities.cs
+++ b/WEB/Src/Common/StringUtilities.cs
@@ -63,10 +63,10 @@
         /// <param name="traceId">Trace Id.</param>
         /// <param name="spanId">Span id.</param>
         /// <returns>valid Request-Id.</returns>
-        [Obsolete("Obsolete, implement yourself with 'string.Concat(\"|\", traceId, \".\", spanId, \".\").'")]
+        [Obsolete("Obsolete, use spanId instead")]
         public static string FormatRequestId(string traceId, string spanId)
         {
-            return string.Concat("|", traceId, ".", spanId, ".");
+            return spanId;
         }
     }
 }

--- a/WEB/Src/Common/W3C/W3CConstants.cs
+++ b/WEB/Src/Common/W3C/W3CConstants.cs
@@ -47,8 +47,5 @@
         public const char TracestateAzureSeparator = ';';
 
         internal const string LegacyRootPropertyIdKey = "ai_legacyRootId";
-
-        // TODO[tracestate]: remove, this is done in base SDK
-        internal const string TracestatePropertyKey = "tracestate";
     }
 }

--- a/WEB/Src/Common/W3C/W3CUtilities.cs
+++ b/WEB/Src/Common/W3C/W3CUtilities.cs
@@ -45,10 +45,5 @@
 
             return false;
         }
-
-        internal static string FormatTelemetryId(string traceId, string spanId)
-        {
-            return string.Concat('|', traceId, '.', spanId, '.');
-        }
     }
 }

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -26,6 +26,7 @@
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             Activity.ForceDefaultIdFormat = true;
             this.configuration = new TelemetryConfiguration();
+            this.configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
             this.sentItems = new List<ITelemetry>();
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sentItems.Add(item), EndpointAddress = "https://dc.services.visualstudio.com/v2/track" };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
@@ -79,9 +80,9 @@
                 Assert.AreEqual("InProc", telemetry.Type);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 
@@ -113,7 +114,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -139,7 +140,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -177,7 +178,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 // does not throw
                 var jsonSettingThrowOnError = new JsonSerializerSettings
@@ -233,7 +234,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -272,7 +273,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(httpActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{httpActivity.TraceId.ToHexString()}.{httpActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(httpActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -306,7 +307,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(httpActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{httpActivity.TraceId.ToHexString()}.{httpActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(httpActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -341,7 +342,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(httpActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{httpActivity.TraceId.ToHexString()}.{httpActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(httpActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -376,7 +377,7 @@
                 Assert.AreEqual(exception.ToInvariantString(), telemetry.Properties["Error"]);
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 
@@ -409,7 +410,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
             }
         }
 

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/ClientServerDependencyTrackerTests.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/ClientServerDependencyTrackerTests.cs
@@ -85,9 +85,9 @@
             Assert.AreNotEqual(parentActivity, currentActivity);
             Assert.AreEqual(parentActivity, currentActivity.Parent);
 
-            Assert.AreEqual($"|{currentActivity.TraceId.ToHexString()}.{currentActivity.SpanId.ToHexString()}.", telemetry.Id);
+            Assert.AreEqual(currentActivity.SpanId.ToHexString(), telemetry.Id);
             Assert.AreEqual(currentActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-            Assert.AreEqual($"|{currentActivity.TraceId.ToHexString()}.{currentActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(currentActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
 
             var properties = telemetry.Properties;
             Assert.AreEqual(2, properties.Count);
@@ -105,7 +105,7 @@
             Assert.IsNotNull(Activity.Current);
             Assert.IsNull(currentActivity.Parent);
 
-            Assert.AreEqual($"|{currentActivity.TraceId.ToHexString()}.{currentActivity.SpanId.ToHexString()}.", telemetry.Id);
+            Assert.AreEqual(currentActivity.SpanId.ToHexString(), telemetry.Id);
             Assert.AreEqual(currentActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
             Assert.IsNull(telemetry.Context.Operation.ParentId);
 
@@ -152,9 +152,9 @@
 
             var telemetry = ClientServerDependencyTracker.BeginTracking(this.telemetryClient);
 
-            Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", telemetry.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Id);
             Assert.AreEqual(activity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-            Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+            Assert.AreEqual(activity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
 
             var properties = telemetry.Properties;
             Assert.AreEqual(1, properties.Count);

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netcore20.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netcore20.cs
@@ -116,10 +116,8 @@ namespace Microsoft.ApplicationInsights.Tests
                 // check only legacy headers here
                 Assert.AreEqual(activity.RootId,
                     requestMsg.Headers.GetValues(RequestResponseHeaders.StandardRootIdHeader).Single());
-                Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.",
-                    requestMsg.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
-                Assert.AreEqual(this.testApplicationId1,
-                    GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+                Assert.AreEqual(activity.SpanId.ToHexString(), requestMsg.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
+                Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
             }
         }
 
@@ -187,9 +185,7 @@ namespace Microsoft.ApplicationInsights.Tests
                 Assert.AreEqual(activity.RootId, telemetry.Context.Operation.Id);
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
 
-                Assert.AreEqual(
-                    string.Concat('|', telemetry.Context.Operation.Id, '.', activity.SpanId.ToHexString(), '.'),
-                    telemetry.Id);
+                Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Id);
                 Assert.AreEqual("v", telemetry.Properties["k"]);
 
                 Assert.AreEqual(32, telemetry.Context.Operation.Id.Length);
@@ -285,7 +281,7 @@ namespace Microsoft.ApplicationInsights.Tests
 
                 Assert.IsNotNull(telemetry);
                 Assert.AreEqual("0123456789abcdef0123456789abcdef", telemetry.Context.Operation.Id);
-                Assert.AreEqual("|0123456789abcdef0123456789abcdef.0123456789abcdef.",
+                Assert.AreEqual("0123456789abcdef",
                     telemetry.Context.Operation.ParentId);
             }
         }
@@ -312,8 +308,7 @@ namespace Microsoft.ApplicationInsights.Tests
 
                 Assert.IsNotNull(telemetry);
                 Assert.AreEqual(parent.RootId, telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{parent.RootId}.{parent.SpanId.ToHexString()}.",
-                    telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(parent.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
             }
         }
 
@@ -342,9 +337,8 @@ namespace Microsoft.ApplicationInsights.Tests
 
                 Assert.IsNotNull(telemetry);
                 Assert.AreEqual(parent.RootId, telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.ParentSpanId.ToHexString()}.",
-                    telemetry.Context.Operation.ParentId);
-                Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(activity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(activity.SpanId.ToHexString(), telemetry.Id);
                 Assert.AreEqual("v", telemetry.Properties["k"]);
 
                 string expectedVersion =

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netcore30.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/DependencyCollectorDiagnosticListenerTests.Netcore30.cs
@@ -94,10 +94,8 @@ namespace Microsoft.ApplicationInsights.Tests
                 // check only legacy headers here
                 Assert.AreEqual(activity.RootId,
                     requestMsg.Headers.GetValues(RequestResponseHeaders.StandardRootIdHeader).Single());
-                Assert.AreEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.",
-                    requestMsg.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
-                Assert.AreEqual(this.testApplicationId1,
-                    GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
+                Assert.AreEqual(activity.SpanId.ToHexString(), requestMsg.Headers.GetValues(RequestResponseHeaders.StandardParentIdHeader).Single());
+                Assert.AreEqual(this.testApplicationId1, GetRequestContextKeyValue(requestMsg, RequestResponseHeaders.RequestContextCorrelationSourceKey));
             }
         }
 

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/EventHubsDiagnosticListenerTests.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/EventHubsDiagnosticListenerTests.cs
@@ -25,6 +25,7 @@
             Activity.DefaultIdFormat = ActivityIdFormat.W3C;
             Activity.ForceDefaultIdFormat = true;
             this.configuration = new TelemetryConfiguration();
+            this.configuration.TelemetryInitializers.Add(new OperationCorrelationTelemetryInitializer());
             this.sentItems = new List<ITelemetry>();
             this.configuration.TelemetryChannel = new StubTelemetryChannel { OnSend = item => this.sentItems.Add(item), EndpointAddress = "https://dc.services.visualstudio.com/v2/track" };
             this.configuration.InstrumentationKey = Guid.NewGuid().ToString();
@@ -87,9 +88,9 @@
                 Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
@@ -127,9 +128,9 @@
                 Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
@@ -167,9 +168,9 @@
                 Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
@@ -207,9 +208,9 @@
                 Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
@@ -285,7 +286,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
                 Assert.AreEqual("ehname", telemetry.Properties["eh.event_hub_name"]);
@@ -319,7 +320,7 @@
 
                 Assert.AreEqual("parent", telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);
                 Assert.AreEqual("ehname", telemetry.Properties["eh.event_hub_name"]);
@@ -352,9 +353,9 @@
                 Assert.AreEqual("sb://eventhubname.servicebus.windows.net/ | ehname", telemetry.Target);
                 Assert.IsFalse(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.ParentSpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(sendActivity.ParentSpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("eventhubname.servicebus.windows.net", telemetry.Properties["peer.hostname"]);

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkHttpProcessingTest.cs
@@ -465,7 +465,7 @@
                 if (parentActivity.IdFormat == ActivityIdFormat.W3C)
                 {
                     Assert.AreEqual(parentActivity.TraceId.ToHexString(), remoteDependencyTelemetryActual.Context.Operation.Id);
-                    Assert.AreEqual($"|{parentActivity.TraceId.ToHexString()}.{parentActivity.SpanId.ToHexString()}.", remoteDependencyTelemetryActual.Context.Operation.ParentId);
+                    Assert.AreEqual(parentActivity.SpanId.ToHexString(), remoteDependencyTelemetryActual.Context.Operation.ParentId);
                     if (parentActivity.TraceStateString != null)
                     {
                         Assert.IsTrue(remoteDependencyTelemetryActual.Properties.ContainsKey("tracestate"));

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkSqlProcessingTest.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/FrameworkSqlProcessingTest.cs
@@ -351,7 +351,7 @@
                 if (parentActivity.IdFormat == ActivityIdFormat.W3C)
                 {
                     Assert.AreEqual(parentActivity.TraceId.ToHexString(), remoteDependencyTelemetryActual.Context.Operation.Id);
-                    Assert.AreEqual($"|{parentActivity.TraceId.ToHexString()}.{parentActivity.SpanId.ToHexString()}.", remoteDependencyTelemetryActual.Context.Operation.ParentId);
+                    Assert.AreEqual(parentActivity.SpanId.ToHexString(), remoteDependencyTelemetryActual.Context.Operation.ParentId);
                     if (parentActivity.TraceStateString != null)
                     {
                         Assert.IsTrue(remoteDependencyTelemetryActual.Properties.ContainsKey("tracestate"));

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/ServiceBusDiagnosticListenerTests.cs
@@ -86,9 +86,9 @@
                 Assert.AreEqual("sb://queuename.myservicebus.com/ | queueName", telemetry.Target);
                 Assert.IsTrue(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{parentActivity.TraceId.ToHexString()}.{parentActivity.SpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(parentActivity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(parentActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("messageId", telemetry.Properties["MessageId"]);
@@ -152,7 +152,7 @@
 
                 Assert.IsNull(telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(sendActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("messageId", telemetry.Properties["MessageId"]);
             }
@@ -181,9 +181,9 @@
                 Assert.AreEqual("sb://queuename.myservicebus.com/ | queueName", telemetry.Target);
                 Assert.IsFalse(telemetry.Success.Value);
 
-                Assert.AreEqual($"|{parentActivity.TraceId.ToHexString()}.{parentActivity.SpanId.ToHexString()}.", telemetry.Context.Operation.ParentId);
+                Assert.AreEqual(parentActivity.SpanId.ToHexString(), telemetry.Context.Operation.ParentId);
                 Assert.AreEqual(parentActivity.TraceId.ToHexString(), telemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{sendActivity.TraceId.ToHexString()}.{sendActivity.SpanId.ToHexString()}.", telemetry.Id);
+                Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
                 Assert.AreEqual("messageId", telemetry.Properties["MessageId"]);
@@ -222,9 +222,9 @@
                     requestTelemetry.Source);
                 Assert.IsTrue(requestTelemetry.Success.Value);
 
-                Assert.AreEqual($"|{messageActivity.TraceId.ToHexString()}.{messageActivity.ParentSpanId.ToHexString()}.", requestTelemetry.Context.Operation.ParentId);
+                Assert.AreEqual(messageActivity.ParentSpanId.ToHexString(), requestTelemetry.Context.Operation.ParentId);
                 Assert.AreEqual(messageActivity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-                Assert.AreEqual($"|{messageActivity.TraceId.ToHexString()}.{messageActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+                Assert.AreEqual(messageActivity.SpanId.ToHexString(), requestTelemetry.Id);
 
                 Assert.AreEqual("v1", requestTelemetry.Properties["k1"]);
 
@@ -322,7 +322,7 @@
                 Assert.IsTrue(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRoot));
                 Assert.AreEqual("hierarchical-parent", legacyRoot);
                 Assert.AreEqual("|hierarchical-parent.", requestTelemetry.Context.Operation.ParentId);
-                Assert.AreEqual($"|{messageActivity.TraceId.ToHexString()}.{messageActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+                Assert.AreEqual(messageActivity.SpanId.ToHexString(), requestTelemetry.Id);
                 Assert.AreEqual(messageActivity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
                 Assert.AreEqual("messageId", requestTelemetry.Properties["MessageId"]);
 
@@ -369,7 +369,7 @@
 
                 Assert.IsFalse(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out _));
                 Assert.AreEqual(parentId, requestTelemetry.Context.Operation.ParentId);
-                Assert.AreEqual($"|{messageActivity.TraceId.ToHexString()}.{messageActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+                Assert.AreEqual(messageActivity.SpanId.ToHexString(), requestTelemetry.Id);
                 Assert.AreEqual(messageActivity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
 
                 Assert.AreEqual("messageId", requestTelemetry.Properties["MessageId"]);
@@ -417,7 +417,7 @@
                 Assert.IsTrue(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRoot));
                 Assert.AreEqual("malformed-parent", legacyRoot);
                 Assert.AreEqual("malformed-parent", requestTelemetry.Context.Operation.ParentId);
-                Assert.AreEqual($"|{messageActivity.TraceId.ToHexString()}.{messageActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+                Assert.AreEqual(messageActivity.SpanId.ToHexString(), requestTelemetry.Id);
                 Assert.AreEqual(messageActivity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
                 Assert.AreEqual("messageId", requestTelemetry.Properties["MessageId"]);
 
@@ -461,7 +461,7 @@
 
                 Assert.AreEqual(messageActivity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
                 Assert.IsNull(requestTelemetry.Context.Operation.ParentId);
-                Assert.AreEqual($"|{messageActivity.TraceId.ToHexString()}.{messageActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+                Assert.AreEqual(messageActivity.SpanId.ToHexString(), requestTelemetry.Id);
 
                 Assert.AreEqual("messageId", requestTelemetry.Properties["MessageId"]);
 

--- a/WEB/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
+++ b/WEB/Src/DependencyCollector/Shared.Tests/Implementation/SqlClientDiagnosticSourceListenerTests.cs
@@ -148,7 +148,7 @@ namespace Microsoft.ApplicationInsights.Tests
             var dependencyTelemetry = (DependencyTelemetry)this.sendItems.Single();
 
             Assert.Equal(activity.TraceId.ToHexString(), dependencyTelemetry.Context.Operation.Id);
-            Assert.Equal(W3CUtilities.FormatTelemetryId(activity.TraceId.ToHexString(), activity.SpanId.ToHexString()), dependencyTelemetry.Context.Operation.ParentId);
+            Assert.Equal(activity.SpanId.ToHexString(), dependencyTelemetry.Context.Operation.ParentId);
             Assert.Equal("123", dependencyTelemetry.Properties["Stuff"]);
         }
 

--- a/WEB/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/ClientServerDependencyTracker.cs
@@ -55,16 +55,10 @@
 
                 if (activity.Parent != null || activity.ParentSpanId != default)
                 {
-                    context.Operation.ParentId = W3CUtilities.FormatTelemetryId(context.Operation.Id, activity.ParentSpanId.ToHexString());
+                    context.Operation.ParentId = activity.ParentSpanId.ToHexString();
                 }
 
-                telemetry.Id = W3CUtilities.FormatTelemetryId(context.Operation.Id, activity.SpanId.ToHexString());
-
-                // TODO[tracestate]: remove, this is done in base SDK
-                if (activity.TraceStateString != null && !telemetry.Properties.ContainsKey(W3CConstants.TracestatePropertyKey))
-                {
-                    telemetry.Properties.Add(W3CConstants.TracestatePropertyKey, activity.TraceStateString);
-                }
+                telemetry.Id = activity.SpanId.ToHexString();
             }
             else
             {

--- a/WEB/Src/DependencyCollector/Shared/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
@@ -53,7 +53,7 @@
                 {
                     if (activity.ParentSpanId != default)
                     {
-                        telemetry.Context.Operation.ParentId = W3CUtilities.FormatTelemetryId(traceId, activity.ParentSpanId.ToHexString());
+                        telemetry.Context.Operation.ParentId = activity.ParentSpanId.ToHexString();
                     }
                     else if (!string.IsNullOrEmpty(activity.ParentId))
                     {
@@ -62,13 +62,7 @@
                     }
                 }
 
-                telemetry.Id = W3CUtilities.FormatTelemetryId(traceId, activity.SpanId.ToHexString());
-
-                // TODO[tracestate]: remove, this is done in base SDK
-                if (!string.IsNullOrEmpty(activity.TraceStateString) && !telemetry.Properties.ContainsKey(W3CConstants.TracestatePropertyKey))
-                {
-                    telemetry.Properties.Add(W3CConstants.TracestatePropertyKey, activity.TraceStateString);
-                }
+                telemetry.Id = activity.SpanId.ToHexString();
             }
             else
             {

--- a/WEB/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/HttpProcessing.cs
@@ -240,7 +240,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                     {
                         if (webRequest.Headers[RequestResponseHeaders.RequestIdHeader] == null)
                         {
-                            webRequest.Headers.Add(RequestResponseHeaders.RequestIdHeader, telemetry.Id);
+                            webRequest.Headers.Add(RequestResponseHeaders.RequestIdHeader, string.Concat('|', telemetry.Context.Operation.Id, '.', telemetry.Id, '.'));
                         }
                     }
                 }

--- a/WEB/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
+++ b/WEB/Src/DependencyCollector/Shared/Implementation/SqlClientDiagnostics/SqlClientDiagnosticSourceListener.cs
@@ -354,7 +354,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation.SqlCl
                 {
                     var traceId = activity.TraceId.ToHexString();
                     telemetry.Context.Operation.Id = traceId;
-                    telemetry.Context.Operation.ParentId = W3CUtilities.FormatTelemetryId(traceId, activity.SpanId.ToHexString());
+                    telemetry.Context.Operation.ParentId = activity.SpanId.ToHexString();
                 }
                 else
                 {

--- a/WEB/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
+++ b/WEB/Src/Web/Web.Net45.Tests/AspNetDiagnosticTelemetryModuleTest.cs
@@ -177,7 +177,7 @@
             Assert.IsNotNull(requestTelemetry);
             Assert.IsNull(requestTelemetry.Context.Operation.ParentId);
             Assert.AreEqual(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-            Assert.AreEqual(FormatTelemetryId(activity.TraceId, activity.SpanId), requestTelemetry.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), requestTelemetry.Id);
         }
 
         [TestMethod]
@@ -287,7 +287,7 @@
             var request = (RequestTelemetry)this.sendItems[0];
             Assert.AreEqual(activity.TraceId.ToHexString(), request.Context.Operation.Id);
             Assert.IsNull(request.Context.Operation.ParentId);
-            Assert.AreEqual(FormatTelemetryId(activity.TraceId, activity.SpanId), request.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), request.Id);
 
             Assert.IsFalse(request.Properties.ContainsKey("ai_legacyRootId"));
         }
@@ -338,8 +338,8 @@
             var requestTelemetry = this.sendItems[0] as RequestTelemetry;
             Assert.IsNotNull(requestTelemetry);
             Assert.AreEqual("4bf92f3577b34da6a3ce929d0e0e4736", requestTelemetry.Context.Operation.Id);
-            Assert.AreEqual("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual($"|4bf92f3577b34da6a3ce929d0e0e4736.{activity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.AreEqual("00f067aa0ba902b7", requestTelemetry.Context.Operation.ParentId);
+            Assert.AreEqual(activity.SpanId.ToHexString(), requestTelemetry.Id);
 
             Assert.AreEqual(0, requestTelemetry.Properties.Count);
             Assert.IsFalse(requestTelemetry.Properties.ContainsKey("ai_legacyRootId"));
@@ -371,8 +371,8 @@
             var requestTelemetry = this.sendItems[0] as RequestTelemetry;
             Assert.IsNotNull(requestTelemetry);
             Assert.AreEqual("4bf92f3577b34da6a3ce929d0e0e4736", requestTelemetry.Context.Operation.Id);
-            Assert.AreEqual("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual($"|4bf92f3577b34da6a3ce929d0e0e4736.{activity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.AreEqual("00f067aa0ba902b7", requestTelemetry.Context.Operation.ParentId);
+            Assert.AreEqual(activity.SpanId.ToHexString(), requestTelemetry.Id);
 
             Assert.IsFalse(requestTelemetry.Properties.ContainsKey("ai_legacyRootId"));
             Assert.AreEqual(0, requestTelemetry.Properties.Count);
@@ -403,7 +403,7 @@
             Assert.IsNotNull(requestTelemetry);
             Assert.AreEqual(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
             Assert.AreEqual("|requestId.", requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual(FormatTelemetryId(activity.TraceId, activity.SpanId), requestTelemetry.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), requestTelemetry.Id);
 
             Assert.AreEqual(1, requestTelemetry.Properties.Count);
             Assert.IsTrue(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var aiLegacyRootId));
@@ -440,7 +440,7 @@
             Assert.IsNotNull(requestTelemetry);
             Assert.AreEqual("4bf92f3577b34da6a3ce929d0e0e4736", requestTelemetry.Context.Operation.Id);
             Assert.AreEqual("|4bf92f3577b34da6a3ce929d0e0e4736.", requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual($"|4bf92f3577b34da6a3ce929d0e0e4736.{currentActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.AreEqual(currentActivity.SpanId.ToHexString(), requestTelemetry.Id);
 
             Assert.IsFalse(requestTelemetry.Properties.ContainsKey("ai_legacyRootId"));
             Assert.AreEqual(1, requestTelemetry.Properties.Count);
@@ -473,7 +473,7 @@
             Assert.IsNotNull(requestTelemetry);
             Assert.AreEqual(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
             Assert.AreEqual("parent", requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual(FormatTelemetryId(activity.TraceId, activity.SpanId), requestTelemetry.Id);
+            Assert.AreEqual(activity.SpanId.ToHexString(), requestTelemetry.Id);
 
             Assert.IsTrue(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRootId));
             Assert.AreEqual("root", legacyRootId);
@@ -507,7 +507,7 @@
             Assert.IsNotNull(requestTelemetry);
             Assert.AreEqual(currentActivity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
             Assert.IsNull(requestTelemetry.Context.Operation.ParentId);
-            Assert.AreEqual($"|{currentActivity.TraceId.ToHexString()}.{currentActivity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.AreEqual(currentActivity.SpanId.ToHexString(), requestTelemetry.Id);
 
             Assert.AreEqual(1, requestTelemetry.Properties.Count);
             Assert.IsTrue(requestTelemetry.Properties.TryGetValue("k", out var v));
@@ -554,11 +554,6 @@
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);
-        }
-
-        private static string FormatTelemetryId(ActivityTraceId traceId, ActivitySpanId spanId)
-        {
-            return string.Concat('|', traceId, '.', spanId, '.');
         }
 
         private AspNetDiagnosticTelemetryModule CreateModule(string rootIdHeaderName = null, string parentIdHeaderName = null)

--- a/WEB/Src/Web/Web.Net45.Tests/RequestTrackingTelemetryModuleTest.Net45.cs
+++ b/WEB/Src/Web/Web.Net45.Tests/RequestTrackingTelemetryModuleTest.Net45.cs
@@ -62,7 +62,7 @@
             module.OnEndRequest(context);
 
             Assert.Equal(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-            Assert.Equal($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activity.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.Equal("guid1", requestTelemetry.Context.Operation.ParentId);
             Assert.True(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRootId));
             Assert.Equal("guid1", legacyRootId);
@@ -87,7 +87,7 @@
 
             Assert.Null(requestTelemetry.Context.Operation.ParentId);
             Assert.Equal(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-            Assert.Equal($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activity.SpanId.ToHexString(), requestTelemetry.Id);
         }
 
         [TestMethod]
@@ -136,7 +136,7 @@
             module.OnEndRequest(context);
 
             Assert.Equal(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-            Assert.Equal($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activity.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.Equal("guid1", requestTelemetry.Context.Operation.ParentId);
             Assert.True(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRootId));
             Assert.Equal("guid2", legacyRootId);
@@ -169,7 +169,7 @@
             var requestTelemetry = context.GetRequestTelemetry();
             module.OnEndRequest(context);
 
-            Assert.Equal($"|{activityInitializedByW3CHeader.TraceId.ToHexString()}.{activityInitializedByW3CHeader.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activityInitializedByW3CHeader.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.Equal(activityInitializedByW3CHeader.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
             Assert.Null(requestTelemetry.Context.Operation.ParentId);
         }
@@ -254,7 +254,7 @@
             module.OnEndRequest(context);
 
             Assert.Equal(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-            Assert.Equal($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activity.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.Equal("guid1", requestTelemetry.Context.Operation.ParentId);
             Assert.True(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRootId));
             Assert.Equal("guid2", legacyRootId);
@@ -280,7 +280,9 @@
             Assert.Equal("ParentId", requestTelemetry.Context.Operation.ParentId);
 
             Assert.Equal(activity.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
-            Assert.NotEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}", requestTelemetry.Id);
+            
+            // Assert.NotEqual($"|{activity.TraceId.ToHexString()}.{activity.SpanId.ToHexString()}", requestTelemetry.Id);
+            Assert.Equal(activity.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.True(requestTelemetry.Properties.TryGetValue("ai_legacyRootId", out var legacyRootId));
             Assert.Equal("RootId", legacyRootId);
         }
@@ -465,7 +467,7 @@
 
             var request = (RequestTelemetry)this.sentTelemetry.Single(t => t is RequestTelemetry);
             Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", request.Context.Operation.Id);
-            Assert.Equal("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", request.Context.Operation.ParentId);
+            Assert.Equal("00f067aa0ba902b7", request.Context.Operation.ParentId);
 
             Assert.Equal(trace1.Context.Operation.Id, request.Context.Operation.Id);
             Assert.Equal(trace2.Context.Operation.Id, request.Context.Operation.Id);
@@ -539,9 +541,9 @@
             var requestTelemetry = context.GetRequestTelemetry();
             module.OnEndRequest(context);
 
-            Assert.Equal($"|4bf92f3577b34da6a3ce929d0e0e4736.{activityInitializedByW3CHeader.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activityInitializedByW3CHeader.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.Equal("4bf92f3577b34da6a3ce929d0e0e4736", requestTelemetry.Context.Operation.Id);
-            Assert.Equal("|4bf92f3577b34da6a3ce929d0e0e4736.00f067aa0ba902b7.", requestTelemetry.Context.Operation.ParentId);
+            Assert.Equal("00f067aa0ba902b7", requestTelemetry.Context.Operation.ParentId);
 
             Assert.Equal("state=some", requestTelemetry.Properties["tracestate"]);
         }
@@ -565,7 +567,7 @@
             var requestTelemetry = context.GetRequestTelemetry();
             module.OnEndRequest(context);
 
-            Assert.Equal($"|{activityInitializedByW3CHeader.TraceId.ToHexString()}.{activityInitializedByW3CHeader.SpanId.ToHexString()}.", requestTelemetry.Id);
+            Assert.Equal(activityInitializedByW3CHeader.SpanId.ToHexString(), requestTelemetry.Id);
             Assert.Equal(activityInitializedByW3CHeader.TraceId.ToHexString(), requestTelemetry.Context.Operation.Id);
 
             if (addRequestId)

--- a/WEB/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
+++ b/WEB/Src/Web/Web.Shared.Net/Implementation/RequestTrackingExtensions.cs
@@ -87,7 +87,7 @@
 
                 if (currentActivity.ParentSpanId != default && legacyParentId == null)
                 {
-                    requestContext.ParentId = W3CUtilities.FormatTelemetryId(requestContext.Id, currentActivity.ParentSpanId.ToHexString());
+                    requestContext.ParentId = currentActivity.ParentSpanId.ToHexString();
                 }
                 else
                 {
@@ -98,13 +98,7 @@
                     }
                 }
 
-                // TODO[tracestate]: remove, this is done in base SDK
-                if (!string.IsNullOrEmpty(currentActivity.TraceStateString))
-                {
-                    result.Properties[W3CConstants.TracestatePropertyKey] = currentActivity.TraceStateString;
-                }
-
-                result.Id = W3CUtilities.FormatTelemetryId(requestContext.Id, currentActivity.SpanId.ToHexString());
+                result.Id = currentActivity.SpanId.ToHexString();
             }
             else
             {

--- a/WEB/Test/E2ETests/E2ETests/Test452Base.cs
+++ b/WEB/Test/E2ETests/E2ETests/Test452Base.cs
@@ -28,9 +28,9 @@ namespace E2ETests
     }
     public abstract class Test452Base
     {
-        
+
         internal static Dictionary<string, DeployedApp> Apps = new Dictionary<string, DeployedApp>()
-        {                          
+        {
             {
                 TestConstants.WebApiName,
                 new DeployedApp
@@ -96,9 +96,9 @@ namespace E2ETests
                 DockerUtils.PrintDockerProcessStats("Docker-Compose -build retry");
                 PopulateIPAddresses();
                 allAppsHealthy = HealthCheckAndRemoveImageIfNeededAllApp();
-            }            
+            }
 
-            Assert.IsTrue(allAppsHealthy, "All Apps are not unhealthy.");            
+            Assert.IsTrue(allAppsHealthy, "All Apps are not unhealthy.");
 
             dataendpointClient = new DataEndpointClient(new Uri("http://" + Apps[TestConstants.IngestionName].ipAddress));
 
@@ -160,13 +160,13 @@ namespace E2ETests
         private static bool HealthCheckAndRemoveImageIfNeededAllApp()
         {
             bool healthy = true;
-            foreach(var app in Apps)
+            foreach (var app in Apps)
             {
                 healthy = healthy && HealthCheckAndRemoveImageIfNeeded(app.Value);
             }
 
             return healthy;
-        }       
+        }
 
         private static void PopulateIPAddresses()
         {
@@ -174,7 +174,7 @@ namespace E2ETests
             Trace.WriteLine("Inspecting Docker containers to get IP addresses");
             foreach (var app in Apps)
             {
-                app.Value.ipAddress = DockerUtils.FindIpDockerContainer(app.Value.containerName);                
+                app.Value.ipAddress = DockerUtils.FindIpDockerContainer(app.Value.containerName);
             }
         }
 
@@ -277,7 +277,7 @@ namespace E2ETests
                 var request = new HttpRequestMessage(HttpMethod.Post, string.Format($"http://{Apps[TestConstants.WebApiName].ipAddress}/api/values"));
                 request.Headers.Add("traceparent", $"00-{operationId}-{ActivitySpanId.CreateRandom()}-01");
 
-                request.Content = new StringContent($"\"{new string('1', 1024*1024)}\"", Encoding.UTF8, "application/json");
+                request.Content = new StringContent($"\"{new string('1', 1024 * 1024)}\"", Encoding.UTF8, "application/json");
 
                 var response = await httpClient.SendAsync(request);
 
@@ -301,7 +301,7 @@ namespace E2ETests
             PrintDependencies(dependencies);
             Assert.AreEqual(1, dependencies.Count);
 
-            var requests = WaitForReceiveRequestItemsFromDataIngestion(Apps[TestConstants.WebApiName].ipAddress, Apps[TestConstants.WebApiName].ikey, expectNumberOfItems:1);
+            var requests = WaitForReceiveRequestItemsFromDataIngestion(Apps[TestConstants.WebApiName].ipAddress, Apps[TestConstants.WebApiName].ikey, expectNumberOfItems: 1);
             Trace.WriteLine("Requests count for WebApp:" + requests.Count);
             PrintRequests(requests);
             Assert.AreEqual(1, requests.Count);
@@ -314,7 +314,7 @@ namespace E2ETests
             {
                 var spanId = restoredActivityId.Split('-')[2];
                 Assert.AreEqual(operationId, dependency.tags["ai.operation.id"]);
-                Assert.AreEqual($"|{operationId}.{spanId}.", dependency.tags["ai.operation.parentId"]);
+                Assert.AreEqual(spanId, dependency.tags["ai.operation.parentId"]);
                 Assert.AreEqual(requests[0].data.baseData.id, dependency.tags["ai.operation.parentId"]);
             }
             else
@@ -515,7 +515,7 @@ namespace E2ETests
             // will be a local url in case of emulator.
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
-            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorTable;            
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorTable;
 
             // 2 dependency item is expected.
             // 1 from creating table, and 1 from writing data to it.
@@ -531,7 +531,7 @@ namespace E2ETests
             // will be a local url in case of emulator.
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
-            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorQueue;            
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorQueue;
 
             // 2 dependency item is expected.
             // 1 from creating queue, and 1 from writing data to it.
@@ -547,7 +547,7 @@ namespace E2ETests
             // will be a local url in case of emulator.
             expectedDependencyTelemetry.Type = "Http";
             expectedDependencyTelemetry.Success = true;
-            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorBlob;            
+            expectedDependencyTelemetry.Target = TestConstants.WebAppTargetToEmulatorBlob;
 
             // 2 dependency item is expected.
             // 1 from creating table, and 1 from writing data to it.
@@ -569,7 +569,7 @@ namespace E2ETests
             }
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
             expectedDependencyTelemetry.Data = expectedData;
-            
+
             ValidateBasicDependency(Apps[appname].ipAddress, path, expectedDependencyTelemetry,
                 Apps[appname].ikey, 1, expectedPrefix);
         }
@@ -580,8 +580,8 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteReaderAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -594,7 +594,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Success = false;
             expectedDependencyTelemetry.ResultCode = "208";
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;            
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlException : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteReaderAsync&success=false", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -606,7 +606,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader0&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -631,7 +631,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader1&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -656,7 +656,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader2&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -681,7 +681,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteReader3&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -706,7 +706,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteReader1&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -731,7 +731,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteReader1&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -756,7 +756,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteScalarAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -781,7 +781,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteScalar&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -806,7 +806,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteNonQuery&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -831,7 +831,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=ExecuteNonQueryAsync&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -856,7 +856,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteNonQuery0&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -881,7 +881,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf")? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccess : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=BeginExecuteNonQuery2&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -956,7 +956,7 @@ namespace E2ETests
             expectedDependencyTelemetry.Type = "SQL";
             expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
-            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccessXML : string.Empty;            
+            expectedDependencyTelemetry.Data = (expectedPrefix != "rddf") ? TestConstants.WebAppFullQueryToSqlSuccessXML : string.Empty;
 
             ValidateBasicDependency(Apps[AppNameBeingTested].ipAddress, "/Dependencies.aspx?type=SqlCommandExecuteXmlReader&success=true", expectedDependencyTelemetry,
                 Apps[AppNameBeingTested].ikey, 1, expectedPrefix);
@@ -979,7 +979,7 @@ namespace E2ETests
         {
             var expectedDependencyTelemetry = new DependencyTelemetry();
             expectedDependencyTelemetry.Type = "SQL";
-            expectedDependencyTelemetry.Success = true;            
+            expectedDependencyTelemetry.Success = true;
             expectedDependencyTelemetry.Target = TestConstants.WebAppTargetNameToSql;
             expectedDependencyTelemetry.Data = TestConstants.WebAppStoredProcedureNameToSql;
 
@@ -998,9 +998,9 @@ namespace E2ETests
             Trace.WriteLine("Hitting the target url:" + url);
             var response = await client.GetAsync(url);
             Trace.WriteLine("Actual Response code: " + response.StatusCode);
-            Thread.Sleep(5 * AISDKBufferFlushTime);            
+            Thread.Sleep(5 * AISDKBufferFlushTime);
 
-            var requestsSource = WaitForReceiveRequestItemsFromDataIngestion(sourceInstanceIp, sourceIKey);            
+            var requestsSource = WaitForReceiveRequestItemsFromDataIngestion(sourceInstanceIp, sourceIKey);
             var dependenciesSource = WaitForReceiveDependencyItemsFromDataIngestion(sourceInstanceIp, sourceIKey);
             var requestsTarget = WaitForReceiveRequestItemsFromDataIngestion(targetInstanceIp, targetIKey);
 
@@ -1084,7 +1084,7 @@ namespace E2ETests
             ValidateDependency(expectedDependencyTelemetry, dependency, expectedPrefix);
         }
 
-        private static IList<TelemetryItem<RemoteDependencyData>> WaitForReceiveDependencyItemsFromDataIngestion(string targetInstanceIp,string ikey, int maxRetryCount = 5, bool flushChannel = true)
+        private static IList<TelemetryItem<RemoteDependencyData>> WaitForReceiveDependencyItemsFromDataIngestion(string targetInstanceIp, string ikey, int maxRetryCount = 5, bool flushChannel = true)
         {
             int receivedItemCount = 0;
             int iteration = 0;
@@ -1092,12 +1092,12 @@ namespace E2ETests
 
             while (iteration < maxRetryCount && receivedItemCount < 1)
             {
-                Thread.Sleep(AISDKBufferFlushTime);                
+                Thread.Sleep(AISDKBufferFlushTime);
                 items = dataendpointClient.GetItemsOfType<TelemetryItem<AI.RemoteDependencyData>>(ikey);
                 receivedItemCount = items.Count;
                 iteration++;
                 if (receivedItemCount == 0 && flushChannel)
-                {                    
+                {
                     ExecuteWebRequestToTarget(targetInstanceIp, Apps[AppNameBeingTested].flushPath).Wait();
                 }
             }
@@ -1140,7 +1140,7 @@ namespace E2ETests
                 }
                 Trace.WriteLine("End Application Traces for ikey:" + ikey + "----------------------------------------------------------------------------------------");
             }
-            catch(Exception ex)
+            catch (Exception ex)
             {
                 Trace.WriteLine("Exception printing application traces:" + ex.Message);
             }
@@ -1149,7 +1149,7 @@ namespace E2ETests
         private void ReadApplicationTraces(string targetInstanceIp, string targetPath)
         {
             try
-            {                
+            {
                 Trace.WriteLine("Begin Application Traces----------------------------------------------------------------------------------------");
 
 
@@ -1176,7 +1176,7 @@ namespace E2ETests
 
         private void ValidateAzureDependencyAsync(string targetInstanceIp, string targetPath,
             DependencyTelemetry expectedDependencyTelemetry, string ikey, int minCount, string expectedPrefix, int additionalSleepTimeMsec = 0)
-        {            
+        {
             var success = ExecuteWebRequestToTarget(targetInstanceIp, targetPath).Result;
             Assert.IsTrue(success, "Web App did not respond with success. Failing test. Check exception from logs.");
             Thread.Sleep(AISDKBufferFlushTime + additionalSleepTimeMsec);
@@ -1208,7 +1208,7 @@ namespace E2ETests
             catch (Exception ex)
             {
                 success = false;
-                Trace.WriteLine("Exception occured:" + ex);                
+                Trace.WriteLine("Exception occured:" + ex);
             }
 
             return success;
@@ -1224,7 +1224,7 @@ namespace E2ETests
             string actualSdkVersion = actualDependencyTelemetry.tags[new ContextTagKeys().InternalSdkVersion];
             Assert.IsTrue(actualSdkVersion.Contains(expectedPrefix), "Actual version:" + actualSdkVersion);
 
-            if(!string.IsNullOrEmpty(expectedDependencyTelemetry.ResultCode))
+            if (!string.IsNullOrEmpty(expectedDependencyTelemetry.ResultCode))
             {
                 Assert.AreEqual(expectedDependencyTelemetry.ResultCode, actualDependencyTelemetry.data.baseData.resultCode);
             }
@@ -1239,11 +1239,11 @@ namespace E2ETests
             {
                 Assert.AreEqual(expectedDependencyTelemetry.Data, actualDependencyTelemetry.data.baseData.data);
             }
-            
-            var depTime = TimeSpan.Parse(actualDependencyTelemetry.data.baseData.duration, CultureInfo.InvariantCulture);            
+
+            var depTime = TimeSpan.Parse(actualDependencyTelemetry.data.baseData.duration, CultureInfo.InvariantCulture);
             if (expectedDependencyTelemetry.Success.HasValue)
             {
-                if(expectedDependencyTelemetry.Success.Value == true)
+                if (expectedDependencyTelemetry.Success.Value == true)
                 {
                     Assert.IsTrue(depTime.TotalMilliseconds > 0, "Access time should be above zero");
                 }
@@ -1251,7 +1251,7 @@ namespace E2ETests
                 {
                     Assert.IsTrue(depTime.TotalMilliseconds >= 0, "Access time should be zero or above zero if success is false.");
                 }
-            }            
+            }
         }
 
         private void PrintDependencies(IList<TelemetryItem<AI.RemoteDependencyData>> dependencies)
@@ -1265,7 +1265,7 @@ namespace E2ETests
                 Trace.WriteLine("deps.data.baseData.name:" + deps.data.baseData.name);
                 Trace.WriteLine("deps.tags[ai.operation.id]:" + deps.tags["ai.operation.id"]);
                 Trace.WriteLine("deps.data.baseData.type:" + deps.data.baseData.type);
-                Trace.WriteLine("deps.data.baseData.data:" + deps.data.baseData.data);                
+                Trace.WriteLine("deps.data.baseData.data:" + deps.data.baseData.data);
                 Trace.WriteLine("deps.data.baseData.success:" + deps.data.baseData.success);
                 Trace.WriteLine("deps.data.baseData.duration:" + deps.data.baseData.duration);
                 Trace.WriteLine("deps.data.baseData.resultCode:" + deps.data.baseData.resultCode);
@@ -1285,10 +1285,10 @@ namespace E2ETests
                 Trace.WriteLine("req.iKey: " + req.iKey);
                 Trace.WriteLine("req.name: " + req.name);
                 Trace.WriteLine("req.data.baseData.name:" + req.data.baseData.name);
-                Trace.WriteLine("req.tags[ai.operation.id]:" + req.tags["ai.operation.id"]); 
+                Trace.WriteLine("req.tags[ai.operation.id]:" + req.tags["ai.operation.id"]);
                 Trace.WriteLine("req.data.baseData.responseCode:" + req.data.baseData.responseCode);
                 Trace.WriteLine("req.data.baseData.success:" + req.data.baseData.success);
-                Trace.WriteLine("req.data.baseData.duration:" + req.data.baseData.duration);                
+                Trace.WriteLine("req.data.baseData.duration:" + req.data.baseData.duration);
                 Trace.WriteLine("req.data.baseData.id:" + req.data.baseData.id);
                 Trace.WriteLine("req.data.baseData.url:" + req.data.baseData.url);
                 Trace.WriteLine("InternalSdkVersion:" + req.tags[new ContextTagKeys().InternalSdkVersion]);
@@ -1298,12 +1298,12 @@ namespace E2ETests
 
         private static void RemoveIngestionItems()
         {
-            Trace.WriteLine("Deleting items started:" + DateTime.UtcNow.ToLongTimeString());            
-            foreach(var app in Apps)
+            Trace.WriteLine("Deleting items started:" + DateTime.UtcNow.ToLongTimeString());
+            foreach (var app in Apps)
             {
                 Trace.WriteLine("Deleting items for ikey:" + app.Value.ikey);
                 dataendpointClient.DeleteItems(app.Value.ikey);
-            }            
+            }
             Trace.WriteLine("Deleting items completed:" + DateTime.UtcNow.ToLongTimeString());
         }
 
@@ -1335,7 +1335,7 @@ namespace E2ETests
 
         private static bool HealthCheck(DeployedApp app)
         {
-            bool isHealthy = true;            
+            bool isHealthy = true;
             string url = "";
             try
             {
@@ -1354,7 +1354,7 @@ namespace E2ETests
             {
                 isHealthy = false;
                 Trace.WriteLine(string.Format("Exception occuring hitting {0} : {1}", url, ex));
-            }            
+            }
             return isHealthy;
         }
     }

--- a/WEB/Test/Web/FunctionalTests/FunctionalTests/WebAppFW45Tests.cs
+++ b/WEB/Test/Web/FunctionalTests/FunctionalTests/WebAppFW45Tests.cs
@@ -104,8 +104,7 @@
 
             // Check that request has operation Id, parentId and Id are set from headers
             Assert.AreEqual("9d2341f8070895468dbdffb599cf49fc", request.tags[new ContextTagKeys().OperationId], "Request Operation Id is not parsed from header");
-            Assert.AreEqual("|9d2341f8070895468dbdffb599cf49fc.0895468dbdffb519.", request.tags[new ContextTagKeys().OperationParentId], "Request Parent Id is not parsed from header");
-            Assert.IsTrue(request.data.baseData.id.StartsWith("|9d2341f8070895468dbdffb599cf49fc."), "Request Id is not properly set");
+            Assert.AreEqual("0895468dbdffb519", request.tags[new ContextTagKeys().OperationParentId], "Request Parent Id is not parsed from header");
 
             Assert.IsTrue(request.data.baseData.properties.TryGetValue("tracestate", out var tracestate));
             Assert.AreEqual("some=state", tracestate);
@@ -177,7 +176,6 @@
             var operationId = request.tags[new ContextTagKeys().OperationId];
             Assert.IsNotNull(operationId, "Request Operation Id is not parsed from header");
             Assert.AreEqual("|guid2.guid1.", request.tags[new ContextTagKeys().OperationParentId], "Request Parent Id is not parsed from header");
-            Assert.IsTrue(request.data.baseData.id.StartsWith($"|{operationId}."), "Request Id is not properly set");
             Assert.IsTrue(request.data.baseData.properties.TryGetValue("ai_legacyRootId", out var legacyRootId));
             Assert.AreEqual("guid2", legacyRootId);
         }


### PR DESCRIPTION
In W3C mode we report parentId and Id in the format of `|traceId.parentSpanId.` and `|traceId.spanId.` respectively.

This is not needed anymore even for backward compatibility reasons. Compatibility with old versions of Application Insights SDK is handled by ingestion.

**Describe the solution you would like**

**When SDK receives a valid incoming request** with
1. `traceparent = 00-traceId-parentId-00`, it should track request telemetry
  * request.Context.Operation.Id = traceId // no changes
  * request.Context.Operation.ParentId = parentId  // new, was |traceId.parentId.
  * request.Id = new span Id // new, was |traceId.spanId.

2. no header, it should track request telemetry
  * request.Context.Operation.Id = new traceId  // no changes
  * request.Context.Operation.ParentId = null // no changes
  * request.Id = new span Id// new, was |traceId.spanId.

3. legacy Request-Id header, it should track request telemetry
  * request.Context.Operation.Id = if request-id root part is compatible with trace-id, reuse it, otherwise generate a new one
  * request.Context.Operation.ParentId = headers[Request-Id] // no changes
  * request.Id = new span Id // new, was |traceId.spanId.
  * properties["ai_LegacyRootId"] = if request-id root part is NOT compatible with trace-id, put it here, otherwise keep empty // no changes

**Similarly for dependencies**
-  dependency.Context.Operation.Id = traceId,
-  dependency.Context.Operation.ParentId = parent span id, // new, was |trace.parent.
-  dependency.Id = new span id, // new, was |trace.span.

**When sending Request-Id in outgoing requests it still MUST be formatted in the |TraceId.SpanId. format!**