### PR TITLE
Add new constructor to TraceListener that accepts TelemetryConfiguration

### DIFF
--- a/LOGGING/src/TraceListener/ApplicationInsightsTraceListener.cs
+++ b/LOGGING/src/TraceListener/ApplicationInsightsTraceListener.cs
@@ -14,6 +14,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
     using System.Linq;
 
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Implementation;
 
@@ -46,6 +47,19 @@ namespace Microsoft.ApplicationInsights.TraceListener
                 this.TelemetryClient.Context.InstrumentationKey = instrumentationKey;
             }
 
+            this.TelemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("sd:");
+        }
+
+        /// <summary>
+        /// Initializes a newinstance of the ApplicationInsightsTraceListener class.
+        /// </summary>
+        /// <param name="configuration"></param>
+        public ApplicationInsightsTraceListener(TelemetryConfiguration configuration)
+        {
+            configuration = configuration ?? TelemetryConfiguration.Active;
+
+            this.TelemetryClient = new TelemetryClient(configuration);
+            
             this.TelemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("sd:");
         }
 
@@ -147,7 +161,7 @@ namespace Microsoft.ApplicationInsights.TraceListener
 
             string message = string.Join(", ", data.Select(d => d == null ? string.Empty : d.ToString()));
             var trace = new TraceTelemetry(message);
-            CreateTraceData(eventType, id, trace);                       
+            CreateTraceData(eventType, id, trace);
             this.TelemetryClient.Track(trace);
         }
 
@@ -193,9 +207,9 @@ namespace Microsoft.ApplicationInsights.TraceListener
         private static void CreateTraceData(TraceEventType eventType, int? id, TraceTelemetry trace)
         {
             trace.SeverityLevel = GetSeverityLevel(eventType);
-            
+
             IDictionary<string, string> metaData = trace.Properties;
-            
+
             if (id.HasValue)
             {
                 metaData.Add("EventId", id.Value.ToString(CultureInfo.InvariantCulture));

--- a/LOGGING/test/Shared/ApplicationInsightsTraceListenerTests.cs
+++ b/LOGGING/test/Shared/ApplicationInsightsTraceListenerTests.cs
@@ -29,7 +29,7 @@
         [TestCategory("TraceListener")]
         public void TraceListenerInitializeDoesNotThrowWhenInstrumentationKeyIsNull()
         {
-            var listener = new ApplicationInsightsTraceListener(null);
+            var listener = new ApplicationInsightsTraceListener(instrumentationKey: null);
             listener.Dispose();
         }
 
@@ -40,7 +40,15 @@
             var listener = new ApplicationInsightsTraceListener(string.Empty);
             listener.Dispose();
         }
-        
+
+        [TestMethod]
+        [TestCategory("TraceListener")]
+        public void TraceListenerInitializeDoesNotThrowWhenConfigurationIsNull()
+        {
+            var listener = new ApplicationInsightsTraceListener(configuration: null);
+            listener.Dispose();
+        }
+
         [TestMethod]
         [TestCategory("TraceListener")]
         public void TraceListenerWriteUsedApplicationInsightsConfigInstrumentationKeyWhenUnspecifiedInstrumentationKey()
@@ -53,7 +61,7 @@
             TelemetryConfiguration.Active.TelemetryChannel = this.adapterHelper.Channel;
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            using (var listener = new ApplicationInsightsTraceListener(null))
+            using (var listener = new ApplicationInsightsTraceListener(instrumentationKey: null))
             {                
                 this.VerifyMessagesInMockChannel(listener, this.adapterHelper.InstrumentationKey);
             }
@@ -95,6 +103,18 @@
                 Assert.AreEqual(expectedMessage, telemetry.Message);
                 Assert.IsFalse(telemetry.Properties.ContainsKey("EventId"));
                 Assert.AreEqual(SeverityLevel.Verbose, telemetry.SeverityLevel);
+            }
+        }
+
+        [TestMethod]
+        [TestCategory("TraceListener")]
+        public void TraceListenerWriteUsedTelemetryConfigurationInstrumentationKeyWhenSpecified()
+        {
+            TelemetryConfiguration telemetryConfiguration = TelemetryConfiguration.Active;
+
+            using (var listener = new ApplicationInsightsTraceListener(telemetryConfiguration))
+            {
+                this.VerifyMessagesInMockChannel(listener, telemetryConfiguration.InstrumentationKey);
             }
         }
 


### PR DESCRIPTION
Fix Issue #1476.

- [X] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build