### PR TITLE
fix test assembly names

### DIFF
--- a/NETCORE/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests10.csproj
+++ b/NETCORE/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests10.csproj
@@ -7,7 +7,7 @@
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>EmptyApp.FunctionalTests</AssemblyName>    
+    <AssemblyName>EmptyApp.FunctionalTests.Tests</AssemblyName>    
     <PackageId>EmptyApp.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <!--<RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.1.5</RuntimeFrameworkVersion>-->

--- a/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/ExceptionTelemetryEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/ExceptionTelemetryEmptyAppTests.cs
@@ -6,14 +6,17 @@ using Xunit.Abstractions;
 namespace EmptyApp.FunctionalTests.FunctionalTest
 {
     using System;
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
 
     public class ExceptionTelemetryEmptyAppTests : TelemetryTestsBase
     {
-        private const string assemblyName = "EmptyApp.FunctionalTests";
+        private readonly string assemblyName;
+
         public ExceptionTelemetryEmptyAppTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -9,9 +9,11 @@
 
     public class RequestTelemetryEmptyAppTests : TelemetryTestsBase
     {
-        private const string assemblyName = "EmptyApp.FunctionalTests";
+        private readonly string assemblyName;
+
         public RequestTelemetryEmptyAppTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -2,6 +2,7 @@
 {
     using System.Linq;
     using System.Net.Http;
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;

--- a/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
@@ -1,14 +1,17 @@
 ﻿namespace EmptyApp.FunctionalTests.FunctionalTest
 {
+    using System.Reflection;
     using FunctionalTestUtils;
     using Xunit;
     using Xunit.Abstractions;
 
     public class TelemetryModuleWorkingEmptyAppTests : TelemetryTestsBase
     {
-        private const string assemblyName = "EmptyApp.FunctionalTests";
+        private readonly string assemblyName;
+
         public TelemetryModuleWorkingEmptyAppTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 

--- a/NETCORE/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
+++ b/NETCORE/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
@@ -6,7 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>EmptyApp20.FunctionalTests20</AssemblyName>    
+    <AssemblyName>EmptyApp20.FunctionalTests20.Tests</AssemblyName>    
     <PackageId>EmptyApp20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>

--- a/NETCORE/test/EmptyApp20.FunctionalTests/FunctionalTest/ExceptionTelemetryEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp20.FunctionalTests/FunctionalTest/ExceptionTelemetryEmptyAppTests.cs
@@ -6,16 +6,18 @@ using Xunit.Abstractions;
 namespace EmptyApp20.FunctionalTests.FunctionalTest
 {
     using System;
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
 
     public class ExceptionTelemetryEmptyAppTests : TelemetryTestsBase
     {
-        private const string assemblyName = "EmptyApp20.FunctionalTests20";
+        private readonly string assemblyName;
+
         public ExceptionTelemetryEmptyAppTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
-
 
         [Fact]
         public void TestBasicRequestPropertiesAfterRequestingRequestThatThrows()

--- a/NETCORE/test/EmptyApp20.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp20.FunctionalTests/FunctionalTest/RequestTelemetryEmptyAppTests.cs
@@ -3,6 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
+    using System.Reflection;
     using AI;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -11,10 +12,11 @@
 
     public class RequestTelemetryEmptyAppTests : TelemetryTestsBase
     {
-        private const string assemblyName = "EmptyApp20.FunctionalTests20";
+        private readonly string assemblyName;
 
         public RequestTelemetryEmptyAppTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/EmptyApp20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
+++ b/NETCORE/test/EmptyApp20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingEmptyAppTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace EmptyApp20.FunctionalTests.FunctionalTest
 {
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
@@ -7,9 +8,11 @@
 
     public class TelemetryModuleWorkingEmptyAppTests : TelemetryTestsBase
     {
-        private const string assemblyName = "EmptyApp20.FunctionalTests20";
+        private readonly string assemblyName;
+
         public TelemetryModuleWorkingEmptyAppTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.

--- a/NETCORE/test/FunctionalTestUtils/TelemetryTestsBase.cs
+++ b/NETCORE/test/FunctionalTestUtils/TelemetryTestsBase.cs
@@ -61,7 +61,7 @@
                 Assert.Equal(expected.Success, actual.Success);
                 Assert.Equal(expected.Url, actual.Url);
                 InRange(actual.Timestamp, expected.Timestamp, DateTimeOffset.Now);
-                Assert.True(actual.Duration < timer.Elapsed, "duration");
+                Assert.True(actual.Duration < timer.Elapsed, $"actual.Duration '{actual.Duration}' is not less than timer.Elpased '{timer.Elapsed}'");
             }
         }
 

--- a/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -15,12 +15,15 @@ namespace MVCFramework.FunctionalTests.FunctionalTest
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.Extensions.DependencyInjection;
+    using System.Reflection;
 
     public class DependencyTelemetryMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework.FunctionalTests";
+        private readonly string assemblyName;
+
         public DependencyTelemetryMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/ExceptionTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/ExceptionTelemetryMvcTests.cs
@@ -4,6 +4,7 @@
 namespace MVCFramework.FunctionalTests.FunctionalTest
 {
     using System;
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
@@ -11,10 +12,11 @@ namespace MVCFramework.FunctionalTests.FunctionalTest
 
     public class ExceptionTelemetryMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework.FunctionalTests";
+        private readonly string assemblyName;
 
         public ExceptionTelemetryMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
@@ -5,6 +5,7 @@ namespace MVCFramework.FunctionalTests.FunctionalTest
 {
     using System.Linq;
     using System.Net.Http;
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
@@ -12,9 +13,11 @@ namespace MVCFramework.FunctionalTests.FunctionalTest
 
     public class RequestTelemetryMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework.FunctionalTests";
+        private readonly string assemblyName;
+
         public RequestTelemetryMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/NETCORE/test/MVCFramework.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -1,15 +1,17 @@
 ﻿namespace MVCFramework.FunctionalTests.FunctionalTest
 {
+    using System.Reflection;
     using FunctionalTestUtils;
     using Xunit;
     using Xunit.Abstractions;
 
     public class TelemetryModuleWorkingMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework.FunctionalTests";
+        private readonly string assemblyName;
 
         public TelemetryModuleWorkingMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.

--- a/NETCORE/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
+++ b/NETCORE/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
@@ -6,7 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>MVCFramework.FunctionalTests</AssemblyName>        
+    <AssemblyName>MVCFramework.FunctionalTests.Tests</AssemblyName>        
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>

--- a/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/DependencyTelemetryMvcTests.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Linq;
     using System.Net.Http;
+    using System.Reflection;
     using System.Text;
 
     using AI;
@@ -15,9 +16,11 @@
 
     public class DependencyTelemetryMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework20.FunctionalTests20";
+        private readonly string assemblyName;
+
         public DependencyTelemetryMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/ExceptionTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/ExceptionTelemetryMvcTests.cs
@@ -4,6 +4,7 @@
 namespace MVC20.FuncTests
 {
     using System;
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
@@ -11,10 +12,11 @@ namespace MVC20.FuncTests
 
     public class ExceptionTelemetryMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework20.FunctionalTests20";
+        private readonly string assemblyName;
 
         public ExceptionTelemetryMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/RequestTelemetryMvcTests.cs
@@ -3,7 +3,7 @@
     using System.Collections.Generic;
     using System.Linq;
     using System.Net.Http;
-
+    using System.Reflection;
     using AI;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -12,10 +12,11 @@
     
     public class RequestTelemetryMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework20.FunctionalTests20";
+        private readonly string assemblyName;
 
         public RequestTelemetryMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/FunctionalTest/TelemetryModuleWorkingMvcTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace MVC20.FuncTests
 {
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
@@ -7,10 +8,11 @@
 
     public class TelemetryModuleWorkingMvcTests : TelemetryTestsBase
     {
-        private const string assemblyName = "MVCFramework20.FunctionalTests20";
+        private readonly string assemblyName;
 
         public TelemetryModuleWorkingMvcTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.

--- a/NETCORE/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
@@ -6,7 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>MVCFramework20.FunctionalTests20</AssemblyName>
+    <AssemblyName>MVCFramework20.FunctionalTests20.Tests</AssemblyName>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <UserSecretsId>aspnet-MVCFramework45.FunctionalTests-60cfc765-2dc9-454c-bb34-dc379ed92cd0</UserSecretsId>

--- a/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
+++ b/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
@@ -6,14 +6,16 @@
     using Xunit;
     using Microsoft.ApplicationInsights.Extensibility;
     using Xunit.Abstractions;
+    using System.Reflection;
 
     public class ExceptionTelemetryWebApiTests : TelemetryTestsBase
     {
+        private readonly string assemblyName;
+
         public ExceptionTelemetryWebApiTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
-
-        private const string assemblyName = "WebApi.FunctionalTests";
 
         [Fact]
         public void TestBasicRequestPropertiesAfterRequestingControllerThatThrows()

--- a/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
+++ b/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
@@ -26,9 +26,7 @@
 
                 var expectedRequestTelemetry = new RequestTelemetry();
                 expectedRequestTelemetry.Name = "GET Exception/Get";
-                //TODO: default template of Web API application doesn't have error handling middleware 
-                //that will set appropriate status code
-                expectedRequestTelemetry.ResponseCode = "200";
+                expectedRequestTelemetry.ResponseCode = "500";
                 expectedRequestTelemetry.Success = false;
                 expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
 

--- a/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
+++ b/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/ExceptionTelemetryWebApiTests.cs
@@ -26,7 +26,7 @@
 
                 var expectedRequestTelemetry = new RequestTelemetry();
                 expectedRequestTelemetry.Name = "GET Exception/Get";
-                //TODO: default template of Web API applicaiton doesn't have error handling middleware 
+                //TODO: default template of Web API application doesn't have error handling middleware 
                 //that will set appropriate status code
                 expectedRequestTelemetry.ResponseCode = "200";
                 expectedRequestTelemetry.Success = false;

--- a/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
+++ b/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/RequestTelemetryWebApiTests.cs
@@ -1,5 +1,6 @@
 ﻿namespace WebApi.FunctionalTests.FunctionalTest
 {
+    using System.Reflection;
     using FunctionalTestUtils;
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
@@ -7,10 +8,11 @@
 
     public class RequestTelemetryWebApiTests : TelemetryTestsBase
     {
-        private const string assemblyName = "WebApi.FunctionalTests";
+        private readonly string assemblyName;
 
         public RequestTelemetryWebApiTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
+++ b/NETCORE/test/WebApi.FunctionalTests/FunctionalTest/TelemetryModuleWorkingWebApiTests.cs
@@ -3,15 +3,17 @@
 [assembly: CollectionBehavior(DisableTestParallelization = true)]
 namespace WebApi.FunctionalTests.FunctionalTest
 {
+    using System.Reflection;
     using FunctionalTestUtils;
     using Xunit.Abstractions;
 
     public class TelemetryModuleWorkingWebApiTests : TelemetryTestsBase
     {
-        private const string assemblyName = "WebApi.FunctionalTests";
+        private readonly string assemblyName;
 
         public TelemetryModuleWorkingWebApiTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.
 

--- a/NETCORE/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
+++ b/NETCORE/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
@@ -6,7 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi.FunctionalTests</AssemblyName>    
+    <AssemblyName>WebApi.FunctionalTests.Tests</AssemblyName>    
     <PackageId>WebApi.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);portable-net45+win8</PackageTargetFallback>

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/LoggerTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/LoggerTests.cs
@@ -15,19 +15,21 @@
     using Xunit.Abstractions;
     using AI;
     using Microsoft.Extensions.Logging;
+    using System.Reflection;
 
     /// <summary>
     /// These are Functional Tests validating E2E ILogger integration. Though filtering mechanism is done by the ILogger framework itself, we 
     /// are here testing that the integration is done in correct ways.
     /// Specifically,
     /// 1. By Default, Warning and above from All categories is expected to captured.
-    /// 2. Any overriding done by user is respected and will override default behaviour
+    /// 2. Any overriding done by user is respected and will override default behavior
     /// </summary>
     public class LoggerTests : TelemetryTestsBase, IDisposable
     {
-        private const string assemblyName = "WebApi20.FunctionalTests20";
+        private readonly string assemblyName;
         public LoggerTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/MultipleWebHostsTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/MultipleWebHostsTests.cs
@@ -12,11 +12,12 @@ namespace WebApi20.FuncTests
 {
     public class MultipleWebHostsTests : TelemetryTestsBase
     {
-        private const string assemblyName = "WebApi20.FunctionalTests20";
+        private readonly string assemblyName;
         private const string requestPath = "/api/dependency";
         
         public MultipleWebHostsTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         public void TwoWebHostsCreatedSequentially()

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCollectionTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCollectionTests.cs
@@ -9,12 +9,15 @@
     using Microsoft.ApplicationInsights.DataContracts;
     using Xunit;
     using Xunit.Abstractions;
+    using System.Reflection;
 
     public class RequestCollectionTests : TelemetryTestsBase
     {
-        private const string assemblyName = "WebApi20.FunctionalTests20";
+        private readonly string assemblyName;
+
         public RequestCollectionTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestCorrelationTests.cs
@@ -13,12 +13,15 @@
     using Microsoft.ApplicationInsights.DependencyCollector;
     using System.Text.RegularExpressions;
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+    using System.Reflection;
 
     public class RequestCorrelationTests : TelemetryTestsBase
     {
-        private const string assemblyName = "WebApi20.FunctionalTests20";
+        private readonly string assemblyName;
+
         public RequestCorrelationTests(ITestOutputHelper output) : base(output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         [Fact]

--- a/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestDependencyCorrelationTests.cs
+++ b/NETCORE/test/WebApi20.FunctionalTests/FunctionalTest/RequestDependencyCorrelationTests.cs
@@ -10,12 +10,15 @@
     using Microsoft.Extensions.DependencyInjection;
     using Xunit;
     using Xunit.Abstractions;
+    using System.Reflection;
 
     public class RequestDependencyCorrelationTests : TelemetryTestsBase, IDisposable
     {
-        private const string assemblyName = "WebApi20.FunctionalTests20";
+        private readonly string assemblyName;
+
         public RequestDependencyCorrelationTests(ITestOutputHelper output) : base (output)
         {
+            this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
         }
 
         // The NET451 conditional check is wrapped inside the test to make the tests visible in the test explorer. We can move them to the class level once if the issue is resolved.

--- a/NETCORE/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
+++ b/NETCORE/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
@@ -6,7 +6,7 @@
 	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
 	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>WebApi20.FunctionalTests20</AssemblyName>
+    <AssemblyName>WebApi20.FunctionalTests20.Tests</AssemblyName>
     <PackageId>WebApi20.FunctionalTests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>


### PR DESCRIPTION
Fix Issue # .

Build server test tasks use the wildcard expecting test dlls to end in ".Tests.dll"
Changing name here to fix build




Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build