### PR TITLE
Tilee/fix argoutofrange

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - [Fix Environment read permission Exception](https://github.com/microsoft/ApplicationInsights-dotnet/issues/657)
 - [Exceptions are not correlated to requests when customErrors=Off and Request-Id is passed](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1493)
 - [Switch to compact Id format in W3C mode](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1498)
+- [Fix CreateRequestTelemetryPrivate throwing System.ArgumentOutOfRangeException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1513)
 
 ## Version 2.12.0
 - [Fix IndexOutOfRangeException in W3CUtilities.TryGetTraceId](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1327)

--- a/WEB/Src/Common/W3C/W3CUtilities.cs
+++ b/WEB/Src/Common/W3C/W3CUtilities.cs
@@ -16,9 +16,12 @@
 
             if (legacyId[0] == '|')
             {
-                var dot = legacyId.IndexOf('.');
+                var dotIndex = legacyId.IndexOf('.');
 
-                return legacyId.Substring(1, dot - 1);
+                if (dotIndex > 0)
+                {
+                    return legacyId.Substring(1, dotIndex - 1);
+                }
             }
 
             return StringUtilities.EnforceMaxLength(legacyId, InjectionGuardConstants.RequestHeaderMaxLength);

--- a/WEB/Src/Microsoft.ApplicationInsights.Web.sln
+++ b/WEB/Src/Microsoft.ApplicationInsights.Web.sln
@@ -42,7 +42,6 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xdt.Tests", "PerformanceCol
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Solution Items", ".Solution Items", "{0828A19C-C62C-4B5E-9160-5A6F992F2000}"
 	ProjectSection(SolutionItems) = preProject
-		..\CHANGELOG.md = ..\CHANGELOG.md
 		..\Common.props = ..\Common.props
 		..\Directory.Build.props = ..\Directory.Build.props
 		..\dirs.proj = ..\dirs.proj

--- a/WEB/Src/Web/Web.Net45.Tests/W3CUtilitiesTests.cs
+++ b/WEB/Src/Web/Web.Net45.Tests/W3CUtilitiesTests.cs
@@ -29,5 +29,14 @@
         {
             Assert.IsFalse(W3C.Internal.W3CUtilities.TryGetTraceId("|0123456789abcdef0123456789abcdef", out _));
         }
+
+        [TestMethod]
+        public void VerifyGetRootId_ReturnsCorrectValue() => Assert.AreEqual("0123456789", W3C.Internal.W3CUtilities.GetRootId("|0123456789.abcdef"));
+
+        [TestMethod]
+        public void VerifyGetRootId_ReturnsInputIfInputValueMissingPipe() => Assert.AreEqual("0123456789abcdef", W3C.Internal.W3CUtilities.GetRootId("0123456789abcdef"));
+
+        [TestMethod]
+        public void VerifyGetRootId_ReturnsInputIfInputValueMissingDecimal() => Assert.AreEqual("|0123456789abcdef", W3C.Internal.W3CUtilities.GetRootId("|0123456789abcdef"));
     }
 }


### PR DESCRIPTION
Fix Issue #1513 

Fixing ArgumentOutOfRangeException.
W3CUtilities could have thrown if `IndexOf` returns a -1.

- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build