### PR TITLE
[WIP] Tilee/refactor defineconstants

### DIFF
--- a/.props/DefineConstants.props
+++ b/.props/DefineConstants.props
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <Target Name="Info_DefineConstants"  BeforeTargets="Build" Condition=" $(Internal_Logging) == 'true' ">
+    <Message Text="Info: DefineConstants.props imported by $(MSBuildProjectName)." Importance="high"/>
+  </Target>
+
+  <!-- NET FULL FRAMEWORK TARGETS -->
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
+    <DefineConstants>$(DefineConstants);NET45;</DefineConstants>
+  </PropertyGroup>
+
+  <!-- NET STANDARD TARGETS -->
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETCORE;NETSTANDARD1_3;</DefineConstants>
+    <IsNetStandardBuild>True</IsNetStandardBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
+    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETSTANDARD1_6;</DefineConstants>
+    <IsNetStandardBuild>True</IsNetStandardBuild>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <DefineConstants>$(DefineConstants);NETSTANDARD;NETCORE;NETSTANDARD2_0;</DefineConstants>
+    <IsNetStandardBuild>True</IsNetStandardBuild>
+  </PropertyGroup>
+
+  <!-- NET CORE APP TARGETS -->
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.0'">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCOREAPP1_0;</DefineConstants>
+  </PropertyGroup>
+  
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
+    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP1_1;</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCOREAPP;NETCOREAPP2_0</DefineConstants>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
+    <DefineConstants>$(DefineConstants);NETCORE;NETCOREAPP2_1</DefineConstants>
+  </PropertyGroup>
+  
+  
+  
+</Project>

--- a/.props/DefineConstants.props
+++ b/.props/DefineConstants.props
@@ -1,6 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
+  <!-- 
+  This file is separate from the other Test.props and Product.props.
+  These constants are used to switch code branches on/off and need to be controlled without any other dependencies. -->
+  
   <Target Name="Info_DefineConstants"  BeforeTargets="Build" Condition=" $(Internal_Logging) == 'true' ">
     <Message Text="Info: DefineConstants.props imported by $(MSBuildProjectName)." Importance="high"/>
   </Target>
@@ -37,10 +41,12 @@
   
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp1.1'">
     <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP1_1;</DefineConstants>
+    <IsNetCoreBuild>True</IsNetCoreBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
     <DefineConstants>$(DefineConstants);NETCORE;NETCOREAPP;NETCOREAPP2_0</DefineConstants>
+    <IsNetCoreBuild>True</IsNetCoreBuild>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -21,6 +21,9 @@
     <BondOutputDirectory>$(MSBuildThisFileDirectory)\Generated</BondOutputDirectory>
     <EnableDefaultItems Condition="$(OS) == 'Windows_NT'">false</EnableDefaultItems>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <Compile Include="ItemType.cs" />
     <Compile Include="TelemetryItem.cs" />

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Net45/Microsoft.ApplicationInsights.Net45.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Net45/Microsoft.ApplicationInsights.Net45.Tests.csproj
@@ -23,6 +23,8 @@
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Net46/Microsoft.ApplicationInsights.Net46.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Net46/Microsoft.ApplicationInsights.Net46.Tests.csproj
@@ -23,6 +23,9 @@
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Standalone/Microsoft.ApplicationInsights.Isolated.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Standalone/Microsoft.ApplicationInsights.Isolated.Tests.csproj
@@ -21,7 +21,10 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/netcoreapp11/Microsoft.ApplicationInsights.netcoreapp11.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/netcoreapp11/Microsoft.ApplicationInsights.netcoreapp11.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Test.props'))\Test.props" />
 
   <Import Project="$(PropsRoot)\Test.props" />
-
+  
   <PropertyGroup>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
@@ -14,10 +14,11 @@
     <TargetFrameworks>netcoreapp1.1</TargetFrameworks>
     <DebugType>pdbonly</DebugType> 
     <DebugSymbols>true</DebugSymbols> 
-    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP1_1</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/netcoreapp20/Microsoft.ApplicationInsights.netcoreapp20.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/netcoreapp20/Microsoft.ApplicationInsights.netcoreapp20.Tests.csproj
@@ -14,9 +14,10 @@
     <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
     <DebugType>pdbonly</DebugType> 
     <DebugSymbols>true</DebugSymbols> 
-    <DefineConstants>$(DefineConstants);NETCOREAPP</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />

--- a/BASE/Test/ServerTelemetryChannel.Test/Net45.Tests/TelemetryChannel.Net45.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/Net45.Tests/TelemetryChannel.Net45.Tests.csproj
@@ -23,7 +23,10 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />

--- a/BASE/Test/ServerTelemetryChannel.Test/NetCore.Tests/TelemetryChannel.netcoreapp11.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/NetCore.Tests/TelemetryChannel.netcoreapp11.Tests.csproj
@@ -16,8 +16,9 @@
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.NetCore.Tests</AssemblyName>
     <DebugType>pdbonly</DebugType> 
     <DebugSymbols>true</DebugSymbols> 
-    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP1_1</DefineConstants>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />

--- a/BASE/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/NetCore20.Tests/TelemetryChannel.netcoreapp20.Tests.csproj
@@ -17,8 +17,9 @@
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.NetCore20.Tests</AssemblyName>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
-    <DefineConstants>$(DefineConstants);NETCOREAPP;NETCOREAPP2_0</DefineConstants>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Nuget.Tests/TelemetryChannel.Nuget.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Nuget.Tests/TelemetryChannel.Nuget.Tests.csproj
@@ -22,7 +22,10 @@
     <EnableDefaultCompileItems>false</EnableDefaultCompileItems>
     <TargetFrameworks>netstandard1.3</TargetFrameworks>
   </PropertyGroup>
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <ProjectReference Include="..\..\..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\Test\Microsoft.ApplicationInsights.Test\ApplicationInsightsTypes\ApplicationInsightsTypes.csproj" />

--- a/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -9,7 +9,9 @@
     <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights</PackageId>

--- a/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -10,22 +10,13 @@
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel</PackageId>
     <Title>Application Insights Telemetry Channel for Windows Server Applications</Title>
     <Description>This nuget provides a telemetry channel to Application Insights Windows Server SDK that will preserve telemetry in offline scenarios. This is a dependent package, for the best experience please install the platform specific package. Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.3'">TRACE;DEBUG;NETCORE;NETSTANDARD1_3</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard2.0'">TRACE;DEBUG;NETCORE;NETSTANDARD2_0</DefineConstants>
-    <DefineConstants Condition="'$(TargetFramework)' == 'net45'">TRACE;DEBUG;NET45</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
-    <IsNetStandardBuild>True</IsNetStandardBuild>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(OS) == 'Windows_NT'">

--- a/LOGGING/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
+++ b/LOGGING/src/DiagnosticSourceListener/DiagnosticSourceListener.csproj
@@ -9,6 +9,9 @@
   
   <Import Project="$(PropsRoot)\Product.props" />
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.DiagnosticSourceListener</PackageId>

--- a/LOGGING/src/EtwCollector/EtwCollector.csproj
+++ b/LOGGING/src/EtwCollector/EtwCollector.csproj
@@ -8,7 +8,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 
   <Import Project="$(PropsRoot)\Product.props" />
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/LOGGING/src/EventSourceListener/EventSourceListener.csproj
+++ b/LOGGING/src/EventSourceListener/EventSourceListener.csproj
@@ -8,7 +8,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 
   <Import Project="$(PropsRoot)\Product.props" />
-    
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>

--- a/LOGGING/src/ILogger/ILogger.csproj
+++ b/LOGGING/src/ILogger/ILogger.csproj
@@ -8,7 +8,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 
   <Import Project="$(PropsRoot)\Product.props" />
-    
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!-- Publish the repository URL in the built .nupkg (in the NuSpec <Repository> element) -->
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/LOGGING/src/Log4NetAppender/Log4NetAppender.csproj
+++ b/LOGGING/src/Log4NetAppender/Log4NetAppender.csproj
@@ -8,7 +8,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 
   <Import Project="$(PropsRoot)\Product.props" />
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.Log4NetAppender</PackageId>

--- a/LOGGING/src/NLogTarget/NLogTarget.csproj
+++ b/LOGGING/src/NLogTarget/NLogTarget.csproj
@@ -8,7 +8,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 
   <Import Project="$(PropsRoot)\Product.props" />
-  
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.NLogTarget</PackageId>

--- a/LOGGING/src/TraceListener/TraceListener.csproj
+++ b/LOGGING/src/TraceListener/TraceListener.csproj
@@ -8,7 +8,10 @@
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
 
   <Import Project="$(PropsRoot)\Product.props" />
-    
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.TraceListener</PackageId>

--- a/LOGGING/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
+++ b/LOGGING/test/DiagnosticSourceListener.netcoreapp10.Tests/DiagnosticSourceListener.netcoreapp1.Tests.csproj
@@ -7,6 +7,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/LOGGING/test/EtwCollector.Net46.Tests/EtwCollector.Net46.Tests.csproj
+++ b/LOGGING/test/EtwCollector.Net46.Tests/EtwCollector.Net46.Tests.csproj
@@ -7,6 +7,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/LOGGING/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
+++ b/LOGGING/test/EventSourceListener.netcoreapp10.Tests/EventSourceListener.netcoreapp10.Tests.csproj
@@ -14,6 +14,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>    
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/LOGGING/test/ILogger.NetStandard.Tests/ILogger.NetStandard.Tests.csproj
+++ b/LOGGING/test/ILogger.NetStandard.Tests/ILogger.NetStandard.Tests.csproj
@@ -6,6 +6,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />

--- a/LOGGING/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
+++ b/LOGGING/test/Log4NetAppender.Net45.Tests/Log4NetAppender.Net45.Tests.csproj
@@ -7,6 +7,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/LOGGING/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
+++ b/LOGGING/test/Log4NetAppender.NetCoreApp10.Tests/Log4NetAppender.NetCoreApp10.Tests.csproj
@@ -8,6 +8,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <Compile Include="..\Log4NetAppender.Net45.Tests\ApplicationInsightsAppenderTests.cs" Link="ApplicationInsightsAppenderTests.cs" />
     <Compile Include="..\Log4NetAppender.Net45.Tests\GlobalSuppressions.cs" Link="GlobalSuppressions.cs" />

--- a/LOGGING/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
+++ b/LOGGING/test/NLogTarget.Net45.Tests/NLogTarget.Net45.Tests.csproj
@@ -7,6 +7,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/LOGGING/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
+++ b/LOGGING/test/NLogTarget.NetCoreApp10.Tests/NLogTarget.NetCoreApp10.Tests.csproj
@@ -8,6 +8,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <Compile Include="..\NLogTarget.Net45.Tests\NLogTargetTests.cs" Link="NLogTargetTests.cs" />
   </ItemGroup>

--- a/LOGGING/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
+++ b/LOGGING/test/TraceListener.Net45.Tests/TraceListener.Net45.Tests.csproj
@@ -7,6 +7,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <Compile Include="..\Shared\ApplicationInsightsTraceFilterTests.cs" Link="ApplicationInsightsTraceFilterTests.cs" />
     <Compile Include="..\Shared\ApplicationInsightsTraceListenerTests.cs" Link="ApplicationInsightsTraceListenerTests.cs" />

--- a/LOGGING/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
+++ b/LOGGING/test/TraceListener.netcoreapp10.Tests/TraceListener.netcoreapp10.Tests.csproj
@@ -8,6 +8,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <Compile Include="..\Shared\ApplicationInsightsTraceFilterTests.cs" Link="ApplicationInsightsTraceFilterTests.cs" />
     <Compile Include="..\Shared\ApplicationInsightsTraceListenerTests.cs" Link="ApplicationInsightsTraceListenerTests.cs" />

--- a/LOGGING/test/Xdt.Tests/Xdt.Tests.csproj
+++ b/LOGGING/test/Xdt.Tests/Xdt.Tests.csproj
@@ -7,6 +7,9 @@
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -19,9 +19,10 @@
     <LangVersion>7.2</LangVersion>
     <TargetFrameworks>netstandard2.0;net451;net46;netstandard1.6</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6;netstandard2.0</TargetFrameworks>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.6' ">1.6.1</NetStandardImplicitPackageVersion>	
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WEB;</DefineConstants>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <PropertyGroup>
     <!--Nupkg properties-->

--- a/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
@@ -21,6 +21,9 @@
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WORKER;</DefineConstants>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.WorkerService</PackageId>

--- a/NETCORE/test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/NETCORE/test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -16,7 +16,8 @@
 	<EnableDefaultItems Condition="$(OS) == 'Windows_NT'">false</EnableDefaultItems>
   </PropertyGroup>
 
-  
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <PackageReference Include="Bond.Core.CSharp" Version="7.0.0" />
     <PackageReference Include="Bond.CSharp" Version="7.0.0" />    

--- a/NETCORE/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests10.csproj
+++ b/NETCORE/test/EmptyApp.FunctionalTests/EmptyApp.FunctionalTests10.csproj
@@ -15,6 +15,9 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <ProjectReference Include="..\FunctionalTestUtils\FunctionalTestUtils.csproj" />
   </ItemGroup>

--- a/NETCORE/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
+++ b/NETCORE/test/EmptyApp20.FunctionalTests/EmptyApp20.FunctionalTests20.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+	  <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>EmptyApp20.FunctionalTests20.Tests</AssemblyName>    
     <PackageId>EmptyApp20.FunctionalTests</PackageId>
@@ -12,10 +12,13 @@
     <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp2.0' ">2.0.0</RuntimeFrameworkVersion>
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>    
-	<DependsOnNETStandard Condition=" '$(TargetFramework)' == 'net461'">true</DependsOnNETStandard>
+	  <DependsOnNETStandard Condition=" '$(TargetFramework)' == 'net461'">true</DependsOnNETStandard>
   </PropertyGroup>
 
-	<ItemGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
+  <ItemGroup>
     <ProjectReference Include="..\FunctionalTestUtils20\FunctionalTestUtils20.csproj" />
   </ItemGroup>  
 

--- a/NETCORE/test/FunctionalTestUtils/FunctionalTestUtils.csproj
+++ b/NETCORE/test/FunctionalTestUtils/FunctionalTestUtils.csproj
@@ -3,12 +3,15 @@
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFrameworks>net46;netstandard1.6</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>    
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard1.6</TargetFrameworks>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTestUtils</AssemblyName>        
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.csproj" />

--- a/NETCORE/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
+++ b/NETCORE/test/FunctionalTestUtils20/FunctionalTestUtils20.csproj
@@ -3,12 +3,15 @@
   <PropertyGroup>
     <VersionPrefix>1.0.2</VersionPrefix>
     <TargetFrameworks>net461;netcoreapp2.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>    
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTestUtils20</AssemblyName>    
     <PackageId>FunctionalTestUtils</PackageId>
     <NetStandardImplicitPackageVersion>2.0.0</NetStandardImplicitPackageVersion>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.csproj" />

--- a/NETCORE/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
+++ b/NETCORE/test/MVCFramework.FunctionalTests/MVCFramework.FunctionalTests10.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>    
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
+  	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MVCFramework.FunctionalTests.Tests</AssemblyName>        
     <PackageId>MVCFramework.FunctionalTests</PackageId>
@@ -16,6 +16,9 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
 
   <ItemGroup>
     <None Update="App.config">

--- a/NETCORE/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
+++ b/NETCORE/test/MVCFramework20.FunctionalTests/MVCFramework20.FunctionalTests20.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+	  <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>MVCFramework20.FunctionalTests20.Tests</AssemblyName>
     <PackageId>MVCFramework.FunctionalTests</PackageId>
@@ -20,7 +20,10 @@
     <StartupObject />
   </PropertyGroup>
 
-    <ItemGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
+  <ItemGroup>
     <None Update="App.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
       <Generator>SettingsSingleFileGenerator</Generator>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net46</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
     <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>
@@ -16,6 +16,9 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
 
   <ItemGroup>
     <None Update="content\*">

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ApplicationInsights.WorkerService\Microsoft.ApplicationInsights.WorkerService.csproj" />
   </ItemGroup>

--- a/NETCORE/test/TestApp30.Tests/TestApp30.Tests30.csproj
+++ b/NETCORE/test/TestApp30.Tests/TestApp30.Tests30.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="3.0.0-preview8.19405.7" />
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/NETCORE/test/TestApp30/TestApp30.csproj
+++ b/NETCORE/test/TestApp30/TestApp30.csproj
@@ -4,6 +4,9 @@
     <TargetFramework>netcoreapp3.0</TargetFramework>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.csproj" />
   </ItemGroup>

--- a/NETCORE/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
+++ b/NETCORE/test/WebApi.FunctionalTests/WebApi.FunctionalTests10.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>net46;netcoreapp1.0</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.0</TargetFrameworks>
+	  <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net46' ">win7-x86</RuntimeIdentifier>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>WebApi.FunctionalTests.Tests</AssemblyName>    
     <PackageId>WebApi.FunctionalTests</PackageId>
@@ -14,6 +14,9 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
 
   <ItemGroup>
     <None Update="App.config">

--- a/NETCORE/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
+++ b/NETCORE/test/WebApi20.FunctionalTests/WebApi20.FunctionalTests20.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>
     <TargetFrameworks>netcoreapp2.0;net461</TargetFrameworks>
-	<TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
-	<RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
+	  <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.0</TargetFrameworks>
+	  <RuntimeIdentifier Condition=" '$(TargetFramework)' == 'net461' ">win7-x86</RuntimeIdentifier>    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>WebApi20.FunctionalTests20.Tests</AssemblyName>
     <PackageId>WebApi20.FunctionalTests</PackageId>
@@ -13,6 +13,10 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
 
   <ItemGroup>
     <None Update="App.config">

--- a/WEB/Common.props
+++ b/WEB/Common.props
@@ -6,25 +6,7 @@
   <!-- If $(EnlistmentRoot) is still not set, then import Directory.Build.props directly. This can happen when gitlink tries to build (because it uses MSBuild tools version 4.0 and we can't find Microsoft.Common.props) -->
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), 'Directory.Build.props'))\Directory.Build.props" Condition="'$(EnlistmentRoot)' == ''"/>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'net45'">
-   <DefineConstants>$(DefineConstants);NET45;</DefineConstants>
-  </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-
-   <DefineConstants>$(DefineConstants);NETSTANDARD2_0;</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6'">
-
-
-    <NetStandardImplicitPackageVersion>1.6.1</NetStandardImplicitPackageVersion>
-    <DefineConstants>$(DefineConstants);NETSTANDARD1_6;NETSTANDARD;</DefineConstants>
-  </PropertyGroup>
-  
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DefineConstants>$(DefineConstants);TRACE;DEBUG;CODE_ANALYSIS;</DefineConstants>
-  </PropertyGroup>
 
   <PropertyGroup>
     <PartitionPropertiesFile>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Partition.props'))\Partition.props</PartitionPropertiesFile>

--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -12,10 +12,8 @@
     <DefineConstants>$(DefineConstants);DEPENDENCY_COLLECTOR;ALLOW_AGGRESSIVE_INLIGNING_ATTRIBUTE;</DefineConstants>
   </PropertyGroup>
 
-   <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD;</DefineConstants>
-  </PropertyGroup>
-  
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.DependencyCollector</PackageId>

--- a/WEB/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
+++ b/WEB/Src/DependencyCollector/Net45.Tests/DependencyCollector.Net45.Tests.csproj
@@ -19,12 +19,14 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
     <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <PropertyGroup>

--- a/WEB/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
+++ b/WEB/Src/DependencyCollector/NetCore.Tests/DependencyCollector.NetCore.Tests.csproj
@@ -9,17 +9,10 @@
     <AssemblyName>Microsoft.ApplicationInsights.DependencyCollector.NetCore.Tests</AssemblyName>
     <PackageId>Microsoft.AI.DependencyCollector.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591</NoWarn>
-    <DefineConstants>TRACE;DEBUG;NETCORE;NETCOREAPP2_1</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591</NoWarn>
-    <DefineConstants>TRACE;RELEASE;NETCORE;NETCOREAPP2_1</DefineConstants>
-  </PropertyGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.2" />

--- a/WEB/Src/EventCounterCollector/EventCounterCollector.Tests/EventCounterCollector.Tests/EventCounterCollector.Tests.csproj
+++ b/WEB/Src/EventCounterCollector/EventCounterCollector.Tests/EventCounterCollector.Tests/EventCounterCollector.Tests.csproj
@@ -10,6 +10,9 @@
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />

--- a/WEB/Src/EventCounterCollector/EventCounterCollector/EventCounterCollector.csproj
+++ b/WEB/Src/EventCounterCollector/EventCounterCollector/EventCounterCollector.csproj
@@ -9,6 +9,9 @@
     <TargetFrameworks>netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.EventCounterCollector</PackageId>

--- a/WEB/Src/HostingStartup/HostingStartup.Net45.Tests/HostingStartup.Net45.Tests.csproj
+++ b/WEB/Src/HostingStartup/HostingStartup.Net45.Tests/HostingStartup.Net45.Tests.csproj
@@ -24,8 +24,10 @@
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.QualityTools.Testing.Fakes, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>fakesAssemblyForBuild\Microsoft.QualityTools.Testing.Fakes.dll</HintPath>

--- a/WEB/Src/HostingStartup/HostingStartup/HostingStartup.csproj
+++ b/WEB/Src/HostingStartup/HostingStartup/HostingStartup.csproj
@@ -11,6 +11,9 @@
     <DefineConstants>$(DefineConstants);ALLOW_AGGRESSIVE_INLIGNING_ATTRIBUTE</DefineConstants>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.AspNet.ApplicationInsights.HostingStartup</PackageId>

--- a/WEB/Src/PerformanceCollector/NetCore.Tests/Perf.NetCore.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/NetCore.Tests/Perf.NetCore.Tests.csproj
@@ -11,17 +11,10 @@
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <RuntimeFrameworkVersion>1.0.4</RuntimeFrameworkVersion>
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
+    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
-    <DefineConstants>TRACE;DEBUG;NETCORE;NETCOREAPP1_0</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
-    <DefineConstants>TRACE;RELEASE;NETCORE;NETCOREAPP1_0</DefineConstants>
-  </PropertyGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/WEB/Src/PerformanceCollector/NetCore20.Tests/Perf-NetCore20.Tests/Perf-NetCore20.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/NetCore20.Tests/Perf-NetCore20.Tests/Perf-NetCore20.Tests.csproj
@@ -10,17 +10,10 @@
     <PackageId>Microsoft.AI.PerformanceCollector.Tests</PackageId>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>    
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
+    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
-    <DefineConstants>TRACE;DEBUG;NETCORE;NETCOREAPP2_0</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591;8002</NoWarn>
-    <DefineConstants>TRACE;RELEASE;NETCORE;NETCOREAPP2_0</DefineConstants>
-  </PropertyGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/WEB/Src/PerformanceCollector/Perf.Net45.Tests/Perf.Net45.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Perf.Net45.Tests/Perf.Net45.Tests.csproj
@@ -27,17 +27,18 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <DefineConstants>DEBUG;TRACE;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <DefineConstants>TRACE;NET45</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -10,6 +10,9 @@
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.6;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.PerfCounterCollector</PackageId>

--- a/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
@@ -23,8 +23,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\</SolutionDir>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+  </PropertyGroup><PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
@@ -39,6 +38,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.Web.XmlTransform">
       <HintPath>..\..\..\..\..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>

--- a/WEB/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
+++ b/WEB/Src/Web/Web.Net45.Tests/Web.Net45.Tests.csproj
@@ -19,12 +19,14 @@
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\..\..\</SolutionDir>
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
     <TargetFrameworkProfile />
     <Prefer32Bit>false</Prefer32Bit>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>

--- a/WEB/Src/Web/Web/Web.csproj
+++ b/WEB/Src/Web/Web/Web.csproj
@@ -11,6 +11,9 @@
     <DefineConstants>$(DefineConstants);ALLOW_AGGRESSIVE_INLIGNING_ATTRIBUTE</DefineConstants>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.Web</PackageId>

--- a/WEB/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Net45.Tests/WindowsServer.Net45.Tests.csproj
@@ -21,10 +21,12 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
-    <DefineConstants>$(DefineConstants);NET45</DefineConstants>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' " />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' " />
   <ItemGroup>

--- a/WEB/Src/WindowsServer/WindowsServer.NetCore.Tests/WindowsServer.NetCore.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.NetCore.Tests/WindowsServer.NetCore.Tests.csproj
@@ -12,17 +12,10 @@
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591</NoWarn>
-    <DefineConstants>TRACE;RELEASE;NETCORE;NETCOREAPP1_0</DefineConstants>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;1705;1591</NoWarn>
-    <DefineConstants>TRACE;DEBUG;NETCORE;NETCOREAPP1_0</DefineConstants>
-  </PropertyGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />

--- a/WEB/Src/WindowsServer/WindowsServer/WindowsServer.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer/WindowsServer.csproj
@@ -10,16 +10,14 @@
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.6;netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup>
     <!--Nupkg properties-->
     <PackageId>Microsoft.ApplicationInsights.WindowsServer</PackageId>
     <Title>Application Insights Windows Server</Title>
     <Description>Application Insights Windows Server nuget package provides automatic collection of application insights telemetry for .NET applications. This package can be used as a dependent package for Application Insights platform specific packages or as a standalone package for .NET applications that are not covered by platform specific packages (like for .NET worker roles). Privacy statement: https://go.microsoft.com/fwlink/?LinkId=512156</Description>
     <PackageTags>Azure Monitoring Analytics ApplicationInsights Telemetry AppInsights</PackageTags>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(TargetFramework)' == 'netstandard1.6' OR '$(TargetFramework)' == 'netstandard2.0'">
-    <DefineConstants>$(DefineConstants);NETSTANDARD;</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup Condition=" $(OS) == 'Windows_NT'">

--- a/WEB/Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/WEB/Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -20,6 +20,9 @@
     <AssemblyName>ApplicationInsightsTypes</AssemblyName>
     <BondOptions>--collection-interfaces --using="DateTimeOffset=System.DateTimeOffset" --using="TimeSpan=System.TimeSpan" --using="Guid=System.Guid"</BondOptions>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
   </ItemGroup>
   <ItemGroup>

--- a/WEB/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
+++ b/WEB/Test/E2ETests/E2ETests/DependencyCollectionTests.csproj
@@ -42,6 +42,8 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <!--
   <ItemGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <Reference Include="ApplicationInsightsTypes">

--- a/WEB/Test/E2ETests/IngestionService/IngestionService.csproj
+++ b/WEB/Test/E2ETests/IngestionService/IngestionService.csproj
@@ -46,6 +46,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data.DataSetExtensions" />

--- a/WEB/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
+++ b/WEB/Test/E2ETests/TestApps/Net452/E2ETestApp/E2ETestApp.csproj
@@ -51,6 +51,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>

--- a/WEB/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
+++ b/WEB/Test/E2ETests/TestApps/Net452/E2ETestWebApi/E2ETestWebApi.csproj
@@ -50,6 +50,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.7\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/WEB/Test/E2ETests/TestApps/NetCore20/E2ETestAppCore20/E2ETestAppCore20.csproj
+++ b/WEB/Test/E2ETests/TestApps/NetCore20/E2ETestAppCore20/E2ETestAppCore20.csproj
@@ -12,6 +12,9 @@
     <DoNotSign>true</DoNotSign>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
     <Folder Include="wwwroot\" />
   </ItemGroup>

--- a/WEB/Test/E2ETests/TestApps/NetCore30/E2ETestAppCore30/E2ETestAppCore30.csproj.ignored
+++ b/WEB/Test/E2ETests/TestApps/NetCore30/E2ETestAppCore30/E2ETestAppCore30.csproj.ignored
@@ -10,6 +10,9 @@
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
   </PropertyGroup>
 
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
+
   <ItemGroup>
       <PackageReference Include="Microsoft.ApplicationInsights" Version="2.11.0-beta1" />
       <PackageReference Include="System.Data.SqlClient" Version="4.6.1" />

--- a/WEB/Test/E2ETests/TestApps/helpersfortestapp/FW40Shared/HttpSQLHelpers.csproj
+++ b/WEB/Test/E2ETests/TestApps/helpersfortestapp/FW40Shared/HttpSQLHelpers.csproj
@@ -37,6 +37,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <PropertyGroup>
     <StartupObject />
   </PropertyGroup>

--- a/WEB/Test/E2ETests/TestConstants/TestConstants.csproj
+++ b/WEB/Test/E2ETests/TestConstants/TestConstants.csproj
@@ -29,6 +29,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />

--- a/WEB/Test/PerformanceCollector/FunctionalTests/FunctionalTests.csproj
+++ b/WEB/Test/PerformanceCollector/FunctionalTests/FunctionalTests.csproj
@@ -37,6 +37,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <EmbedInteropTypes>True</EmbedInteropTypes>

--- a/WEB/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
+++ b/WEB/Test/PerformanceCollector/FunctionalTests/TestApps/TestApp45/TestApp45.csproj
@@ -43,6 +43,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />

--- a/WEB/Test/Web/FunctionalTests/FunctionalTests/Functional.csproj
+++ b/WEB/Test/Web/FunctionalTests/FunctionalTests/Functional.csproj
@@ -37,6 +37,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <HintPath>..\..\..\..\..\..\packages\EnvDTE.8.0.1\lib\net10\EnvDTE.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/StressTest/StressTest.csproj
+++ b/WEB/Test/Web/FunctionalTests/StressTest/StressTest.csproj
@@ -32,6 +32,9 @@
     <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.Diagnostics.OperationTracking">
       <HintPath>$(BinRoot)\$(Configuration)\OperationTracking\Core\OperationTrackingUniversal40\Microsoft.Diagnostics.OperationTracking.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/AspNetDiagnostics/AspNetDiagnostics.csproj
@@ -41,6 +41,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.7.0, Culture=neutral, PublicKeyToken=f23a46de0be5d6f3, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.7\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/Aspx45/Aspx45.csproj
@@ -45,6 +45,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.7.0, Culture=neutral, PublicKeyToken=f23a46de0be5d6f3, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.7\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/ConsoleAppFW45/ConsoleAppFW45.csproj
@@ -35,6 +35,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.Diagnostics.Tracing.EventSource, Version=1.1.28.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>

--- a/WEB/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/Mvc4_MediumTrust/Mvc4_MediumTrust.csproj
@@ -53,6 +53,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\EntityFramework.6.1.0\lib\net45\EntityFramework.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/Wa45Aspx/Wa45Aspx.csproj
@@ -50,6 +50,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.7.0, Culture=neutral, PublicKeyToken=f23a46de0be5d6f3, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.7\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/Wcf45Tests/Wcf45Tests.csproj
@@ -51,6 +51,9 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.7.0, Culture=neutral, PublicKeyToken=f23a46de0be5d6f3, processorArchitecture=MSIL">
       <HintPath>..\..\..\..\..\..\..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.7\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>

--- a/WEB/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/WebAppFW45/WebAppFW45.csproj
@@ -54,6 +54,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\BASE\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj">
       <Project>{3a5be8ff-4571-48c0-bf28-5dbcb509900e}</Project>

--- a/WEB/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
+++ b/WEB/Test/Web/FunctionalTests/TestApps/WebAppFW45Sampled/WebAppFW45Sampled.csproj
@@ -54,6 +54,9 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
+
+  <Import Project="$(PropsRoot)\DefineConstants.props" />
+
   <ItemGroup>
     <ProjectReference Include="..\..\..\..\..\..\BASE\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj">
       <Project>{3a5be8ff-4571-48c0-bf28-5dbcb509900e}</Project>


### PR DESCRIPTION
Fix Issue #1214  .

**Changes**
- moving all Framework related Constants to a new props file.

none of this may be necessary. see: https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget

> The build system is aware of the following preprocessor symbols used in #if directives:

Target Frameworks | Symbols
-- | --
.NET Framework | NETFRAMEWORK, NET20, NET35, NET40, NET45, NET451, NET452, NET46, NET461, NET462, NET47, NET471, NET472, NET48
.NET Standard | NETSTANDARD, NETSTANDARD1_0, NETSTANDARD1_1, NETSTANDARD1_2, NETSTANDARD1_3, NETSTANDARD1_4, NETSTANDARD1_5, NETSTANDARD1_6, NETSTANDARD2_0, NETSTANDARD2_1
.NET Core | NETCOREAPP, NETCOREAPP1_0, NETCOREAPP1_1, NETCOREAPP2_0, NETCOREAPP2_1, NETCOREAPP2_2, NETCOREAPP3_0, NETCOREAPP3_1



Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build