### PR TITLE
Tilee/add netcore3.0 tests

### DIFF
--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -3,7 +3,7 @@ pool:
 steps:
 
 
-- task: DotNetCoreInstaller@0
+- task: DotNetCoreInstaller@1
   displayName: install dotnet core 3.0
   inputs:
     version: 3.0.102
@@ -31,7 +31,7 @@ steps:
 
 ## Install and test NetCore 2.2
 
-- task: DotNetCoreInstaller@0
+- task: DotNetCoreInstaller@1
   displayName: install dotnet core 2.2
   inputs:
     version: 2.2.207
@@ -46,7 +46,8 @@ steps:
 
  ## Install and test NetCore 1.1
 
-- task: DotNetCoreInstaller@0
+- task: DotNetCoreInstaller@1
+  displayName: install dotnet core 1.1
   inputs:
     version: "1.1.5"
 

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -49,7 +49,7 @@ steps:
 - task: DotNetCoreInstaller@1
   displayName: install dotnet core 1.1
   inputs:
-    version: "1.1.x"
+    version: 1.1.x
 
 - task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Test NetCore 1.1

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -4,9 +4,14 @@ variables:
 pool:
   vmImage: 'ubuntu-16.04'
 steps:
+
 - task: DotNetCoreInstaller@0
   inputs:
-    version: $(DotNetVersion)
+    version: 2.2.207
+
+- task: DotNetCoreInstaller@0
+  inputs:
+    version: 3.0.102
 
 - task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Restore Solution

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -6,7 +6,7 @@ steps:
 - task: DotNetCoreInstaller@1
   displayName: install dotnet core 3.0
   inputs:
-    version: 3.0.102
+    version: 3.0.x
 
 - task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Restore Solution
@@ -49,7 +49,7 @@ steps:
 - task: DotNetCoreInstaller@1
   displayName: install dotnet core 1.1
   inputs:
-    version: "1.1.5"
+    version: "1.1.x"
 
 - task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Test NetCore 1.1

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -34,7 +34,7 @@ steps:
 - task: DotNetCoreInstaller@1
   displayName: install dotnet core 2.2
   inputs:
-    version: 2.2.207
+    version: 2.2.x
 
 - task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Test NetCore 2.0

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -1,15 +1,10 @@
-variables:
-  DotNetVersion: "2.2.101"
-
 pool:
   vmImage: 'ubuntu-16.04'
 steps:
 
-- task: DotNetCoreInstaller@0
-  inputs:
-    version: 2.2.207
 
 - task: DotNetCoreInstaller@0
+  displayName: install dotnet core 3.0
   inputs:
     version: 3.0.102
 
@@ -27,11 +22,29 @@ steps:
     arguments: "--configuration Release"
 
 - task: DotNetCoreCLI@1
+  displayName: DotNetCoreCLI - Test NetCore 3.0
+  inputs:
+    command: "test"
+    projects: "BASE/Test/**/Microsoft.ApplicationInsights.Tests.csproj"
+    arguments: "--configuration Release --framework netcoreapp3.0 -l trx --filter TestCategory!=WindowsOnly"
+
+
+## Install and test NetCore 2.2
+
+- task: DotNetCoreInstaller@0
+  displayName: install dotnet core 2.2
+  inputs:
+    version: 2.2.207
+
+- task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Test NetCore 2.0
   inputs:
     command: "test"
     projects: "BASE/Test/**/Microsoft.ApplicationInsights.Tests.csproj"
     arguments: "--configuration Release --framework netcoreapp2.0 -l trx --filter TestCategory!=WindowsOnly"
+
+
+ ## Install and test NetCore 1.1
 
 - task: DotNetCoreInstaller@0
   inputs:
@@ -43,6 +56,8 @@ steps:
     command: "test"
     projects: "BASE/Test/**/Microsoft.ApplicationInsights.Tests.csproj"
     arguments: "--configuration Release --framework netcoreapp1.1 -l trx --filter TestCategory!=WindowsOnly"
+
+## Publish test results
 
 - task: PublishTestResults@2
   condition: always()

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -46,7 +46,7 @@ steps:
 
  ## Install and test NetCore 1.1
 
-- task: DotNetCoreInstaller@1
+- task: DotNetCoreInstaller@0
   displayName: install dotnet core 1.1
   inputs:
     version: 1.1.5

--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -49,7 +49,7 @@ steps:
 - task: DotNetCoreInstaller@1
   displayName: install dotnet core 1.1
   inputs:
-    version: 1.1.x
+    version: 1.1.5
 
 - task: DotNetCoreCLI@1
   displayName: DotNetCoreCLI - Test NetCore 1.1

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/InMemoryChannelTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/InMemoryChannelTest.cs
@@ -51,7 +51,7 @@
             }
         }
 
-#if (!NETCOREAPP1_1 && !NETCOREAPP2_0)
+#if (!NETCOREAPP) // This constant is defined for all versions of NetCore https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
 
         [Ignore("This test is failing intermittently and needs to be investigated. ~Timothy")]
         [TestMethod]

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/TelemetryConfigurationFactoryTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/TelemetryConfigurationFactoryTest.cs
@@ -504,7 +504,11 @@
         }
 
         [TestMethod]
+#if NETCOREAPP3_0
+        [ExpectedExceptionWithMessage(typeof(ArgumentException), "Failed to parse configuration value. Property: 'TimeSpanProperty' Reason: String 'TestValue' was not recognized as a valid TimeSpan.")]
+#else
         [ExpectedExceptionWithMessage(typeof(ArgumentException), "Failed to parse configuration value. Property: 'TimeSpanProperty' Reason: String was not recognized as a valid TimeSpan.")]
+#endif
         public void LoadInstanceSetsInstancePropertiesOfTimeSpanTypeFromChildElementValuesOfDefinitionWithInvalidFormatThrowsException()
         {
             var definition = new XElement(
@@ -641,9 +645,9 @@
             Assert.AreEqual(42, loaded.Int32Property);
         }
 
-        #endregion
+#endregion
 
-        #region TelemetryProcesors
+#region TelemetryProcesors
 
         [TestMethod]
         public void InitializeTelemetryProcessorsFromConfigurationFile()
@@ -873,9 +877,9 @@
             AssertEx.IsType<StubTelemetryProcessor2>(configuration.TelemetryProcessors[1]);
         }
 
-        #endregion
+#endregion
 
-        #region Modules
+#region Modules
 
         [TestMethod]
         public void InitializeTelemetryModulesFromConfigurationFile()
@@ -961,9 +965,9 @@
             }
         }
 
-        #endregion
+#endregion
 
-        #region TelemetryInitializers
+#region TelemetryInitializers
         [TestMethod]
         public void InitializeAddTelemetryInitializersWithOneInvalid()
         {
@@ -982,9 +986,9 @@
         }
 
 
-        #endregion
+#endregion
 
-        #region LoadInstances<T>
+#region LoadInstances<T>
 
         [TestMethod]
         public void LoadInstancesPopulatesListWithInstancesOfSpecifiedType()
@@ -1055,9 +1059,9 @@
             AssertEx.AreEqual(new[] { 42 }, instances);
         }
 
-        #endregion
+#endregion
 
-        #region LoadProperties
+#region LoadProperties
 
         [TestMethod]
         public void LoadPropertiesConvertsPropertyValuesFromStringToPropertyType()
@@ -1215,9 +1219,9 @@
             Assert.IsFalse(instance.TelemetryChannel.DeveloperMode.HasValue);
         }
 
-        #endregion
+#endregion
 
-        #region TelemetrySinks
+#region TelemetrySinks
 
         [TestMethod]
         public void EmptyConfigurationCreatesDefaultSink()
@@ -1783,7 +1787,7 @@
             Assert.IsTrue(processor.Initialized);
         }
 
-        #endregion 
+#endregion
 
         [TestMethod]
         public void InitializeIsMarkesAsInternalSdkOperation()

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Metrics/TestUtility/TestUtil.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Metrics/TestUtility/TestUtil.cs
@@ -236,7 +236,7 @@ namespace Microsoft.ApplicationInsights.Metrics.TestUtility
             Assert.IsNotNull(versionMoniker);
 
             // Expected result example: "m-agg2:2.6.0-12552"
-#if NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP // This constant is defined for all versions of NetCore https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         const string expectedPrefix = "m-agg2c:";
 #else
             const string expectedPrefix = "m-agg2:";

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -14,8 +14,8 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <TargetFrameworks>net45;net46;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;net46;netcoreapp1.1;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp1.1;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
     <DebugType>pdbonly</DebugType> 
     <DebugSymbols>true</DebugSymbols> 
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
@@ -1045,7 +1045,7 @@
             Assert.AreEqual(client.Context.Properties[PropertyNameGlobal], globalValueInInitializer);
         }
 
-#if (!NETCOREAPP1_1 && !NETCOREAPP2_0)
+#if (!NETCOREAPP) // This constant is defined for all versions of NetCore https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         [TestMethod]
         public void TrackAddsSdkVerionByDefault()
         {

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp1.1;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp1.1;netcoreapp2.0;netcoreapp3.0</TargetFrameworks>
 
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.Tests</AssemblyName>
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/Tags.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/Tags.cs
@@ -68,10 +68,10 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         {
             if (tagValue.HasValue)
             {
-#if NET45 || NET46 || NETSTANDARD2_0
-                string value = tagValue.Value.ToString(CultureInfo.InvariantCulture);
-#else
+#if NETSTANDARD1_3
                 string value = tagValue.Value.ToString();
+#else
+                string value = tagValue.Value.ToString(CultureInfo.InvariantCulture);
 #endif
                 tags.Add(tagKey, value);
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -29,7 +29,7 @@
         /// <summary>
         /// Value for property indicating 'app insights version' related specifically to heartbeats.
         /// </summary>        
-#if NETSTANDARD1_3 || NETSTANDARD2_0
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbnetc:");
 #else
         private static string sdkVersionPropertyValue = SdkVersionUtils.GetSdkVersion("hbnet:");

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -102,9 +102,9 @@
         /// If the configuration file does not exist, the active configuration instance is initialized with minimum defaults 
         /// needed to send telemetry to Application Insights.
         /// </summary>
-#if NETSTANDARD1_3 || NETSTANDARD2_0
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 for more details")]
-#endif 
+#endif
         public static TelemetryConfiguration Active
         {
             get

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
@@ -16,7 +16,7 @@
 
         private const string FallbackParameterName = "specified parameter";
 
-#if NETSTANDARD1_3 || NETSTANDARD2_0
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         private static string sdkVersionMoniker = SdkVersionUtils.GetSdkVersion("m-agg2c:");
 #else
         private static string sdkVersionMoniker = SdkVersionUtils.GetSdkVersion("m-agg2:");

--- a/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -8,6 +8,10 @@
     <AssemblyName>Microsoft.ApplicationInsights</AssemblyName>
     <TargetFrameworks>net45;net46;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
+
+
+    <!-- this constant is set for all other netcore targets except 1-->
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.3'">$(DefineConstants);NETSTANDARD;</DefineConstants>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -19,7 +19,7 @@
     /// </summary>
     public sealed class TelemetryClient
     {
-#if NETSTANDARD1_3 || NETSTANDARD2_0
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         private const string VersionPrefix = "dotnetc:";
 #else
         private const string VersionPrefix = "dotnet:";
@@ -32,7 +32,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the active configuration, usually loaded from ApplicationInsights.config.
         /// </summary>
-#if NETSTANDARD1_3 || NETSTANDARD2_0
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
         [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 for more details")]
 #endif
         public TelemetryClient() : this(TelemetryConfiguration.Active)

--- a/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -8,6 +8,10 @@
     <AssemblyName>Microsoft.AI.ServerTelemetryChannel</AssemblyName>
     <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard1.3;netstandard2.0</TargetFrameworks>
+
+
+    <!-- this constant is set for all other netcore targets except 1-->
+    <DefineConstants Condition="'$(TargetFramework)' == 'netstandard1.3'">$(DefineConstants);NETSTANDARD;</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION


## Changes
- enable netcore 3.0 tests on Base SDK and TelemetlyChannel.
- fix preprocessors to use correct constant https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
