### PR TITLE
Performance improvement for PerfCounters. switching to PerformanceCounterCategory api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Adding a flag to DependencyTrackingTelemetryModule to enable/disable collection of SQL Command text.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1514)
    Collecting SQL Command Text will now be opt-in, so this value will default to false. This is a change from the current behavior on .NET Core. To see how to collect SQL Command Text see here for details: https://docs.microsoft.com/en-us/azure/azure-monitor/app/asp-net-dependencies#advanced-sql-tracking-to-get-full-sql-query
 - [change references to log4net to version 2.0.8](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1675)
+- [Fix: PerformanceCounter implementation is taking large memory allocation](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1694)
 
 ## Version 2.13.0-beta2
 - [Move FileDiagnosticTelemetryModule to Microsoft.ApplicationInsights assembly.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1059)

--- a/WEB/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
@@ -49,7 +49,9 @@
         private const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
         private const string WebSiteIsolationHyperV = "hyperv";
 
+#if !NETSTANDARD1_6
         private static readonly ConcurrentDictionary<string, Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>> cache = new ConcurrentDictionary<string, Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>>();
+#endif
 
         private static readonly ConcurrentDictionary<string, string> PlaceholderCache =
             new ConcurrentDictionary<string, string>();

--- a/WEB/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared/Implementation/PerformanceCounterUtility.cs
@@ -49,6 +49,8 @@
         private const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
         private const string WebSiteIsolationHyperV = "hyperv";
 
+        private static readonly ConcurrentDictionary<string, Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>> cache = new ConcurrentDictionary<string, Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>>();
+
         private static readonly ConcurrentDictionary<string, string> PlaceholderCache =
             new ConcurrentDictionary<string, string>();
 
@@ -480,26 +482,54 @@
         }
 
 #if !NETSTANDARD1_6
-        private static string FindProcessInstance(
-            int pid,
-            IEnumerable<string> instances,
-            string categoryName,
-            string counterName)
+        private static string FindProcessInstance(int pid, IEnumerable<string> instances, string categoryName, string counterName)
         {
-            return instances.FirstOrDefault(
-                i =>
+            Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection> cached;
+
+            DateTime utcNow = DateTime.UtcNow;
+
+            InstanceDataCollectionCollection result = null;
+
+            PerformanceCounterCategory category = null;
+
+            if (cache.TryGetValue(categoryName, out cached))
+            {
+                category = cached.Item2;
+
+                if (cached.Item1 < utcNow)
                 {
-                    try
+                    result = cached.Item3;
+                }
+            }
+
+            if (result == null)
+            {
+                if (category == null)
+                {
+                    category = new PerformanceCounterCategory(categoryName);
+                }
+
+                result = category.ReadCategory();
+
+                cache.TryAdd(categoryName, new Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>(utcNow.AddMinutes(1), category, result));
+            }
+
+            InstanceDataCollection counters = result[counterName];
+
+            if (counters != null)
+            {
+                foreach (string i in instances)
+                {
+                    InstanceData instance = counters[i];
+
+                    if ((instance != null) && (pid == instance.RawValue))
                     {
-                        return pid == (int)new PerformanceCounter(categoryName, counterName, i, true).RawValue;
+                        return i;
                     }
-                    catch (Exception)
-                    {
-                        // most likely the process has terminated since we got the process list
-                        // that process is not us, we're still running
-                        return false;
-                    }
-                });
+                }
+            }
+
+            return null;
         }
 
         private static IList<string> GetInstances(string categoryName)


### PR DESCRIPTION
Fix Issue #1694  .

## Changes
- replaced implementation of `FindProcessInstance()`.  Using PerformanceCounterCategory api instead of PerformanceCounter api.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
