### PR TITLE
fix for AspNetCore AddApplicationInsightsSettings() and MissingMethodException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,18 @@
 ## VNext
 
 
+## Version 2.14.0-beta2
+- [Fix: AspNetCore AddApplicationInsightsSettings() and MissingMethodException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1702)
+
 ## Version 2.14.0-beta1
 - [Support new conventions for EventHubs from Azure.Messaging.EventHubs and processor.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1674)
 - [Adding a flag to DependencyTrackingTelemetryModule to enable/disable collection of SQL Command text.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1514)
    Collecting SQL Command Text will now be opt-in, so this value will default to false. This is a change from the current behavior on .NET Core. To see how to collect SQL Command Text see here for details: https://docs.microsoft.com/azure/azure-monitor/app/asp-net-dependencies#advanced-sql-tracking-to-get-full-sql-query
 - [change references to log4net to version 2.0.8](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1675)
 - [Fix: PerformanceCounter implementation is taking large memory allocation](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1694)
+
+## Version 2.13.1
+- [Fix: AspNetCore AddApplicationInsightsSettings() and MissingMethodException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1702)
 
 ## Version 2.13.0
 - no changes since beta.
@@ -27,6 +33,9 @@
 - [Sanitizing Message in Exception](https://github.com/microsoft/ApplicationInsights-dotnet/issues/546)
 - [Fix CreateRequestTelemetryPrivate throwing System.ArgumentOutOfRangeException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1513)
 - [NLog supports TargetFramework NetStandard2.0 and reduces dependencies](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1522)
+
+## Version 2.12.2
+- [Fix: AspNetCore AddApplicationInsightsSettings() and MissingMethodException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1702)
 
 ## Version 2.12.1
 - [Fix Endpoint configuration bug affecting ServerTelemetryChannel and QuickPulseTelemetryModule](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1648)

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -158,14 +158,25 @@
         /// <param name="developerMode">Enables or disables developer mode.</param>
         /// <param name="endpointAddress">Sets telemetry endpoint address.</param>
         /// <param name="instrumentationKey">Sets instrumentation key.</param>
-        /// <param name="connectionString">Sets connection string.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
+        public static IConfigurationBuilder AddApplicationInsightsSettings(this IConfigurationBuilder configurationSourceRoot,  bool? developerMode = null, string endpointAddress = null, string instrumentationKey = null)
+            => configurationSourceRoot.AddApplicationInsightsSettings(developerMode, endpointAddress, instrumentationKey);
+
+            /// <summary>
+            /// Adds Application Insight specific configuration properties to <see cref="IConfigurationBuilder"/>.
+            /// </summary>
+            /// <param name="configurationSourceRoot">The <see cref="IConfigurationBuilder"/> instance.</param>
+            /// <param name="connectionString">Sets connection string.</param>
+            /// <param name="developerMode">Enables or disables developer mode.</param>
+            /// <param name="endpointAddress">Sets telemetry endpoint address.</param>
+            /// <param name="instrumentationKey">Sets instrumentation key.</param>
+            /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddApplicationInsightsSettings(
             this IConfigurationBuilder configurationSourceRoot,
+            string connectionString,
             bool? developerMode = null,
             string endpointAddress = null,
-            string instrumentationKey = null,
-            string connectionString = null)
+            string instrumentationKey = null)
         {
             if (configurationSourceRoot == null)
             {

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -160,7 +160,7 @@
         /// <param name="instrumentationKey">Sets instrumentation key.</param>
         /// <returns>The <see cref="IConfigurationBuilder"/>.</returns>
         public static IConfigurationBuilder AddApplicationInsightsSettings(this IConfigurationBuilder configurationSourceRoot,  bool? developerMode = null, string endpointAddress = null, string instrumentationKey = null)
-            => configurationSourceRoot.AddApplicationInsightsSettings(developerMode, endpointAddress, instrumentationKey);
+            => configurationSourceRoot.AddApplicationInsightsSettings(connectionString: null, developerMode: developerMode, endpointAddress: endpointAddress, instrumentationKey: instrumentationKey);
 
             /// <summary>
             /// Adds Application Insight specific configuration properties to <see cref="IConfigurationBuilder"/>.


### PR DESCRIPTION
Fix Issue #1702.

## Changes
- Restore the removed method signature, now an overload.
- Note that this brakes the method signature for anyone who took a dependency on the order of parameters instead of using named parameters.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
