### PR TITLE
Update System Dependencies (alt pr)

### DIFF
--- a/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.5.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.3'">

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 - [New: JavaScript Property to support Content Security Policy](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1443)
 - [Fix: All perf counters stop being collected when any of faulty counters are specified to collect on Azure WebApps](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1686)
 - [Fix: Some perf counters aren't collected when app is hosted on Azure WebApp](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1685)
+- [Fix: Update dependencies to fix incompatibility with NetCore 3.0 and 3.1](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1699)
+    - System.Data.SqlClient v4.3.1 -> v4.7.0
+    - System.Diagnostics.PerformanceCounter v4.5.0 -> v4.7.0
+    - System.IO.FileSystem.AccessControl v4.5.0 -> 4.7.0
 
 ## Version 2.14.0-beta2
 - [Fix: AspNetCore AddApplicationInsightsSettings() and MissingMethodException](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1702)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - [Fix: All perf counters stop being collected when any of faulty counters are specified to collect on Azure WebApps](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1686)
 - [Fix: Some perf counters aren't collected when app is hosted on Azure WebApp](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1685)
 - [Fix: Update dependencies to fix incompatibility with NetCore 3.0 and 3.1](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1699)
-    - System.Data.SqlClient v4.3.1 -> v4.7.0
+    - removing dependency on System.Data.SqlClient
     - System.Diagnostics.PerformanceCounter v4.5.0 -> v4.7.0
     - System.IO.FileSystem.AccessControl v4.5.0 -> 4.7.0
 

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
@@ -48,6 +48,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="1.1.2" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="1.1.2" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
 
   </ItemGroup>
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+    <!--<PackageReference Include="System.Data.SqlClient" Version="4.7.0" />-->
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">

--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -60,7 +60,6 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-    <!--<PackageReference Include="System.Data.SqlClient" Version="4.7.0" />-->
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">

--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -60,7 +60,7 @@
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.3.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net45'">

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -59,7 +59,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.5.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix Issue #1699 .
Following recommendations from dotnet team, we are updating these packages to resolve errors related to dotnetcore 3.0


## Changes
- ~System.Data.SqlClient v4.3.1 -> v4.7.0 (Will update this to 4.8.1 in a follow up PR)~
- removing dependency on SqlClient (still needed in unit tests)
- System.Diagnostics.PerformanceCounter v4.5.0 -> v4.7.0
- System.IO.FileSystem.AccessControl v4.5.0 -> 4.7.0

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
