### PR TITLE
Dispose the HeartBeat timer when HeartBeatProvider is disabled.

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -120,9 +120,15 @@
             {
                 if (!this.isEnabled && value)
                 {
-                    // we need to start calling the timer again
-                    // if requested to disable, let the next HeartbeatPulse disable it for us (do nothing here)
-                    this.HeartbeatTimer.Change(this.HeartbeatInterval, this.HeartbeatInterval);
+                    // we need to start calling the timer again                    
+                    this.HeartbeatTimer?.Change(this.HeartbeatInterval, this.HeartbeatInterval);
+                }
+                else if (this.isEnabled && !value)
+                {
+                    // heartbeat was enabled previously, and being disabled now.
+                    // dispose timers so they never fire again.
+                    this.HeartbeatTimer?.Change(Timeout.Infinite, Timeout.Infinite);
+                    this.HeartbeatTimer?.Dispose();
                 }
 
                 this.isEnabled = value;
@@ -146,7 +152,7 @@
             get => this.disabledDefaultFields;
         }
 
-        private Timer HeartbeatTimer { get; set; } // timer that will send each heartbeat in intervals
+        internal Timer HeartbeatTimer { get; set; } // timer that will send each heartbeat in intervals
 
         public void Initialize(TelemetryConfiguration configuration)
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/HeartbeatProvider.cs
@@ -152,7 +152,7 @@
             get => this.disabledDefaultFields;
         }
 
-        internal Timer HeartbeatTimer { get; set; } // timer that will send each heartbeat in intervals
+        private Timer HeartbeatTimer { get; set; } // timer that will send each heartbeat in intervals
 
         public void Initialize(TelemetryConfiguration configuration)
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ﻿# Changelog
 
 ## VNext
+- [Fix: Disabling HeartBeats in Asp.Net Core projects causes Error traces every heart beat interval (15 minutes defualt)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1681)
 
 ## Version 2.14.0-beta3
 - [New: JavaScript Property to support Content Security Policy](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1443)


### PR DESCRIPTION
Fix Issue #1681

## Changes
Current code:
HeartBeatProvider gets enabled automatically by virtue of it being part of DiagnosticTelemetryModule. In Asp.Net Core, when user disable HeartBeat, `IsHeartbeatEnabled` property of `HeartbeatProvider` is set to false. However, this does't reset the already initialized `Timer`, which keeps firing every internal, only to see that it is disabled, and ends up writing Error trace to EventLog.

# Proposed Code:
The Timer is disposed when setting `IsHeartbeatEnabled` to false so that timers no longer fire.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
