### PR TITLE
Fix test: GetApplicationFolderReturnsSubfolderFromTempFolderIfLocalAppDataIsTooLong

### DIFF
--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ApplicationFolderProviderTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ApplicationFolderProviderTest.cs
@@ -161,6 +161,10 @@
             DirectoryInfo localAppData = this.CreateTestDirectory(longName);
             DirectoryInfo temp = this.CreateTestDirectory("Temp");
 
+            //TODO PRINT FULL FOLDER PATHS
+            System.Console.WriteLine($"LocalAppData: {localAppData.FullName}");
+            System.Console.WriteLine($"Temp: {temp.FullName}");
+
             // Initialize ApplicationfolderProvider
             var environmentVariables = new Hashtable 
             { 

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ApplicationFolderProviderTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ApplicationFolderProviderTest.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System.Collections;
+    using System.Diagnostics;
     using System.IO;
     using System.Linq; 
     using System.Security.AccessControl;
@@ -319,6 +320,8 @@
         private DirectoryInfo CreateTestDirectory(string path, FileSystemRights rights = FileSystemRights.FullControl, AccessControlType access = AccessControlType.Allow)
         {
             DirectoryInfo directory = this.testDirectory.CreateSubdirectory(path);
+            Assert.IsTrue(Directory.Exists(directory.FullName), $"failed to create test directory: {directory.FullName}");
+
             DirectorySecurity security = directory.GetAccessControl();
             security.AddAccessRule(new FileSystemAccessRule(WindowsIdentity.GetCurrent().Name, rights, access));
             directory.SetAccessControl(security);

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ApplicationFolderProviderTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ApplicationFolderProviderTest.cs
@@ -157,19 +157,22 @@
         {
             string longName = new string('A', 238 - this.testDirectory.FullName.Length);
 
+            // Setup unit test directories
             DirectoryInfo localAppData = this.CreateTestDirectory(longName);
             DirectoryInfo temp = this.CreateTestDirectory("Temp");
+
+            // Initialize ApplicationfolderProvider
             var environmentVariables = new Hashtable 
             { 
                 { "LOCALAPPDATA", localAppData.FullName },
                 { "TEMP", temp.FullName },
             };
             var provider = new ApplicationFolderProvider(environmentVariables);
-
             IPlatformFolder applicationFolder = provider.GetApplicationFolder();
 
+            // Evaluate
             Assert.IsNotNull(applicationFolder);
-            Assert.AreEqual(1, temp.GetDirectories().Length);
+            Assert.AreEqual(1, temp.GetDirectories().Length, "subdirectories were not created");
 
             localAppData.Delete(true);
             temp.Delete(true);

--- a/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -62,6 +62,7 @@
                 object localAppData = this.environment["LOCALAPPDATA"];
                 if (localAppData != null)
                 {
+                    System.Console.WriteLine("Attempt to create localAppData directory...");
                     result = this.CreateAndValidateApplicationFolder(localAppData.ToString(), createSubFolder: true, errors: errors);
                 }
             }
@@ -71,13 +72,14 @@
                 object temp = this.environment["TEMP"];
                 if (temp != null)
                 {
+                    System.Console.WriteLine("Attempt to create TEMP directory...");
                     result = this.CreateAndValidateApplicationFolder(temp.ToString(), createSubFolder: true, errors: errors);
                 }
             }
 
             if (result == null)
             {
-                Debug.WriteLine("ApplicationfolderProvider unable to create directories.");
+                System.Console.WriteLine("ApplicationfolderProvider unable to create directories.");
                 TelemetryChannelEventSource.Log.TransmissionStorageAccessDeniedError(string.Join(Environment.NewLine, errors), this.identityProvider.GetName(), this.customFolderName);
             }
 
@@ -95,6 +97,7 @@
 
         private static string GetPathAccessFailureErrorMessage(Exception exp, string path)
         {
+            System.Console.WriteLine("Error {0} {1}", exp.ToString(), path);
             return "Path: " + path + "; Error: " + exp.Message + Environment.NewLine;
         }
 

--- a/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -77,6 +77,7 @@
 
             if (result == null)
             {
+                Debug.WriteLine("ApplicationfolderProvider unable to create directories.");
                 TelemetryChannelEventSource.Log.TransmissionStorageAccessDeniedError(string.Join(Environment.NewLine, errors), this.identityProvider.GetName(), this.customFolderName);
             }
 

--- a/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -62,7 +62,6 @@
                 object localAppData = this.environment["LOCALAPPDATA"];
                 if (localAppData != null)
                 {
-                    System.Console.WriteLine("Attempt to create localAppData directory...");
                     result = this.CreateAndValidateApplicationFolder(localAppData.ToString(), createSubFolder: true, errors: errors);
                 }
             }
@@ -72,14 +71,12 @@
                 object temp = this.environment["TEMP"];
                 if (temp != null)
                 {
-                    System.Console.WriteLine("Attempt to create TEMP directory...");
                     result = this.CreateAndValidateApplicationFolder(temp.ToString(), createSubFolder: true, errors: errors);
                 }
             }
 
             if (result == null)
             {
-                System.Console.WriteLine("ApplicationfolderProvider unable to create directories.");
                 TelemetryChannelEventSource.Log.TransmissionStorageAccessDeniedError(string.Join(Environment.NewLine, errors), this.identityProvider.GetName(), this.customFolderName);
             }
 
@@ -97,7 +94,6 @@
 
         private static string GetPathAccessFailureErrorMessage(Exception exp, string path)
         {
-            System.Console.WriteLine("Error {0} {1}", exp.ToString(), path);
             return "Path: " + path + "; Error: " + exp.Message + Environment.NewLine;
         }
 


### PR DESCRIPTION
Investing this test that recently started to fail on our build server.

## Changes
- Added more Asserts to catch the real reason this test was failing.
- Increasing the directory name length to force netcore tests to fail.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
