### PR TITLE
Remove Microsoft.AspNetCore.Hosting eventcounters by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## VNext
 
+## Version 2.14.0-beta5
+- [Stop collecting EventCounters from Microsoft.AspNetCore.Hosting](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1759)
+
 ## Version 2.14.0-beta4
 - [Fix: SQL dependency names are bloated when running under the .NET Framework and using Microsoft.Data.SqlClient package](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1723)
 - [Fix: Disabling HeartBeats in Asp.Net Core projects causes Error traces every heart beat interval (15 minutes defualt)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1681)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -134,8 +134,7 @@
                     AddTelemetryChannel(services);
 
 #if NETSTANDARD2_0
-                    ConfigureEventCounterModuleWithSystemCounters(services);
-                    ConfigureEventCounterModuleWithAspNetCounters(services);
+                    ConfigureEventCounterModuleWithSystemCounters(services);                    
 #endif
 
                     services.TryAddSingleton<IConfigureOptions<ApplicationInsightsServiceOptions>,

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -632,19 +632,13 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 var eventCounterModule = modules.OfType<EventCounterCollectionModule>().Single();
 
                 //VALIDATE
-                Assert.Equal(23, eventCounterModule.Counters.Count);
+                Assert.Equal(19, eventCounterModule.Counters.Count);
                 
                 // sanity check with a sample counter.
                 var cpuCounterRequest = eventCounterModule.Counters.FirstOrDefault<EventCounterCollectionRequest>(
                     eventCounterCollectionRequest => eventCounterCollectionRequest.EventSourceName == "System.Runtime"
                     && eventCounterCollectionRequest.EventCounterName == "cpu-usage");
-                Assert.NotNull(cpuCounterRequest);
-
-                // sanity check - asp.net counters should be added
-                var aspnetCounterRequest = eventCounterModule.Counters.Where<EventCounterCollectionRequest>(
-                    eventCounterCollectionRequest => eventCounterCollectionRequest.EventSourceName == "Microsoft.AspNetCore.Hosting");
-                Assert.NotNull(aspnetCounterRequest);
-                Assert.True(aspnetCounterRequest.Count() == 4);
+                Assert.NotNull(cpuCounterRequest);                
             }
 #endif
 


### PR DESCRIPTION
Fix Issue #1759 .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
