### PR TITLE
Removing TryRun method from ActivityExtensions

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/ActivityExtensionsTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/ActivityExtensionsTests.cs
@@ -8,12 +8,6 @@
     public class ActivityExtensionsTests
     {
         [TestMethod]
-        public void CanLoadDiagnosticSourceAssembly()
-        {
-            Assert.IsTrue(ActivityExtensions.TryRun(() => Assert.IsNull(Activity.Current)));
-        }
-
-        [TestMethod]
         public void GetOperationNameReturnsNullIfThereIsNoOperationName()
         {
             var activity = new Activity("test me");

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Standalone/AppInsightsStandaloneTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Standalone/AppInsightsStandaloneTests.cs
@@ -34,7 +34,7 @@
         [Ignore("Missing netstandard dependencies.")]
 #endif
         [TestMethod]
-        public void AppInsightsDllCouldRunStandalone()
+        public void AppInsightsDllShouldNotRunStandalone()
         {
             // This tests if ApplicationInsights.dll can work standalone without System.DiagnosticSource (for uses like in a powershell script)
             // Its hard to mock this with plain unit tests, so we spin up a dummy application, copy just ApplicationInsights.dll
@@ -111,7 +111,7 @@
             Assert.IsTrue(p.WaitForExit(10000));
             Trace.WriteLine(p.StandardOutput.ReadToEnd());
             Trace.WriteLine(p.StandardError.ReadToEnd());
-            Assert.AreEqual(0, p.ExitCode);
+            Assert.AreNotEqual(0, p.ExitCode);
            
 
             return p.StandardOutput.ReadToEnd();

--- a/BASE/src/Microsoft.ApplicationInsights/ActivityExtensions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/ActivityExtensions.cs
@@ -9,30 +9,6 @@
     internal static class ActivityExtensions
     {
         private const string OperationNameTag = "OperationName";
-        private static bool isInitialized;
-        private static bool isAvailable;
-
-        /// <summary>
-        /// Executes action if Activity is available (DiagnosticSource DLL is available).
-        /// Decorate all code that works with Activity with this method.
-        /// </summary>
-        /// <param name="action">Action to execute.</param>
-        /// <returns>True if Activity is available, false otherwise.</returns>
-        public static bool TryRun(Action action)
-        {
-            Debug.Assert(action != null, "Action must not be null");
-            if (!isInitialized)
-            {
-                isAvailable = Initialize();
-            }
-
-            if (isAvailable)
-            {
-                action.Invoke();
-            }
-
-            return isAvailable;
-        }
 
         internal static string GetOperationName(this Activity activity)
         {
@@ -45,31 +21,6 @@
             Debug.Assert(!string.IsNullOrEmpty(operationName), "OperationName must not be null or empty");
             Debug.Assert(activity != null, "Activity must not be null");
             activity.AddTag(OperationNameTag, operationName);
-        }
-
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private static bool Initialize()
-        {
-            try
-            {
-                Assembly.Load(new AssemblyName("System.Diagnostics.DiagnosticSource, Version=4.0.4.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51"));
-                return true;
-            }
-            catch (System.IO.FileNotFoundException)
-            {
-                // This is a workaround that allows ApplicationInsights Core SDK run without DiagnosticSource.dll
-                // so the ApplicationInsights.dll could be used alone to track telemetry, and will fall back to CallContext/AsyncLocal instead of Activity
-                return false;
-            }
-            catch (System.IO.FileLoadException)
-            {
-                // Dll version, public token or culture is different
-                return false;
-            }
-            finally
-            {
-                isInitialized = true;
-            }
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -61,7 +61,7 @@
                 msg ?? string.Empty,
                 this.nameProvider.Name);
         }
-        
+
         [Event(
             4,
             Keywords = Keywords.Diagnostics | Keywords.UserActionable,
@@ -97,7 +97,7 @@
             string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                6, 
+                6,
                 exception ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -123,7 +123,7 @@
         {
             this.WriteEvent(8, this.nameProvider.Name);
         }
-        
+
         [Event(
             9,
             Message = "No Telemetry Configuration provided. Using the default TelemetryConfiguration.Active.",
@@ -140,8 +140,8 @@
         public void PopulateRequiredStringWithValue(string parameterName, string telemetryType, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                10, 
-                parameterName ?? string.Empty, 
+                10,
+                parameterName ?? string.Empty,
                 telemetryType ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -181,7 +181,7 @@
         public void LogError(string msg, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                14, 
+                14,
                 msg ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -377,7 +377,7 @@
         {
             this.WriteEvent(
                 29,
-                maxBacklogSize,               
+                maxBacklogSize,
                 this.nameProvider.Name);
         }
 
@@ -576,7 +576,7 @@
 
         [Event(50, Message = "Connection String contains invalid delimiters and cannot be parsed.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringInvalidDelimiters(string appDomainName = "Incorrect") => this.WriteEvent(50, this.nameProvider.Name);
-        
+
         [Event(51, Message = "Connection String cannot be NULL.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringNull(string appDomainName = "Incorrect") => this.WriteEvent(51, this.nameProvider.Name);
 
@@ -639,6 +639,9 @@
 
         [Event(69, Message = "{0}", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringParseError(string message, string appDomainName = "Incorrect") => this.WriteEvent(69, message, this.nameProvider.Name);
+
+        [Event(70, Message = "Activity not available: {0}.", Level = EventLevel.Error)]
+        public void ActivityNotAvailable(string exception, string appDomainName = "Incorrect") => this.WriteEvent(70, exception ?? string.Empty, this.nameProvider.Name);
 
         [NonEvent]
         [SuppressMessage("Microsoft.Performance", "CA1822: MarkMembersAsStatic", Justification = "This method does access instance data in NetStandard 2.0 scenarios.")]

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -7,6 +7,7 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// Telemetry initializer that populates OperationContext for the telemetry item from Activity.
@@ -30,8 +31,8 @@
             var itemOperationContext = telemetryItem.Context.Operation;
             var telemetryProp = telemetryItem as ISupportProperties;            
 
-            bool isActivityAvailable = false;
-            isActivityAvailable = ActivityExtensions.TryRun(() =>
+            bool isActivityAvailable = true;
+            try
             {
                 var currentActivity = Activity.Current;
                 if (currentActivity != null)
@@ -96,7 +97,12 @@
                         }
                     }
                 }
-            });
+            }
+            catch (Exception exc)
+            {
+                CoreEventSource.Log.ActivityNotAvailable(exc.ToInvariantString());
+                isActivityAvailable = false;
+            }
 
             if (!isActivityAvailable)
             {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -56,14 +56,18 @@
         /// </summary>
         static TelemetryConfiguration()
         {
-            ActivityExtensions.TryRun(() =>
+            try
             {
                 if (!Activity.ForceDefaultIdFormat)
                 {
                     Activity.DefaultIdFormat = ActivityIdFormat.W3C;
                     Activity.ForceDefaultIdFormat = true;
                 }                
-            });
+            }
+            catch (Exception exc)
+            {
+                CoreEventSource.Log.ActivityNotAvailable(exc.ToInvariantString());
+            }
         }
 
         /// <summary>


### PR DESCRIPTION
Fix Issue #1820.

## Changes
Removed TryRun and Initialize from ActivityExtensions
Maintained the logic and changed the tryRun with a TryCatch. If an exception occurs, we change to false and everything will be the same. A log will be created.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
