### PR TITLE
refactor aspnetcore tests (part1)

### DIFF
--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests.cs
@@ -1439,11 +1439,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             }
         }
 
-        public static TelemetryConfiguration GetTelemetryConfiguration(this IServiceProvider serviceProvider)
-        {
-            return serviceProvider.GetRequiredService<IOptions<TelemetryConfiguration>>().Value;
-        }
-
         public static ServiceCollection CreateServicesAndAddApplicationinsightsTelemetry(string jsonPath, string channelEndPointAddress, Action<ApplicationInsightsServiceOptions> serviceOptions = null, bool addChannel = true)
         {
             var services = ApplicationInsightsExtensionsTests.GetServiceCollectionWithContextAccessor();
@@ -1483,22 +1478,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 services.Configure(serviceOptions);
             }
             return services;
-        }
-
-        private class MockLoggingFactory : ILoggerFactory
-        {
-            public void Dispose()
-            {
-            }
-
-            public ILogger CreateLogger(string categoryName)
-            {
-                return null;
-            }
-
-            public void AddProvider(ILoggerProvider provider)
-            {
-            }
         }
     }
 #pragma warning restore CS0618 // TelemetryConfiguration.Active is obsolete. We still test with this for backwards compatibility.

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/IServiceProviderExtensions.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/IServiceProviderExtensions.cs
@@ -1,0 +1,16 @@
+﻿namespace Microsoft.Extensions.DependencyInjection.Test
+{
+    using System;
+
+    using Microsoft.ApplicationInsights.Extensibility;
+
+    using Microsoft.Extensions.Options;
+
+    internal static class IServiceProviderExtensions
+    {
+        public static TelemetryConfiguration GetTelemetryConfiguration(this IServiceProvider serviceProvider)
+        {
+            return serviceProvider.GetRequiredService<IOptions<TelemetryConfiguration>>().Value;
+        }
+    }
+}

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/MockLoggingFactory.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/MockLoggingFactory.cs
@@ -1,0 +1,20 @@
+﻿namespace Microsoft.Extensions.DependencyInjection.Test
+{
+    using Logging;
+
+    internal class MockLoggingFactory : ILoggerFactory
+    {
+        public void Dispose()
+        {
+        }
+
+        public ILogger CreateLogger(string categoryName)
+        {
+            return null;
+        }
+
+        public void AddProvider(ILoggerProvider provider)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Splitting up my previous PR (#1846) to prevent conflicts with Raj

I need to work with the ApplicationInsightsExtensionsTests but this class is difficult to understand.
It's actually one file with 3 large tests and two helper classes.


## Changes
- move helper classes into separate file.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
