### PR TITLE
removing netstandard1.x branching

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/DataContracts/InnerExceptionCountExceededException.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/DataContracts/InnerExceptionCountExceededException.cs
@@ -2,16 +2,12 @@ namespace Microsoft.ApplicationInsights.DataContracts
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-#if !NETSTANDARD1_3
     using System.Runtime.Serialization;
-#endif
 
     /// <summary>
     /// This exception is used to notify the user that the set of inner exceptions has been trimmed because it exceeded our allowed send limit.
     /// </summary>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     [SuppressMessage("Microsoft.Design", "CA1064:ExceptionsShouldBePublic", Justification = "We expect that this exception will be caught within the internal scope and should never be exposed to an end user.")]
     internal class InnerExceptionCountExceededException : Exception
     {
@@ -37,7 +33,6 @@ namespace Microsoft.ApplicationInsights.DataContracts
         public InnerExceptionCountExceededException(string message, Exception innerException) : base(message, innerException)
         {
         }
-#if !NETSTANDARD1_3
 
         /// <summary>
         /// Initializes a new instance of the <see cref="InnerExceptionCountExceededException"/> class with serialized data.
@@ -49,6 +44,5 @@ namespace Microsoft.ApplicationInsights.DataContracts
         protected InnerExceptionCountExceededException(SerializationInfo info, StreamingContext context) : base(info, context)
         {
         }
-#endif
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/DictionarySerializationWriter.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/DictionarySerializationWriter.cs
@@ -98,11 +98,7 @@
             {
                 if (value.HasValue)
                 {
-#if NETSTANDARD1_3
-                    this.AccumulatedDictionary[key] = value.Value.ToString();
-#else
                     this.AccumulatedDictionary[key] = value.Value.ToString(CultureInfo.InvariantCulture);
-#endif
                 }
                 else
                 {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Endpoints/EndpointMetaAttribute.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Endpoints/EndpointMetaAttribute.cs
@@ -20,15 +20,9 @@
 
         public static EndpointMetaAttribute GetAttribute(EndpointName enumValue)
         {
-#if NETSTANDARD1_3
-            Type type = enumValue.GetType();
-            string name = Enum.GetName(type, enumValue);
-            return type.GetRuntimeField(name).GetCustomAttribute<EndpointMetaAttribute>();
-#else
             Type type = enumValue.GetType();
             string name = Enum.GetName(type, enumValue);
             return type.GetField(name).GetCustomAttribute<EndpointMetaAttribute>();
-#endif
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/Tags.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/Tags.cs
@@ -68,11 +68,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
         {
             if (tagValue.HasValue)
             {
-#if NETSTANDARD1_3
-                string value = tagValue.Value.ToString();
-#else
                 string value = tagValue.Value.ToString(CultureInfo.InvariantCulture);
-#endif
                 tags.Add(tagKey, value);
             }
         }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/FormattableStringTools.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/FormattableStringTools.cs
@@ -1,4 +1,4 @@
-﻿#if NET45 || NETSTANDARD1_1 
+﻿#if NET45
 
 // FormattableString & Co are available in NetFx 4.6+, but not in NetFx 4.5 or NetStandard 1.1
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -1,5 +1,4 @@
-﻿#if !NETSTANDARD1_3 // netstandard1.3 has it's own implementation
-namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
 {
     using System;
     using System.Collections;
@@ -143,81 +142,3 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
         }
     }
 }
-#else
-namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
-{
-    using System;
-    using System.Collections.Generic;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.External;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-
-    internal class PlatformImplementation : IPlatform
-    {
-        private IDebugOutput debugOutput = null;
-
-        public IDictionary<string, object> GetApplicationSettings()
-        {
-            return null;
-        }
-
-        public string ReadConfigurationXml()
-        {
-            return null;
-        }
-
-        public ExceptionDetails GetExceptionDetails(Exception exception, ExceptionDetails parentExceptionDetails)
-        {
-            return ExceptionConverter.ConvertToExceptionDetails(exception, parentExceptionDetails);
-        }
-
-        /// <summary>
-        /// Returns the platform specific Debugger writer to the VS output console.
-        /// </summary>
-        public IDebugOutput GetDebugOutput()
-        {
-            if (this.debugOutput == null)
-            {
-                this.debugOutput = new TelemetryDebugWriter();
-            }
-
-            return this.debugOutput;
-        }
-
-        /// <inheritdoc />
-        public bool TryGetEnvironmentVariable(string name, out string value)
-        {
-            value = string.Empty;
-
-            try
-            {
-                value = Environment.GetEnvironmentVariable(name);
-                return !string.IsNullOrEmpty(value);
-            }
-            catch (Exception e)
-            {
-                CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
-            }
-
-            return false;
-        }
-
-        /// <summary>
-        /// Returns the machine name.
-        /// </summary>
-        /// <returns>The machine name.</returns>
-        public string GetMachineName()
-        {
-            try
-            {
-                return Environment.GetEnvironmentVariable("COMPUTERNAME");
-            }
-            catch (Exception e)
-            {
-                CoreEventSource.Log.FailedToLoadEnvironmentVariables(e.ToString());
-            }
-
-            return string.Empty;
-        }
-    }
-}
-#endif

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/SdkVersionUtils.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/SdkVersionUtils.cs
@@ -15,17 +15,10 @@
         /// <returns>String representation of the version with prefix added.</returns>
         internal static string GetSdkVersion(string versionPrefix)
         {
-#if !NETSTANDARD1_3
             string versionStr = typeof(TelemetryClient).Assembly.GetCustomAttributes(false)
                     .OfType<AssemblyFileVersionAttribute>()
                     .First()
                     .Version;
-
-#else
-            string versionStr = typeof(TelemetryClient).GetTypeInfo().Assembly.GetCustomAttributes<AssemblyFileVersionAttribute>()
-                    .FirstOrDefault()
-                    ?.Version;
-#endif
 
             Version version;
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryDebugWriter.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryDebugWriter.cs
@@ -56,11 +56,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
         void IDebugOutput.WriteLine(string message)
         {
-#if NETSTANDARD1_3
-            Debug.WriteLine(message);
-#else
             Debugger.Log(0, "category", message + Environment.NewLine);
-#endif
         }
 
         bool IDebugOutput.IsLogging()
@@ -69,11 +65,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
             {
                 return false;
             }
-#if NETSTANDARD1_3
-            return true;
-#else
+
             return Debugger.IsLogging();
-#endif
         }
 
         bool IDebugOutput.IsAttached()

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/ApplicationNameProvider.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/ApplicationNameProvider.cs
@@ -22,11 +22,7 @@
             string name;
             try
             {
-#if !NETSTANDARD1_3
                 name = AppDomain.CurrentDomain.FriendlyName;
-#else
-                name = string.Empty;
-#endif
             }
             catch (Exception exp)
             {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/BaseDefaultHeartbeatPropertyProvider.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/BaseDefaultHeartbeatPropertyProvider.cs
@@ -91,7 +91,7 @@
                                 .Cast<AssemblyFileVersionAttribute>()
                                 .FirstOrDefault();
             return objectAssemblyFileVer != null ? objectAssemblyFileVer.Version : "undefined";
-#elif NETSTANDARD1_3 || NETSTANDARD2_0
+#elif NETSTANDARD2_0
             return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
 #else
 #error Unrecognized framework
@@ -109,8 +109,6 @@
             return "net45";
 #elif NET46
             return "net46";
-#elif NETSTANDARD1_3
-            return "netstandard1.3";
 #elif NETSTANDARD2_0
             return "netstandard2.0";
 #else
@@ -133,7 +131,7 @@
 
             osValue = Environment.OSVersion.Platform.ToString();
 
-#elif NETSTANDARD1_3 || NETSTANDARD2_0
+#elif NETSTANDARD2_0
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/Extensions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/Extensions.cs
@@ -22,9 +22,6 @@
                 return string.Empty;
             }
 
-#if NETSTANDARD1_3
-            return exception.ToString();
-#else
             CultureInfo originalUICulture = Thread.CurrentThread.CurrentUICulture;
             try
             {
@@ -35,7 +32,6 @@
             {
                 Thread.CurrentThread.CurrentUICulture = originalUICulture;
             }
-#endif
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileDiagnosticsModule/TraceSourceForEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileDiagnosticsModule/TraceSourceForEventSource.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.FileDiagnosticsModule
 {
-#if !NETSTANDARD1_3
     using System;
     using System.Collections.Generic;
     using System.Diagnostics;
@@ -202,5 +201,4 @@
             }
         }
     }
-#endif
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileDiagnosticsTelemetryModule.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileDiagnosticsTelemetryModule.cs
@@ -1,7 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
 {
-#if !NETSTANDARD1_3
-
     using System;
     using System.Diagnostics;
     using System.Diagnostics.Tracing;
@@ -244,5 +242,4 @@
             return result;
         }
     }
-#endif
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Utils.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Utils.cs
@@ -18,11 +18,8 @@
             {
                 return true;
             }
-#if !NETSTANDARD1_3
+
             return value.All(char.IsWhiteSpace);
-#else
-            return string.IsNullOrWhiteSpace(value);
-#endif
         }
 
         public static void CopyDictionary<TValue>(IDictionary<string, TValue> source, IDictionary<string, TValue> target)

--- a/BASE/src/ServerTelemetryChannel/Implementation/BackoffLogicManager.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/BackoffLogicManager.cs
@@ -15,10 +15,7 @@
         private const int DefaultBackoffEnabledReportingIntervalInMin = 30;
 
         private static readonly Random Random = new Random();
-
-#if !NETSTANDARD1_3
         private static readonly DataContractJsonSerializer Serializer = new DataContractJsonSerializer(typeof(BackendResponse));
-#endif  
 
         private readonly object lockConsecutiveErrors = new object();
         private readonly TimeSpan minIntervalToUpdateConsecutiveErrors;

--- a/BASE/src/ServerTelemetryChannel/Implementation/BackoffLogicManager.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/BackoffLogicManager.cs
@@ -1,14 +1,10 @@
 ﻿namespace Microsoft.ApplicationInsights.Channel.Implementation
 {
     using System;
-    using System.Runtime.Serialization;
-#if NETSTANDARD1_3
-    using Newtonsoft.Json;
-#else
     using System.IO;
+    using System.Runtime.Serialization;
     using System.Runtime.Serialization.Json;
     using System.Text;
-#endif
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
 
     internal class BackoffLogicManager
@@ -77,14 +73,10 @@
             {
                 if (!string.IsNullOrEmpty(responseContent))
                 {
-#if NETSTANDARD1_3
-                    backendResponse = JsonConvert.DeserializeObject<BackendResponse>(responseContent);
-#else
                     using (MemoryStream ms = new MemoryStream(Encoding.Unicode.GetBytes(responseContent)))
                     {
                         backendResponse = Serializer.ReadObject(ms) as BackendResponse;
-                    }
-#endif  
+                    }  
                 }
             }
             catch (ArgumentException exp)
@@ -102,18 +94,7 @@
                 TelemetryChannelEventSource.Log.BreezeResponseWasNotParsedWarning(exp.Message, responseContent);
                 backendResponse = null;
             }
-#if NETSTANDARD1_3
-            catch (JsonReaderException exp)
-            {
-                TelemetryChannelEventSource.Log.BreezeResponseWasNotParsedWarning(exp.Message, responseContent);
-                backendResponse = null;
-            }
-            catch (JsonSerializationException exp)
-            {
-                TelemetryChannelEventSource.Log.BreezeResponseWasNotParsedWarning(exp.Message, responseContent);
-                backendResponse = null;
-            }
-#endif
+
             return backendResponse;
         }
 

--- a/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
@@ -549,11 +549,7 @@
             string name;
             try
             {
-#if !NETSTANDARD1_3
                 name = AppDomain.CurrentDomain.FriendlyName;
-#else
-                name = string.Empty;
-#endif
             }
             catch (Exception exp)
             {

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionStorage.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionStorage.cs
@@ -182,11 +182,7 @@
 
         private static string GetUniqueFileName(string extension)
         {
-#if NETSTANDARD1_3
-            string fileName = Guid.NewGuid().ToString("N");
-#else
             string fileName = Guid.NewGuid().ToString("N", CultureInfo.InvariantCulture);
-#endif
             return Path.ChangeExtension(fileName, extension);
         }
 

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -193,11 +193,7 @@
             {
                 telemetryConfigValues.Add(new KeyValuePair<string, string>(
                     DeveloperModeForWebSites,
-#if !NETSTANDARD1_6
                     developerMode.Value.ToString(System.Globalization.CultureInfo.InvariantCulture)));
-#else
-                    developerMode.Value.ToString()));
-#endif
                 wasAnythingSet = true;
             }
 

--- a/WEB/Src/Common/AppMapCorrelationEventSource.cs
+++ b/WEB/Src/Common/AppMapCorrelationEventSource.cs
@@ -3,9 +3,6 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
-#if NETSTANDARD1_6
-    using System.Reflection;
-#endif
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>

--- a/WEB/Src/Common/ApplicationNameProvider.cs
+++ b/WEB/Src/Common/ApplicationNameProvider.cs
@@ -1,9 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Common
 {
     using System;
-#if NETSTANDARD1_6
-    using System.Reflection;
-#endif
 
     internal sealed class ApplicationNameProvider
     {
@@ -19,11 +16,7 @@
             string name;
             try
             {
-#if NETSTANDARD1_6
-                name = Assembly.GetEntryAssembly().FullName;
-#else
                 name = AppDomain.CurrentDomain.FriendlyName;
-#endif
             }
             catch (Exception exp)
             {

--- a/WEB/Src/Common/GuidExtensions.cs
+++ b/WEB/Src/Common/GuidExtensions.cs
@@ -13,11 +13,7 @@
         /// </remarks>
         public static string ToStringInvariant(this Guid guid, string format)
         {
-#if NETSTANDARD1_6
-            return guid.ToString(format);
-#else
             return guid.ToString(format, CultureInfo.InvariantCulture);
-#endif
         }
     }
 }

--- a/WEB/Src/Common/SdkVersionUtils.cs
+++ b/WEB/Src/Common/SdkVersionUtils.cs
@@ -4,9 +4,6 @@
     using System.Globalization;
     using System.Linq;
     using System.Reflection;
-#if NETSTANDARD1_6
-    using System.Collections.Generic;
-#endif
 
     internal class SdkVersionUtils
     {
@@ -16,11 +13,7 @@
             // For directly using TrackDependency(), version will be simply what is set by core
             Type sdkVersionUtilsType = typeof(SdkVersionUtils);
 
-#if NETSTANDARD1_6
-            IEnumerable<Attribute> assemblyCustomAttributes = sdkVersionUtilsType.GetTypeInfo().Assembly.GetCustomAttributes();
-#else
             object[] assemblyCustomAttributes = sdkVersionUtilsType.Assembly.GetCustomAttributes(false);
-#endif
             string versionStr = assemblyCustomAttributes
                     .OfType<AssemblyFileVersionAttribute>()
                     .First()

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AppMapCorrelationEventSource.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AppMapCorrelationEventSource.cs
@@ -2,9 +2,6 @@
 {
     using System;
     using System.Diagnostics.Tracing;
-#if NETSTANDARD1_6
-    using System.Reflection;
-#endif
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DependencyCollectorEventSource.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DependencyCollectorEventSource.cs
@@ -4,9 +4,6 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
     using System.Globalization;
-#if NETSTANDARD1_6
-    using System.Reflection;
-#endif
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/PerformanceCounterUtility.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/PerformanceCounterUtility.cs
@@ -10,7 +10,7 @@
     using System.Reflection;
     using System.Runtime.InteropServices;
     using System.Text.RegularExpressions;
-    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.StandardPerfCollector;    
+    using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.StandardPerfCollector;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.WebAppPerfCollector;
 #if NETSTANDARD2_0
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.XPlatform;
@@ -49,10 +49,7 @@
         private const string WebSiteIsolationEnvironmentVariable = "WEBSITE_ISOLATION";
         private const string WebSiteIsolationHyperV = "hyperv";
 
-#if !NETSTANDARD1_6
         private static readonly ConcurrentDictionary<string, Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>> cache = new ConcurrentDictionary<string, Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection>>();
-#endif
-
         private static readonly ConcurrentDictionary<string, string> PlaceholderCache =
             new ConcurrentDictionary<string, string>();
 
@@ -65,7 +62,6 @@
                 @"^\\(?<categoryName>[^(]+)(\((?<instanceName>[^)]+)\)){0,1}\\(?<counterName>[\s\S]+)$",
                 RegexOptions.Compiled);
 
-#if !NETSTANDARD1_6
         /// <summary>
         /// Formats a counter into a readable string.
         /// </summary>
@@ -73,7 +69,6 @@
         {
             return FormatPerformanceCounter(pc.CategoryName, pc.CounterName, pc.InstanceName);
         }
-#endif
 
         public static bool IsPerfCounterSupported()
         {
@@ -379,7 +374,6 @@
                 ClrProcessCounterName);
         }
 
-#if !NETSTANDARD1_6
         internal static IList<string> GetWin32ProcessInstances()
         {
             return GetInstances(Win32ProcessCategoryName);
@@ -389,8 +383,6 @@
         {
             return GetInstances(ClrProcessCategoryName);
         }
-
-#endif
 
         private static string ExpandInstanceName(
             string instanceName,
@@ -449,7 +441,6 @@
             return cachedResult;
         }
 
-#if !NETSTANDARD1_6
         private static string FindProcessInstance(int pid, IEnumerable<string> instances, string categoryName, string counterName)
         {
             Tuple<DateTime, PerformanceCounterCategory, InstanceDataCollectionCollection> cached;
@@ -519,6 +510,5 @@
 #endif
             }
         }
-#endif
-            }
+    }
 }

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/PerformanceCounterUtility.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/PerformanceCounterUtility.cs
@@ -77,36 +77,10 @@
 
         public static bool IsPerfCounterSupported()
         {
-#if NETSTANDARD1_6
-            // PerfCounter is limited to only when running in WebApp
-            return IsWebAppRunningInAzure();
-#else
             return true;
-#endif
         }
 
-#if NETSTANDARD1_6
-        public static IPerformanceCollector GetPerformanceCollector()
-        {
-            IPerformanceCollector collector;
-
-            // NetStandard1.6 has perf counter only on web apps.
-
-            if (PerformanceCounterUtility.IsWebAppRunningInAzure())
-            {
-                collector = (IPerformanceCollector)new WebAppPerformanceCollector();
-                PerformanceCollectorEventSource.Log.InitializedWithCollector(collector.GetType().Name);
-            }
-            else
-            {
-                // This will be the Stub collector which won't do anything.
-                collector = (IPerformanceCollector)new StandardPerformanceCollectorStub();
-                PerformanceCollectorEventSource.Log.InitializedWithCollector(collector.GetType().Name);
-            }
-
-            return collector;
-            }
-#elif NET45
+#if NET45
         public static IPerformanceCollector GetPerformanceCollector()
         {
             IPerformanceCollector collector;
@@ -230,7 +204,7 @@
         {
             if (IsWebAppRunningInAzure())
             {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
                 return AzureWebAppCoreSdkVersionPrefix;
 #else
                 return AzureWebAppSdkVersionPrefix;
@@ -363,7 +337,7 @@
 
         internal static string GetInstanceForCurrentW3SvcWorker()
         {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
             string name = new AssemblyName(Assembly.GetEntryAssembly().FullName).Name;
 #else
             string name = AppDomain.CurrentDomain.FriendlyName;
@@ -388,29 +362,21 @@
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "This method has different code for Net45/NetCore")]
         internal static string GetInstanceForWin32Process(IEnumerable<string> win32Instances)
         {
-#if NETSTANDARD1_6
-            return string.Empty;
-#else
             return FindProcessInstance(
                 Process.GetCurrentProcess().Id,
                 win32Instances,
                 Win32ProcessCategoryName,
                 Win32ProcessCounterName);
-#endif
         }
 
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "This method has different code for Net45/NetCore")]
         internal static string GetInstanceForClrProcess(IEnumerable<string> clrInstances)
         {
-#if NETSTANDARD1_6
-            return string.Empty;
-#else
             return FindProcessInstance(
                 Process.GetCurrentProcess().Id,
                 clrInstances,
                 ClrProcessCategoryName,
                 ClrProcessCounterName);
-#endif
         }
 
 #if !NETSTANDARD1_6

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -169,7 +169,7 @@
             string name;
             try
             {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
                 name = new AssemblyName(Assembly.GetEntryAssembly().FullName).Name;
 #else
                 name = AppDomain.CurrentDomain.FriendlyName;

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/WebAppPerformanceCollector/CacheHelper.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/WebAppPerformanceCollector/CacheHelper.cs
@@ -3,7 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
     using Microsoft.Extensions.Caching.Memory;
 #else
     using System.Runtime.Caching;
@@ -21,7 +21,7 @@
         /// </summary>
         private static readonly CacheHelper CacheHelperInstance = new CacheHelper();
 
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
         IMemoryCache cache = new MemoryCache(new MemoryCacheOptions());
 #endif
 
@@ -114,7 +114,7 @@
         /// <param name="absoluteExpiration">DateTimeOffset until item expires from cache.</param>
         public void SaveToCache(string cacheKey, object toCache,  DateTimeOffset absoluteExpiration)
         {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
             cache.Set(cacheKey, toCache, absoluteExpiration);
 #else
             MemoryCache.Default.Add(cacheKey, toCache, absoluteExpiration);                        
@@ -128,7 +128,7 @@
         /// <returns> The requested item, as object type T.</returns>
         public object GetFromCache(string cacheKey) 
         {
-#if NETSTANDARD1_6 || NETSTANDARD2_0          
+#if NETSTANDARD2_0          
             return cache.Get(cacheKey);            
 #else
             return MemoryCache.Default[cacheKey];
@@ -142,7 +142,7 @@
         /// <returns>Boolean value for whether or not a key is in the cache.</returns>
         public bool IsInCache(string cacheKey)
         {
-#if NETSTANDARD1_6 || NETSTANDARD2_0            
+#if NETSTANDARD2_0            
             object output;
             return cache.TryGetValue(cacheKey, out output);
 #else
@@ -160,7 +160,7 @@
         {
             if (disposing)
             {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
                 cache.Dispose();
 #endif
             }

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/PerformanceCollectorModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/PerformanceCollectorModule.cs
@@ -213,10 +213,6 @@
 
         private static bool IsRunningUnderIisExpress()
         {
-#if NETSTANDARD1_6
-            // For netstandard1.6 target, only time perfcounter is active is if running as Azure WebApp
-            return false;
-#else
             var iisExpressProcessName = "iisexpress";
 
             try
@@ -231,7 +227,6 @@
 
                 return false;
             }
-#endif
         }
 
         /// <summary>

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -26,7 +26,7 @@
     /// </summary>
     public sealed class QuickPulseTelemetryModule : ITelemetryModule, IDisposable
     {
-#if NETSTANDARD1_6 || NETSTANDARD2_0
+#if NETSTANDARD2_0
         internal static IQuickPulseModuleScheduler ModuleScheduler = QuickPulseTaskModuleScheduler.Instance;
 #else
         internal static IQuickPulseModuleScheduler ModuleScheduler = QuickPulseThreadModuleScheduler.Instance;

--- a/WEB/Src/Web/Web/Implementation/AppMapCorrelationEventSource.cs
+++ b/WEB/Src/Web/Web/Implementation/AppMapCorrelationEventSource.cs
@@ -2,9 +2,6 @@
 {
     using System;
     using System.Diagnostics.Tracing;
-#if NETSTANDARD1_6
-    using System.Reflection;
-#endif
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>

--- a/WEB/Src/WindowsServer/WindowsServer/BuildInfoConfigComponentVersionTelemetryInitializer.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/BuildInfoConfigComponentVersionTelemetryInitializer.cs
@@ -53,11 +53,7 @@
             {
                 string path = string.Empty;
 
-#if !NETSTANDARD1_6
                 path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, BuildInfoConfigComponentVersionTelemetryInitializer.BuildInfoConfigFilename);
-#else
-                path = Path.Combine(AppContext.BaseDirectory, BuildInfoConfigComponentVersionTelemetryInitializer.BuildInfoConfigFilename);
-#endif
 
                 if (File.Exists(path))
                 {

--- a/WEB/Src/WindowsServer/WindowsServer/Implementation/MetricManager.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/Implementation/MetricManager.cs
@@ -302,7 +302,6 @@ namespace Microsoft.ApplicationInsights.WindowsServer
             {
                 foreach (KeyValuePair<string, string> property in metric.Dimensions)
                 {
-#if !NETSTANDARD1_6
                     if (string.Compare(property.Key, FirstChanceExceptionStatisticsTelemetryModule.OperationNameTag, StringComparison.Ordinal) == 0)
                     {
                         if (string.IsNullOrEmpty(property.Value) == false)
@@ -311,7 +310,6 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                         }
                     }
                     else
-#endif
                     {
                         telemetry.Properties.Add(property);
                     }


### PR DESCRIPTION
Fix Issue #1767

## Changes
- removing branching `#if netstandard1_x`
- removing inversed branching `#if !netstandard1_x`

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
