### PR TITLE
Removing branching for netcoreapp 1x

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
@@ -84,7 +84,7 @@
             Assert.AreEqual(0, stackFrame.line);
         }
 
-#if (!NETCOREAPP1_1 && !NETCOREAPP2_0)
+#if !NETCOREAPP2_0
 
         [TestMethod]
         public void CheckThatFileNameAndLineAreCorrectIfAvailable()
@@ -112,7 +112,7 @@
         }
 #endif
 
-#if !NETCOREAPP1_1 || NETCOREAPP2_0
+#if NETCOREAPP2_0
 
         [TestMethod]
         public void CheckThatAssemblyNameHasCorrectValue()

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/PlatformTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/PlatformTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
-#if (!NETCOREAPP1_1 && !NETCOREAPP2_0)
+#if !NETCOREAPP2_0
     using System;
     using System.IO;
     using System.Reflection;

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/ExtensionsTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/ExtensionsTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
 {
-#if (!NETCOREAPP1_1 && !NETCOREAPP2_0)
+#if !NETCOREAPP2_0
     using System;
     using System.Globalization;
     using System.Threading;

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/DiagnosticsTelemetryModuleTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/DiagnosticsTelemetryModuleTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Tracing.SelfDiagnostics
 {
-#if !NETCOREAPP1_1
     using System;
     using System.Diagnostics.Tracing;
     using System.IO;
@@ -199,5 +198,4 @@
             }
         }
     }
-#endif
 }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/TraceSourceForEventSourceTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/TraceSourceForEventSourceTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Tracing.SelfDiagnostics
 {
-#if !NETCOREAPP1_1
     using System.Diagnostics;
     using System.Diagnostics.Tracing;
 
@@ -86,5 +85,4 @@
             }
         }
     }
-#endif
 }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/OperationTelemetryExtensionsTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/OperationTelemetryExtensionsTests.cs
@@ -64,7 +64,6 @@
             Assert.AreEqual(telemetry.Duration, TimeSpan.Zero);
         }
 
-#if !NETCOREAPP1_1
         /// <summary>
         /// Tests the scenario if Start assigns current *precise* time to start time.
         /// </summary>
@@ -93,7 +92,6 @@
                 Assert.IsTrue(ComputeSomethingHeavy() > 0);
             }
         }
-#endif
 
         /// <summary>
         /// Tests the scenario if Stop computes the duration of the telemetry when timestamps are supplied to Start and Stop.

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
@@ -108,7 +108,6 @@
             Assert.IsTrue(telemetry.Timestamp != default(DateTimeOffset));
         }
 
-#if !NETCOREAPP1_1
         /// <summary>
         /// Tests the scenario if Initialize assigns current precise time to start time.
         /// </summary>
@@ -137,7 +136,6 @@
                 Assert.IsTrue(ComputeSomethingHeavy() > 0);
             }
         }
-#endif
 
         [TestMethod]
         public void InitializeSetsRoleInstance()

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/AdaptiveSamplingTelemetryProcessorTest.cs
@@ -65,9 +65,6 @@
             Assert.AreEqual(itemsProduced, sentTelemetry.Count);
         }
 
-#if !NETCOREAPP1_1 
-// Sampling tests are not stable on linux  Azure pipelines agent on .NET Core 1.1. 
-// considering .NET Core 1.1 is no longer supported, let's not run sampling tests there at all
         [TestMethod]
         public void ProactivelySampledInTelemetryCapturedWhenProactiveSamplingRateIsLowerThanTarget()
         {
@@ -364,7 +361,6 @@
             Assert.IsTrue(sentTelemetry.Count > targetItemCount - tolerance);
             Assert.IsTrue(sentTelemetry.Count < targetItemCount + tolerance);
         }
-#endif
 
         private class AdaptiveTesterMessageSink : ITelemetryProcessor
         {
@@ -514,17 +510,10 @@
         {
             // Regular Dispose() does not wait for all callbacks to complete
             // so TelemetryConfiguration could be disposed while callback still runs
-
-#if (NETCOREAPP1_1)
-            timer.Change(Timeout.InfiniteTimeSpan, Timeout.InfiniteTimeSpan);
-            timer.Dispose();
-            Thread.Sleep(1000);
-#else
             AutoResetEvent allDone = new AutoResetEvent(false);
             timer.Dispose(allDone);
             // this will wait for all callbacks to complete
             allDone.WaitOne();
-#endif
         }
     }
 }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/FileSystemTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/FileSystemTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
-#if !NETCOREAPP1_1
     using System;
     using System.IO;
     using System.Linq;
@@ -74,5 +73,4 @@
             return platformFile.Open(FileMode.Open);
         }
     }
-#endif
 }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/PlatformFileTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/PlatformFileTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
-#if !NETCOREAPP1_1
     using System;
     using System.IO;
     using System.Security.AccessControl;
@@ -280,5 +279,4 @@
             }
         }
     }
-#endif
 }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/PlatformFolderTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/PlatformFolderTest.cs
@@ -1,6 +1,5 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
-#if !NETCOREAPP1_1
     using System;
     using System.Collections.Generic;
     using System.IO;
@@ -268,5 +267,4 @@
             }
         }
     }
-#endif
 }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionStorageTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionStorageTest.cs
@@ -61,7 +61,7 @@
             // [TestMethod]
             public void IsThreadSafe()
             {
-#if (!NETCOREAPP1_1 && !NETCOREAPP2_1)
+#if !NETCOREAPP2_1
                 const int NumberOfThreads = 16;
                 const int NumberOfFilesPerThread = 64;
                 var storage = new TransmissionStorage();

--- a/BASE/Test/TestFramework/Shared/EventSourceTest.cs
+++ b/BASE/Test/TestFramework/Shared/EventSourceTest.cs
@@ -93,11 +93,7 @@ namespace Microsoft.ApplicationInsights.TestFramework
 
         private static void VerifyEventApplicationName(MethodInfo eventMethod, EventWrittenEventArgs actualEvent)
         {
-#if !NETCOREAPP1_1
             string expectedApplicationName = AppDomain.CurrentDomain.FriendlyName;
-#else
-            string expectedApplicationName = "";
-#endif
             string actualApplicationName = actualEvent.Payload.Last().ToString();
             AssertEqual(expectedApplicationName, actualApplicationName, "Application Name");
         }

--- a/WEB/Src/PerformanceCollector/Perf.Tests/PerformanceCollectorModuleTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/PerformanceCollectorModuleTests.cs
@@ -465,7 +465,7 @@
             try
             {
                 module.Initialize(new TelemetryConfiguration());
-#if !NETCOREAPP1_0
+
                 Assert.IsTrue(ContainsPerfCounter(module.DefaultCounters, @"\Process(??APP_WIN32_PROC??)\% Processor Time"));
                 Assert.IsTrue(ContainsPerfCounter(module.DefaultCounters, @"\Process(??APP_WIN32_PROC??)\% Processor Time Normalized"));
                 Assert.IsTrue(ContainsPerfCounter(module.DefaultCounters, @"\Process(??APP_WIN32_PROC??)\Private Bytes"));
@@ -486,9 +486,6 @@
 #else
                 Assert.AreEqual(6, module.DefaultCounters.Count);
 #endif
-
-#endif
-
             }
             finally
             {

--- a/WEB/Src/PerformanceCollector/Perf.Tests/PerformanceCounterUtilityTestsCommon.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/PerformanceCounterUtilityTestsCommon.cs
@@ -18,9 +18,7 @@
             try
             {
                 var actual = PerformanceCounterUtility.GetPerformanceCollector();
-#if NETCOREAPP1_0
-                Assert.AreEqual("StandardPerformanceCollectorStub", actual.GetType().Name);
-#elif NETCOREAPP2_0
+#if NETCOREAPP2_0
             Assert.AreEqual("StandardPerformanceCollector", actual.GetType().Name);
 #else // NET45
             Assert.AreEqual("StandardPerformanceCollector", actual.GetType().Name);

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1,5 +1,4 @@
-﻿#if !NETCOREAPP1_0
-namespace Microsoft.ApplicationInsights.Tests
+﻿namespace Microsoft.ApplicationInsights.Tests
 {
     using System;
     using System.Collections.Concurrent;
@@ -2126,4 +2125,3 @@ namespace Microsoft.ApplicationInsights.Tests
         }
     }
 }
-#endif

--- a/WEB/Src/TestFramework/Shared/TestFramework.Shared.projitems
+++ b/WEB/Src/TestFramework/Shared/TestFramework.Shared.projitems
@@ -21,8 +21,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)TaskExceptionObserver.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TelemetryConfigurationFactoryHelper.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)TestEventListener.cs" />
-  </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp1.0' ">
     <Compile Include="$(MSBuildThisFileDirectory)EventSourceTest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)StubTransmission.cs" />
   </ItemGroup>

--- a/WEB/Test/E2ETests/TestApps/NetCore30/E2ETestAppCore30/SqlCommandHelper.cs
+++ b/WEB/Test/E2ETests/TestApps/NetCore30/E2ETestAppCore30/SqlCommandHelper.cs
@@ -42,7 +42,7 @@
             await ExecuteReaderAsyncInternal(connectionString, commandText, commandType);
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         public static void BeginExecuteReader(string connectionString, string commandText, int numberOfAsyncArgs)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -130,7 +130,7 @@
             await ExecuteNonQueryAsyncInternal(connectionString, commandText);
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         public static void BeginExecuteNonQuery(string connectionString, string commandText, int numberOfArgs)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -190,7 +190,7 @@
             await ExecuteXmlReaderAsyncInternal(connectionString, commandText);
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         public static void BeginExecuteXmlReader(string connectionString, string commandText)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -306,7 +306,7 @@
             }
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         private sealed class AsyncExecuteReaderWrapper : IDisposable
         {
             private readonly SqlCommand command;

--- a/WEB/Test/E2ETests/TestApps/helpersfortestapp/FW40Shared/SqlCommandHelper.cs
+++ b/WEB/Test/E2ETests/TestApps/helpersfortestapp/FW40Shared/SqlCommandHelper.cs
@@ -42,7 +42,7 @@
             await ExecuteReaderAsyncInternal(connectionString, commandText, commandType);
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         public static void BeginExecuteReader(string connectionString, string commandText, int numberOfAsyncArgs)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -130,7 +130,7 @@
             await ExecuteNonQueryAsyncInternal(connectionString, commandText);
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         public static void BeginExecuteNonQuery(string connectionString, string commandText, int numberOfArgs)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -190,7 +190,7 @@
             await ExecuteXmlReaderAsyncInternal(connectionString, commandText);
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         public static void BeginExecuteXmlReader(string connectionString, string commandText)
         {
             ManualResetEvent mre = new ManualResetEvent(false);
@@ -306,7 +306,7 @@
             }
         }
 
-#if !NETCOREAPP3_0 && !NETCOREAPP2_0 && !NETCOREAPP1_0
+#if !NETCOREAPP3_0 && !NETCOREAPP2_0
         private sealed class AsyncExecuteReaderWrapper : IDisposable
         {
             private readonly SqlCommand command;


### PR DESCRIPTION
Fix Issue #1767

## Changes
- removing branching `#if netcoreapp1_x`
- removing inversed branching  `#if !netcoreapp1_x`

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
