### PR TITLE
Configure yml builds to fail whenever tests fail

### DIFF
--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -50,6 +50,7 @@ steps:
   inputs:
     testRunner: "VSTest"
     testResultsFiles: "**/*.trx"
+    failTaskOnFailedTests: true
 
 #- task: DotNetCoreCLI@1
 #  inputs:

--- a/NETCORE/.vsts/linux-build.yml
+++ b/NETCORE/.vsts/linux-build.yml
@@ -94,6 +94,7 @@ steps:
   inputs:
     testRunner: "VSTest"
     testResultsFiles: "**/*.trx"
+    failTaskOnFailedTests: true
 
 #- task: DotNetCoreCLI@1
 #  displayName: Package Nuget


### PR DESCRIPTION
yaml builds have to be manually configured to fail the build when tests fails.


I was looking at the documentation for the test task
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/build/dotnet-core-cli?view=azure-devops

But the correct fix is on the publish results task
https://docs.microsoft.com/en-us/azure/devops/pipelines/tasks/test/publish-test-results?view=azure-devops&tabs=yaml

This is unfortunately not on by default. :(