### PR TITLE
Fix test issues in Linux environment.

### DIFF
--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
@@ -695,7 +695,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -748,7 +748,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -803,7 +803,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -852,7 +852,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -906,7 +906,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -960,7 +960,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -1014,7 +1014,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -1089,7 +1089,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-req-dep-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-req-dep-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -1292,7 +1292,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-req-dep-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-req-dep-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -1395,7 +1395,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -1611,7 +1611,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -1664,7 +1664,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/ExtensionsTest.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/ExtensionsTest.cs
@@ -490,7 +490,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -542,7 +542,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), "content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -594,7 +594,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -646,7 +646,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -698,7 +698,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -750,7 +750,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-req-dep-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-req-dep-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -800,7 +800,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {
@@ -841,7 +841,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         {
             // ARRANGE
             Action<ApplicationInsightsServiceOptions> serviceOptions = null;
-            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString() + ".json");
+            var filePath = Path.Combine("content", "config-all-settings-" + isEnable.ToString().ToLower() + ".json");
 
             if (configType == "Code")
             {


### PR DESCRIPTION
Files in Linux machine are case sensitive. All file names in server are in lower case. File name generated from the code had Pascal casing and that caused an issue (True was generated in code instead of true).  Converting the generated sting to lower to fix an issue. 