### PR TITLE
refactor Azure Heartbeat Modules

### DIFF
--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
@@ -982,12 +982,8 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             // Get telemetry client to trigger TelemetryConfig setup.
             var tc = serviceProvider.GetService<TelemetryClient>();
 
-            Type appServHBModuleType = typeof(AppServicesHeartbeatTelemetryModule);
-            AppServicesHeartbeatTelemetryModule appServHBModule = (AppServicesHeartbeatTelemetryModule)modules.FirstOrDefault(m => m.GetType() == appServHBModuleType);
-            // Get the AppServicesHeartbeatTelemetryModule private field value for isInitialized.             
-            FieldInfo isInitializedField = appServHBModuleType.GetField("isInitialized", BindingFlags.NonPublic | BindingFlags.Instance);
-            // AppServicesHeartbeatTelemetryModule.isInitialized is set to true when EnableAppServicesHeartbeatTelemetryModule is enabled, else it is set to false.
-            Assert.Equal(isEnable, (bool)isInitializedField.GetValue(appServHBModule));
+            AppServicesHeartbeatTelemetryModule appServHBModule = modules.OfType<AppServicesHeartbeatTelemetryModule>().Single();
+            Assert.Equal(isEnable, appServHBModule.IsInitialized);
         }
 
         /// <summary>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
@@ -1032,12 +1032,8 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             // Get telemetry client to trigger TelemetryConfig setup.
             var tc = serviceProvider.GetService<TelemetryClient>();
 
-            Type azureInstanceMetadataModuleType = typeof(AzureInstanceMetadataTelemetryModule);
-            AzureInstanceMetadataTelemetryModule azureInstanceMetadataModule = (AzureInstanceMetadataTelemetryModule)modules.FirstOrDefault(m => m.GetType() == azureInstanceMetadataModuleType);
-            // Get the AzureInstanceMetadataTelemetryModule private field value for isInitialized.
-            FieldInfo isInitializedField = azureInstanceMetadataModuleType.GetField("isInitialized", BindingFlags.NonPublic | BindingFlags.Instance);
-            // AzureInstanceMetadataTelemetryModule.isInitialized is set to true when EnableAzureInstanceMetadataTelemetryModule is enabled, else it is set to false.
-            Assert.Equal(isEnable, (bool)isInitializedField.GetValue(azureInstanceMetadataModule));
+            AzureInstanceMetadataTelemetryModule azureInstanceMetadataModule = modules.OfType<AzureInstanceMetadataTelemetryModule>().Single();
+            Assert.Equal(isEnable, azureInstanceMetadataModule.IsInitialized);
         }
 
         [Fact]

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/HostingDiagnosticListenerTest.cs
@@ -24,6 +24,8 @@
     using Xunit.Abstractions;
 
     using AspNetCoreMajorVersion = Microsoft.ApplicationInsights.AspNetCore.Tests.AspNetCoreMajorVersion;
+    using RequestResponseHeaders = Microsoft.ApplicationInsights.AspNetCore.DiagnosticListeners.RequestResponseHeaders;
+
 
     public class HostingDiagnosticListenerTest : IDisposable
     {

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/ExtensionsTest.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/ExtensionsTest.cs
@@ -720,12 +720,8 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
             // Get telemetry client to trigger TelemetryConfig setup.
             var tc = serviceProvider.GetService<TelemetryClient>();
 
-            Type azureInstanceMetadataModuleType = typeof(AzureInstanceMetadataTelemetryModule);
-            AzureInstanceMetadataTelemetryModule azureInstanceMetadataModule = (AzureInstanceMetadataTelemetryModule)modules.FirstOrDefault(m => m.GetType() == azureInstanceMetadataModuleType);
-            // Get the AzureInstanceMetadataTelemetryModule private field value for isInitialized.
-            FieldInfo isInitializedField = azureInstanceMetadataModuleType.GetField("isInitialized", BindingFlags.NonPublic | BindingFlags.Instance);
-            // AzureInstanceMetadataTelemetryModule.isInitialized is set to true when EnableAzureInstanceMetadataTelemetryModule is enabled, else it is set to false.
-            Assert.Equal(isEnable, (bool)isInitializedField.GetValue(azureInstanceMetadataModule));
+            AzureInstanceMetadataTelemetryModule azureInstanceMetadataModule = modules.OfType<AzureInstanceMetadataTelemetryModule>().Single();
+            Assert.Equal(isEnable, azureInstanceMetadataModule.IsInitialized);
         }
 
         /// <summary>

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
@@ -1,5 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
+  <Import Project="$(PropsRoot)\_Signing.props" />
+
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>

--- a/WEB/Src/WindowsServer/WindowsServer/AppServicesHeartbeatTelemetryModule.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/AppServicesHeartbeatTelemetryModule.cs
@@ -28,9 +28,6 @@
 
         private IHeartbeatPropertyManager heartbeatManager;
 
-        // Used to determine if we call Add or Set heartbeat properties in the case of updates.
-        private bool isInitialized = false;
-        
         /// <summary>
         /// Initializes a new instance of the<see cref="AppServicesHeartbeatTelemetryModule" /> class.
         /// </summary>
@@ -47,6 +44,10 @@
         {
             this.HeartbeatPropertyManager = hbeatPropManager;
         }
+
+        /// <summary>Gets a value indicating whether this module has been initialized.</summary>
+        /// <remarks>Used to determine if we call Add or Set heartbeat properties in the case of updates.</remarks>
+        internal bool IsInitialized { get; private set; } = false;
 
         /// <summary>
         /// Gets or sets an instance of IHeartbeatPropertyManager. 
@@ -93,7 +94,7 @@
                 var hbeatManager = this.HeartbeatPropertyManager;
                 if (hbeatManager != null)
                 {
-                    this.isInitialized = this.AddAppServiceEnvironmentVariablesToHeartbeat(hbeatManager, isUpdateOperation: this.isInitialized);
+                    this.IsInitialized = this.AddAppServiceEnvironmentVariablesToHeartbeat(hbeatManager, isUpdateOperation: this.IsInitialized);
                 }
             }
             catch (Exception appSrvEnvVarHbeatFailure)

--- a/WEB/Src/WindowsServer/WindowsServer/AppServicesHeartbeatTelemetryModule.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/AppServicesHeartbeatTelemetryModule.cs
@@ -26,8 +26,7 @@
             new KeyValuePair<string, string>("appSrv_ResourceGroup", "WEBSITE_RESOURCE_GROUP"),
         };
 
-        // Cache the heartbeat property manager across updates. Note that tests can also override the heartbeat manager.
-        internal IHeartbeatPropertyManager HeartbeatManager;
+        private IHeartbeatPropertyManager heartbeatManager;
 
         // Used to determine if we call Add or Set heartbeat properties in the case of updates.
         private bool isInitialized = false;
@@ -46,7 +45,29 @@
         /// <param name="hbeatPropManager">The heartbeat property manager to use when setting/updating env var values.</param>
         internal AppServicesHeartbeatTelemetryModule(IHeartbeatPropertyManager hbeatPropManager)
         {
-            this.HeartbeatManager = hbeatPropManager;
+            this.HeartbeatPropertyManager = hbeatPropManager;
+        }
+
+        /// <summary>
+        /// Gets or sets an instance of IHeartbeatPropertyManager. 
+        /// </summary>
+        /// <remarks>
+        /// This is expected to be an instance of <see cref="DiagnosticsTelemetryModule"/>.
+        /// Note that tests can also override the heartbeat manager.
+        /// </remarks>
+        internal IHeartbeatPropertyManager HeartbeatPropertyManager
+        {
+            get
+            {
+                if (this.heartbeatManager == null)
+                {
+                    this.heartbeatManager = HeartbeatPropertyManagerProvider.GetHeartbeatPropertyManager();
+                }
+
+                return this.heartbeatManager;
+            }
+
+            set => this.heartbeatManager = value;
         }
 
         /// <summary>
@@ -69,7 +90,7 @@
         {
             try
             {
-                var hbeatManager = this.GetHeartbeatPropertyManager();
+                var hbeatManager = this.HeartbeatPropertyManager;
                 if (hbeatManager != null)
                 {
                     this.isInitialized = this.AddAppServiceEnvironmentVariablesToHeartbeat(hbeatManager, isUpdateOperation: this.isInitialized);
@@ -125,36 +146,6 @@
             }
 
             return hasBeenUpdated;
-        }
-
-        private IHeartbeatPropertyManager GetHeartbeatPropertyManager()
-        {
-            if (this.HeartbeatManager == null)
-            {
-                var telemetryModules = TelemetryModules.Instance;
-
-                try
-                {
-                    foreach (var module in telemetryModules.Modules)
-                    {
-                        if (module is IHeartbeatPropertyManager hman)
-                        {
-                            this.HeartbeatManager = hman;
-                        }
-                    }
-                }
-                catch (Exception hearbeatManagerAccessException)
-                {
-                    WindowsServerEventSource.Log.AppServiceHeartbeatManagerAccessFailure(hearbeatManagerAccessException.ToInvariantString());
-                }
-
-                if (this.HeartbeatManager == null)
-                {
-                    WindowsServerEventSource.Log.AppServiceHeartbeatManagerNotAvailable();
-                }
-            }
-
-            return this.HeartbeatManager;
         }
     }
 }

--- a/WEB/Src/WindowsServer/WindowsServer/AssemblyInfo.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/AssemblyInfo.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AI.WindowsServer.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.AspNetCore.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.WorkerService.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
 
 internal static class AssemblyInfo
 {

--- a/WEB/Src/WindowsServer/WindowsServer/AssemblyInfo.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/AssemblyInfo.cs
@@ -2,6 +2,7 @@
 using System.Runtime.CompilerServices;
 
 [assembly: InternalsVisibleTo("Microsoft.AI.WindowsServer.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
+[assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.AspNetCore.Tests, PublicKey=" + AssemblyInfo.PublicKey)]
 
 internal static class AssemblyInfo
 {

--- a/WEB/Src/WindowsServer/WindowsServer/AzureInstanceMetadataTelemetryModule.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/AzureInstanceMetadataTelemetryModule.cs
@@ -12,9 +12,11 @@
     /// </summary>
     public sealed class AzureInstanceMetadataTelemetryModule : ITelemetryModule
     {
-        private bool isInitialized = false;
         private object lockObject = new object();
         private IHeartbeatPropertyManager heartbeatManager;
+
+        /// <summary>Gets a value indicating whether this module has been initialized.</summary>
+        internal bool IsInitialized { get; private set; } = false;
 
         /// <summary>
         /// Gets or sets an instance of IHeartbeatPropertyManager. 
@@ -48,11 +50,11 @@
         public void Initialize(TelemetryConfiguration unused)
         {
             // Core SDK creates 1 instance of a module but calls Initialize multiple times
-            if (!this.isInitialized)
+            if (!this.IsInitialized)
             {
                 lock (this.lockObject)
                 {
-                    if (!this.isInitialized)
+                    if (!this.IsInitialized)
                     {
                         var hbeatManager = this.HeartbeatPropertyManager;
                         if (hbeatManager != null)
@@ -73,7 +75,7 @@
                             }
                         }
 
-                        this.isInitialized = true;
+                        this.IsInitialized = true;
                     }
                 }
             }

--- a/WEB/Src/WindowsServer/WindowsServer/Implementation/HeartbeatPropertyManagerProvider.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/Implementation/HeartbeatPropertyManagerProvider.cs
@@ -1,0 +1,36 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.Implementation
+{
+    using System;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
+    internal static class HeartbeatPropertyManagerProvider
+    {
+        public static IHeartbeatPropertyManager GetHeartbeatPropertyManager()
+        {
+            var telemetryModules = TelemetryModules.Instance;
+            if (telemetryModules != null)
+            {
+                try
+                {
+                    foreach (var module in telemetryModules.Modules)
+                    {
+                        if (module is IHeartbeatPropertyManager hman)
+                        {
+                            return hman;
+                        }
+                    }
+                }
+                catch (Exception hearbeatManagerAccessException)
+                {
+                    WindowsServerEventSource.Log.AppServiceHeartbeatManagerAccessFailure(hearbeatManagerAccessException.ToInvariantString());
+                }
+            }
+
+            // Module was not found. Log and return null.
+            WindowsServerEventSource.Log.AppServiceHeartbeatManagerNotAvailable();
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This is to prep some other changes I'm working on.

## Changes
- Refactor the two Heartbeat Modules to get the collection of TelemetryModules consistently.
- change private field IsInitialized to a read-only Property to remove reflection from tests.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
