### PR TITLE
[SDL] update analyzers

### DIFF
--- a/.props/Product.props
+++ b/.props/Product.props
@@ -13,13 +13,10 @@
 
   <ItemGroup Condition=" $(OS) == 'Windows_NT' And $(Configuration) == 'Release'">
     <!--Analyzers-->
-    <PackageReference Include="Desktop.Analyzers" Version="1.1.0">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.8">

--- a/.props/Product.props
+++ b/.props/Product.props
@@ -19,7 +19,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="2.9.8">
+    <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.0.0">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationHolder.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/OperationHolder.cs
@@ -16,6 +16,8 @@
         /// </summary>
         public OperationContextForCallContext ParentContext;
 
+        private static readonly object LockObj = new object();
+
         private readonly TelemetryClient telemetryClient;
 
         private readonly object originalActivity = null;
@@ -65,7 +67,7 @@
             {
                 // We need to compare the operation id and name of telemetry with operation id and name of current call context before tracking it 
                 // to make sure that the customer is tracking the right telemetry.
-                lock (this)
+                lock (LockObj)
                 {
                     if (!this.isDisposed)
                     {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -96,7 +96,7 @@
                     }
                 }
 
-                this.SelectInstrumentationKey(configuration);
+                SelectInstrumentationKey(configuration);
 
                 InitializeComponents(configuration, modules);
             }
@@ -469,7 +469,7 @@
             return attributeDefinitions.Concat(elementDefinitions);
         }
 
-        private void SelectInstrumentationKey(TelemetryConfiguration configuration)
+        private static void SelectInstrumentationKey(TelemetryConfiguration configuration)
         {
             if (PlatformSingleton.Current.TryGetEnvironmentVariable(ConnectionStringEnvironmentVariable, out string connectionStringEnVar))
             {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -635,6 +635,7 @@
         public void IngestionResponseTime(int responseCode, float responseDurationInMs, string appDomainName = "Incorrect") => this.WriteEvent(67, responseCode, responseDurationInMs, this.nameProvider.Name);
 
         [NonEvent]
+        [SuppressMessage("Microsoft.Performance", "CA1822: MarkMembersAsStatic", Justification = "This method does access instance data in NetStandard 2.0 scenarios.")]
         public void IngestionResponseTimeEventCounter(float responseDurationInMs)
         {
 #if NETSTANDARD2_0

--- a/BASE/src/ServerTelemetryChannel/Implementation/TelemetryBuffer.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TelemetryBuffer.cs
@@ -14,6 +14,8 @@
     {
         private static readonly TimeSpan DefaultFlushDelay = TimeSpan.FromSeconds(30);
 
+        private static readonly object LockObj = new object();
+
         private readonly TaskTimerInternal flushTimer;
         private readonly TelemetrySerializer serializer;
 
@@ -141,7 +143,7 @@
                 this.flushTimer.Start(this.FlushAsync);
             }
 
-            lock (this)
+            lock (LockObj)
             {
                 if (this.itemBuffer.Count >= this.BacklogSize)
                 {
@@ -170,7 +172,7 @@
             List<ITelemetry> telemetryToFlush = null;
             if (this.itemBuffer.Count > 0)
             {
-                lock (this)
+                lock (LockObj)
                 {
                     if (this.itemBuffer.Count > 0)
                     {

--- a/LOGGING/src/EtwCollector/AITraceEventSession.cs
+++ b/LOGGING/src/EtwCollector/AITraceEventSession.cs
@@ -35,6 +35,11 @@ namespace Microsoft.ApplicationInsights.EtwCollector
             }
         }
 
+        public static bool? IsElevated()
+        {
+            return TraceEventSession.IsElevated();
+        }
+
         public void DisableProvider(Guid providerGuid)
         {
             this.session.DisableProvider(providerGuid);
@@ -58,11 +63,6 @@ namespace Microsoft.ApplicationInsights.EtwCollector
         public bool EnableProvider(string providerName, TraceEventLevel providerLevel = TraceEventLevel.Verbose, ulong matchAnyKeywords = ulong.MaxValue, TraceEventProviderOptions options = null)
         {
             return this.session.EnableProvider(providerName, providerLevel, matchAnyKeywords, options);
-        }
-
-        public bool? IsElevated()
-        {
-            return TraceEventSession.IsElevated();
         }
 
         public bool Stop(bool noThrow = false)

--- a/LOGGING/src/EventSourceListener/EventSourceTelemetryModule.cs
+++ b/LOGGING/src/EventSourceListener/EventSourceTelemetryModule.cs
@@ -8,6 +8,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
     using System;
     using System.Collections.Concurrent;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
     using System.Linq;
     using Microsoft.ApplicationInsights.EventSourceListener.Implementation;
@@ -182,6 +183,7 @@ namespace Microsoft.ApplicationInsights.EventSourceListener
         /// <param name="eventSource">EventSource instance.</param>
         /// <remarks>When an instance of an EventListener is created, it will immediately receive notifications about all EventSources already existing in the AppDomain.
         /// Then, as new EventSources are created, the EventListener will receive notifications about them.</remarks>
+        [SuppressMessage("Microsoft.Reliability", "CA2002:DoNotLockObjectsWithWeakIdentity", Justification = "This was done intentionally for a bug fix.")]
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
             if (eventSource == null)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -138,18 +138,12 @@
         /// <inheritdoc/>
         public string ListenerName { get; } = "Microsoft.AspNetCore";
 
-        /// <inheritdoc />
-        public void OnSubscribe()
-        {
-            SubscriptionManager.Attach(this);
-        }
-
         /// <summary>
         /// Diagnostic event handler method for 'Microsoft.AspNetCore.Mvc.BeforeAction' event.
         /// </summary>
         /// <param name="httpContext">HttpContext is used to retrieve information about the Request and Response.</param>
         /// <param name="routeValues">Used to get the name of the request.</param>
-        public void OnBeforeAction(HttpContext httpContext, IDictionary<string, object> routeValues)
+        public static void OnBeforeAction(HttpContext httpContext, IDictionary<string, object> routeValues)
         {
             var telemetry = httpContext.Features.Get<RequestTelemetry>();
 
@@ -162,6 +156,12 @@
                     telemetry.Name = name;
                 }
             }
+        }
+
+        /// <inheritdoc />
+        public void OnSubscribe()
+        {
+            SubscriptionManager.Attach(this);
         }
 
         /// <summary>
@@ -506,7 +506,7 @@
 
                     if (context != null && routeValues != null)
                     {
-                        this.OnBeforeAction(context, routeValues);
+                        OnBeforeAction(context, routeValues);
                     }
                 }
                 else if (value.Key == "Microsoft.AspNetCore.Hosting.BeginRequest")

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
@@ -72,7 +72,7 @@
                 var stateDictionary = state as IReadOnlyList<KeyValuePair<string, object>>;
                 if (exception == null || this.options?.TrackExceptionsAsExceptionTelemetry == false)
                 {
-                    var traceTelemetry = new TraceTelemetry(formatter(state, exception), this.GetSeverityLevel(logLevel));
+                    var traceTelemetry = new TraceTelemetry(formatter(state, exception), GetSeverityLevel(logLevel));
                     this.PopulateTelemetry(traceTelemetry, stateDictionary, eventId);
                     this.telemetryClient.TrackTrace(traceTelemetry);
                 }
@@ -80,12 +80,31 @@
                 {
                     var exceptionTelemetry = new ExceptionTelemetry(exception);
                     exceptionTelemetry.Message = formatter(state, exception);
-                    exceptionTelemetry.SeverityLevel = this.GetSeverityLevel(logLevel);
+                    exceptionTelemetry.SeverityLevel = GetSeverityLevel(logLevel);
                     exceptionTelemetry.Properties["Exception"] = exception.ToString();
                     exception.Data.Cast<DictionaryEntry>().ToList().ForEach((item) => exceptionTelemetry.Properties[item.Key.ToString()] = (item.Value ?? "null").ToString());
                     this.PopulateTelemetry(exceptionTelemetry, stateDictionary, eventId);
                     this.telemetryClient.TrackException(exceptionTelemetry);
                 }
+            }
+        }
+
+        private static SeverityLevel GetSeverityLevel(LogLevel logLevel)
+        {
+            switch (logLevel)
+            {
+                case LogLevel.Critical:
+                    return SeverityLevel.Critical;
+                case LogLevel.Error:
+                    return SeverityLevel.Error;
+                case LogLevel.Warning:
+                    return SeverityLevel.Warning;
+                case LogLevel.Information:
+                    return SeverityLevel.Information;
+                case LogLevel.Debug:
+                case LogLevel.Trace:
+                default:
+                    return SeverityLevel.Verbose;
             }
         }
 
@@ -120,25 +139,6 @@
             }
 
             telemetry.Context.GetInternalContext().SdkVersion = this.sdkVersion;
-        }
-
-        private SeverityLevel GetSeverityLevel(LogLevel logLevel)
-        {
-            switch (logLevel)
-            {
-                case LogLevel.Critical:
-                    return SeverityLevel.Critical;
-                case LogLevel.Error:
-                    return SeverityLevel.Error;
-                case LogLevel.Warning:
-                    return SeverityLevel.Warning;
-                case LogLevel.Information:
-                    return SeverityLevel.Information;
-                case LogLevel.Debug:
-                case LogLevel.Trace:
-                default:
-                    return SeverityLevel.Verbose;
-            }
         }
     }
 #pragma warning restore CS0618

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -52,7 +52,7 @@
                         }
                     }
 
-                    string type = this.GetType(currentActivity);
+                    string type = GetType(currentActivity);
 
                     if (telemetry == null)
                     {
@@ -61,12 +61,12 @@
 
                     if (type != null && type.EndsWith(RemoteDependencyConstants.AzureEventHubs, StringComparison.Ordinal))
                     {
-                        this.SetEventHubsProperties(currentActivity, telemetry);
+                        SetEventHubsProperties(currentActivity, telemetry);
                     }
 
                     if (this.linksPropertyFetcher.Fetch(evnt.Value) is IEnumerable<Activity> activityLinks)
                     {
-                        this.PopulateLinks(activityLinks, telemetry);
+                        PopulateLinks(activityLinks, telemetry);
 
                         if (telemetry is RequestTelemetry request &&
                             TryGetAverageTimeInQueueForBatch(activityLinks, currentActivity.StartTimeUtc, out long enqueuedTime))
@@ -85,7 +85,7 @@
 
                     if (telemetry is DependencyTelemetry dependency && dependency.Type == RemoteDependencyConstants.HTTP)
                     {
-                        this.SetHttpProperties(currentActivity, dependency);
+                        SetHttpProperties(currentActivity, dependency);
                         if (evnt.Value != null)
                         {
                             dependency.SetOperationDetail(evnt.Value.GetType().FullName, evnt.Value);
@@ -190,7 +190,7 @@
             return false;
         }
 
-        private string GetType(Activity currentActivity)
+        private static string GetType(Activity currentActivity)
         {
             string kind = RemoteDependencyConstants.InProc;
             string component = null;
@@ -242,7 +242,7 @@
             return kind ?? string.Empty;
         }
 
-        private void SetHttpProperties(Activity activity, DependencyTelemetry dependency)
+        private static void SetHttpProperties(Activity activity, DependencyTelemetry dependency)
         {
             string method = null;
             string url = null;
@@ -290,7 +290,7 @@
             }
         }
 
-        private void SetEventHubsProperties(Activity activity, OperationTelemetry telemetry)
+        private static void SetEventHubsProperties(Activity activity, OperationTelemetry telemetry)
         {
             string endpoint = null;
             string queueName = null;
@@ -332,7 +332,7 @@
             }
         }
 
-        private void PopulateLinks(IEnumerable<Activity> links, OperationTelemetry telemetry)
+        private static void PopulateLinks(IEnumerable<Activity> links, OperationTelemetry telemetry)
         {
             if (links.Any())
             {

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/ProfilerHttpProcessing.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/ProfilerHttpProcessing.cs
@@ -3,6 +3,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
 {
     using System;
     using System.Collections.Generic;
+    using System.Diagnostics.CodeAnalysis;
     using System.Net;
     using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.DataContracts;
@@ -13,6 +14,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// Concrete class with all processing logic to generate RDD data from the callbacks
     /// received from Profiler instrumentation for HTTP .   
     /// </summary>
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "These methods have extra parameters to match callbacks with specific number of parameters.")]
     internal sealed class ProfilerHttpProcessing : HttpProcessing
     {
         internal ObjectInstanceBasedOperationHolder<DependencyTelemetry> TelemetryTable;

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/ProfilerSqlProcessingBase.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/ProfilerSqlProcessingBase.cs
@@ -4,6 +4,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using System;
     using System.Data.SqlClient;
     using System.Diagnostics;
+    using System.Diagnostics.CodeAnalysis;
     using System.Globalization;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Common;
@@ -15,6 +16,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// <summary>
     /// Base class with all processing logic to generate dependencies from the callbacks received from Profiler instrumentation for SQL.    
     /// </summary>
+    [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "These methods have extra parameters to match callbacks with specific number of parameters.")]
     internal abstract class ProfilerSqlProcessingBase
     {
         internal ObjectInstanceBasedOperationHolder<DependencyTelemetry> TelemetryTable;

--- a/WEB/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
+++ b/WEB/Src/EventCounterCollector/EventCounterCollector/EventCounterListener.cs
@@ -14,6 +14,7 @@
     /// </summary>
     internal class EventCounterListener : EventListener
     {
+        private static readonly object LockObj = new object();
         private readonly string refreshIntervalInSecs;
         private readonly int refreshInternalInSecInt;
         private readonly EventLevel level = EventLevel.Critical;
@@ -80,7 +81,7 @@
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
             // Keeping track of all EventSources here, as this call may happen before initialization.
-            lock (this)
+            lock (LockObj)
             {
                 if (this.allEventSourcesCreated == null)
                 {

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -163,26 +163,6 @@
 
         #endregion
 
-        [NonEvent]
-        private string GetApplicationName()
-        {
-            string name;
-            try
-            {
-#if NETSTANDARD2_0
-                name = new AssemblyName(Assembly.GetEntryAssembly().FullName).Name;
-#else
-                name = AppDomain.CurrentDomain.FriendlyName;
-#endif
-            }
-            catch (Exception exp)
-            {
-                name = "Undefined " + exp.Message ?? exp.ToString();
-            }
-
-            return name;
-        }
-
         public class Keywords
         {
             public const EventKeywords UserActionable = (EventKeywords)0x1;


### PR DESCRIPTION
as part of SDL, i've updated our Analyzers and resolved the new issues.

## Changes
- Update FxCop
- Update PublicApiAnalyzer
- Desktop.Analyzer has been delisted and I have removed it from our collection.
- CA1822 Methods don't access instance data and can be marked as static
- CA2002 Do not lock on objects with weak identity
- CA1801 Method signatures contain unused parameters.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
