### PR TITLE
fix analyzers

### DIFF
--- a/.props/Product.props
+++ b/.props/Product.props
@@ -11,7 +11,7 @@
   <Import Project=".\_GlobalStaticVersion.props" />
   <Import Project=".\_Nupkg.props" />
 
-  <ItemGroup Condition=" $(OS) == 'Windows_NT' And $(Configuration) == 'Release'">
+  <ItemGroup Condition=" $(OS) == 'Windows_NT'">
     <!--Analyzers-->
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>

--- a/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -38,7 +38,7 @@
                 throw new ArgumentNullException(nameof(environment));
             }
 
-            if(IsWindowsOperatingSystem())
+            if (IsWindowsOperatingSystem())
             {
                 this.identityProvider = new WindowsIdentityProvider();
                 this.ApplySecurityToDirectory = this.SetSecurityPermissionsToAdminAndCurrentUserWindows;
@@ -109,15 +109,6 @@
             return result;
         }
 
-        /// <summary>
-        /// Test hook to allow testing of non-windows scenario.
-        /// </summary>
-        /// <param name="applySecurityToDirectory">The method to be invoked to set directory access.</param>
-        internal void OverrideApplySecurityToDirectory(Func<DirectoryInfo, bool> applySecurityToDirectory)
-        {
-            this.ApplySecurityToDirectory = applySecurityToDirectory;
-        }
-
         internal static bool IsWindowsOperatingSystem()
         {
 #if NET45
@@ -132,6 +123,15 @@
                 return false;
             }
 #endif
+        }
+
+        /// <summary>
+        /// Test hook to allow testing of non-windows scenario.
+        /// </summary>
+        /// <param name="applySecurityToDirectory">The method to be invoked to set directory access.</param>
+        internal void OverrideApplySecurityToDirectory(Func<DirectoryInfo, bool> applySecurityToDirectory)
+        {
+            this.ApplySecurityToDirectory = applySecurityToDirectory;
         }
 
         private static string GetPathAccessFailureErrorMessage(Exception exp, string path)

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -34,7 +34,10 @@
     <PackagesDir>$([System.IO.Path]::GetFullPath( $(PackagesDir) ))</PackagesDir>
 
     <RelativeOutputPathBase>$(MSBuildProjectDirectory.Substring($(EnlistmentRoot.Length)))</RelativeOutputPathBase>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
+
+    <!--This is to disable code analysis while devs are working. Default is true.-->
+    <RunAnalyzers Condition=" '$(Configuration)' == 'Debug' ">false</RunAnalyzers>
 
     <OutputPath>$(BinRoot)\$(Configuration)\test\$(MSBuildProjectName)</OutputPath>
     <OutputPath>$([System.IO.Path]::GetFullPath( $(OutputPath) ))\</OutputPath>


### PR DESCRIPTION

## Changes
- remove Configuration condition on Packages. This wasn't working consistently in every environment.
- introduce flag to disable Analyzers. https://docs.microsoft.com/en-us/visualstudio/code-quality/disable-code-analysis?view=vs-2019
- to test this change, I tested on the build server and verified that the build failed.
- fix violations

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
