### PR TITLE
fix Assembly.GetEntryAssembly() in tests

### DIFF
--- a/NETCORE/src/Shared/Internals/ApplicationNameProvider.cs
+++ b/NETCORE/src/Shared/Internals/ApplicationNameProvider.cs
@@ -25,7 +25,8 @@
         {
             try
             {
-                return Assembly.GetEntryAssembly().GetName().Name;
+                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+                return assembly.GetName().Name;
             }
             catch (Exception exp)
             {

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensibility/Implementation/Tracing/EventSourceTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensibility/Implementation/Tracing/EventSourceTests.cs
@@ -144,7 +144,8 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensibility.Implement
             string expectedApplicationName;
             try
             {
-                expectedApplicationName = System.Reflection.Assembly.GetEntryAssembly().GetName().Name;
+                var assembly = Assembly.GetEntryAssembly() ?? Assembly.GetCallingAssembly();
+                expectedApplicationName = assembly.GetName().Name;
             }
             catch (Exception exp)
             {


### PR DESCRIPTION
I keep encountering test failures because `Assembly.GetEntryAssembly()` returns null which then throws an NRE.
It appears this was a known issue because these places were wrapped in a try/catch.
The cause is that the unit tests are not invoked by an "Entry Assembly", but they do have a "Calling Assembly".
The fix is to do a null check and call `Assembly.GetCallingAssembly()`.

GetEntryAssembly
> Gets the process executable in the default application domain.
> The `GetEntryAssembly` method can return null when a managed assembly has been loaded from an unmanaged application.
> https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getentryassembly?view=netcore-3.1#remarks



GetCallingAssembly
> Returns the Assembly of the method that invoked the currently executing method.
> https://docs.microsoft.com/en-us/dotnet/api/system.reflection.assembly.getcallingassembly?view=netcore-3.1


## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
