### PR TITLE
refactor FileDiagnosticsTelemetryModule

### DIFF
--- a/BASE/Test/TestFramework/Shared/StubPlatform.cs
+++ b/BASE/Test/TestFramework/Shared/StubPlatform.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.TestFramework
 {
     using System;
+    using System.IO;
 
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -43,5 +44,12 @@
         {
             return this.OnGetMachineName();
         }
+
+        public void TestDirectoryPermissions(DirectoryInfo directory)
+        {
+            // no op
+        }
+
+        public string GetCurrentIdentityName() => nameof(StubPlatform);
     }
 }

--- a/BASE/Test/TestFramework/Shared/StubPlatform.cs
+++ b/BASE/Test/TestFramework/Shared/StubPlatform.cs
@@ -47,7 +47,19 @@
 
         public void TestDirectoryPermissions(DirectoryInfo directory)
         {
-            // no op
+            string testFileName = Path.GetRandomFileName();
+            string testFilePath = Path.Combine(directory.FullName, testFileName);
+
+            if (!Directory.Exists(directory.FullName))
+            {
+                Directory.CreateDirectory(directory.FullName);
+            }
+
+            // Create a test file, will auto-delete this file. 
+            using (var testFile = new FileStream(testFilePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose))
+            {
+                testFile.Write(new[] { default(byte) }, 0, 1);
+            }
         }
 
         public string GetCurrentIdentityName() => nameof(StubPlatform);

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs
@@ -1,5 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
+    using System.IO;
+
     using Microsoft.ApplicationInsights.Extensibility;
 
     /// <summary>
@@ -33,5 +35,17 @@
         /// </summary>
         /// <returns>The machine name.</returns>
         string GetMachineName();
+
+        /// <summary>
+        /// Test that this process can read and write to a given directory.
+        /// </summary>
+        /// <param name="directory">The directory to be evaluated.</param>
+        void TestDirectoryPermissions(DirectoryInfo directory);
+
+        /// <summary>
+        /// Get the current process's identity.
+        /// </summary>
+        /// <returns>Returns the current identity of the process.</returns>
+        string GetCurrentIdentityName();
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/IPlatform.cs
@@ -43,9 +43,8 @@
         void TestDirectoryPermissions(DirectoryInfo directory);
 
         /// <summary>
-        /// Get the current process's identity.
+        /// Get the current identity.
         /// </summary>
-        /// <returns>Returns the current identity of the process.</returns>
         string GetCurrentIdentityName();
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Platform/PlatformImplementation.cs
@@ -21,6 +21,7 @@
 
         private IDebugOutput debugOutput = null;
         private string hostName;
+        private string identityName;
 
         /// <summary>
         /// Initializes a new instance of the PlatformImplementation class.
@@ -117,6 +118,48 @@
         public string GetMachineName()
         {
             return this.hostName ?? (this.hostName = GetHostName());
+        }
+
+        public void TestDirectoryPermissions(DirectoryInfo directory)
+        {
+            string testFileName = Path.GetRandomFileName();
+            string testFilePath = Path.Combine(directory.FullName, testFileName);
+
+            if (!Directory.Exists(directory.FullName))
+            {
+                Directory.CreateDirectory(directory.FullName);
+            }
+
+            // Create a test file, will auto-delete this file. 
+            using (var testFile = new FileStream(testFilePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose))
+            {
+                testFile.Write(new[] { default(byte) }, 0, 1);
+            }
+        }
+
+        public string GetCurrentIdentityName()
+        {
+            if (this.identityName == null)
+            {
+                try
+                {
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
+                    this.identityName = System.Environment.UserName;
+#else
+                    using (var identity = System.Security.Principal.WindowsIdentity.GetCurrent())
+                    {
+                        this.identityName = identity.Name;
+                    }
+#endif
+                }
+                catch (SecurityException exp)
+                {
+                    CoreEventSource.Log.LogWindowsIdentityAccessSecurityException(exp.Message);
+                    this.identityName = "Unknown";
+                }
+            }
+
+            return this.identityName;
         }
 
         private static string GetHostName()


### PR DESCRIPTION
Refactoring common implementation from FileDiagnosticsTelemetryModule.
I want to reuse these methods in the newer file logging.

## Changes
- Move Get Identity Name to IPlatform
- Move TestDirectory to IPlatform
- cleanup FileDiagnosticsTelemetryModule

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
