### PR TITLE
refactor DiagnosticsTelemetryModule internal classes

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsListener.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsListener.cs
@@ -26,10 +26,7 @@
 
         public EventLevel LogLevel
         {
-            get
-            {
-                return this.logLevel;
-            }
+            get => this.logLevel;
 
             set
             {
@@ -41,6 +38,23 @@
                 }
 
                 this.logLevel = value;
+            }
+        }
+
+        /// <summary>
+        /// Sets LogLevel. Possible values LogAlways, Critical, Error, Warning, Informational and Verbose.
+        /// </summary>
+        public void SetLogLevel(string value)
+        {
+            // Once logLevel is set from configuration, restart listener with new value
+            if (!string.IsNullOrEmpty(value))
+            {
+                EventLevel parsedValue;
+                if (Enum.IsDefined(typeof(EventLevel), value) == true)
+                {
+                    parsedValue = (EventLevel)Enum.Parse(typeof(EventLevel), value, true);
+                    this.LogLevel = parsedValue;
+                }
             }
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/PortalDiagnosticsQueueSender.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/PortalDiagnosticsQueueSender.cs
@@ -26,5 +26,13 @@
                 this.EventData.Add(eventData);
             }
         }
+
+        public void FlushQueue(IDiagnosticsSender sender)
+        {
+            foreach (var traceEvent in this.EventData)
+            {
+                sender.Send(traceEvent);
+            }
+        }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/PortalDiagnosticsSender.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/PortalDiagnosticsSender.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Globalization;
     using System.Linq;
+
     using Microsoft.ApplicationInsights.DataContracts;
 
     /// <summary>
@@ -10,18 +11,8 @@
     /// </summary>
     internal class PortalDiagnosticsSender : IDiagnosticsSender
     {
-        /// <summary>
-        /// Prefix of the traces in portal.
-        /// </summary>
-        private const string AiPrefix = "AI: ";
-
-        /// <summary>
-        /// For user non actionable traces use AI Internal prefix.
-        /// </summary>
-        private const string AiNonUserActionable = "AI (Internal): ";
-
         private const string SdkTelemetrySyntheticSourceName = "SDKTelemetry";
-        
+
         private readonly TelemetryClient telemetryClient;
         private readonly IDiagnoisticsEventThrottlingManager throttlingManager;
 
@@ -95,24 +86,11 @@
                 return;
             }
 
-            var traceTelemetry = new TraceTelemetry();
-            
-            string message = eventData.Payload != null ? 
-                string.Format(CultureInfo.CurrentCulture, eventData.MetaData.MessageFormat, eventData.Payload.ToArray()) : 
-                eventData.MetaData.MessageFormat;
-
-            // Add "AI: " prefix (if keyword does not contain UserActionable = (EventKeywords)0x1, than prefix should be "AI (Internal):" )
-            if ((eventData.MetaData.Keywords & EventSourceKeywords.UserActionable) == EventSourceKeywords.UserActionable)
+            var traceTelemetry = new TraceTelemetry
             {
-                message = AiPrefix + message;
-            }
-            else
-            {
-                string eventSourceName = '[' + eventData.MetaData.EventSourceName + "] ";
-                message = AiNonUserActionable + eventSourceName + message;
-            }
+                Message = eventData.ToString(),
+            };
 
-            traceTelemetry.Message = message;
             if (!string.IsNullOrEmpty(this.DiagnosticsInstrumentationKey))
             {
                 traceTelemetry.Context.InstrumentationKey = this.DiagnosticsInstrumentationKey;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModule.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsTelemetryModule.cs
@@ -37,25 +37,15 @@
         /// <summary>
         /// Finalizes an instance of the <see cref="DiagnosticsTelemetryModule" /> class.
         /// </summary>
-        ~DiagnosticsTelemetryModule()
-        {
-            this.Dispose(false);
-        }
+        ~DiagnosticsTelemetryModule() => this.Dispose(false);
 
         /// <summary>
         /// Gets or sets a value indicating whether or not the Heartbeat feature is disabled.
         /// </summary>
         public bool IsHeartbeatEnabled
         {
-            get
-            {
-                return this.HeartbeatProvider.IsHeartbeatEnabled;
-            }
-
-            set
-            {
-                this.HeartbeatProvider.IsHeartbeatEnabled = value;
-            }
+            get => this.HeartbeatProvider.IsHeartbeatEnabled;
+            set => this.HeartbeatProvider.IsHeartbeatEnabled = value;
         }
 
         /// <summary>
@@ -81,10 +71,7 @@
         /// default heartbeat properties. The only default heartbeat property provide currently defined is named
         /// 'Base'.
         /// </summary>
-        public IList<string> ExcludedHeartbeatPropertyProviders
-        {
-            get => this.HeartbeatProvider.ExcludedHeartbeatPropertyProviders;
-        }
+        public IList<string> ExcludedHeartbeatPropertyProviders => this.HeartbeatProvider.ExcludedHeartbeatPropertyProviders;
 
         /// <summary>
         /// Gets a list of property names that are not to be sent with the heartbeats. null/empty list means allow all default properties through.
@@ -94,13 +81,7 @@
         /// baseSdkTargetFramework, osType, processSessionId
         /// </remarks>
         /// </summary>
-        public IList<string> ExcludedHeartbeatProperties
-        {
-            get
-            {
-                return this.HeartbeatProvider.ExcludedHeartbeatProperties;
-            }
-        }
+        public IList<string> ExcludedHeartbeatProperties => this.HeartbeatProvider.ExcludedHeartbeatProperties;
 
         /// <summary>
         /// Gets or sets diagnostics Telemetry Module LogLevel configuration setting. 
@@ -108,24 +89,8 @@
         /// </summary>
         public string Severity
         {
-            get
-            {
-                return this.EventListener.LogLevel.ToString();
-            }
-
-            set
-            {
-                // Once logLevel is set from configuration, restart listener with new value
-                if (!string.IsNullOrEmpty(value))
-                {
-                    EventLevel parsedValue;
-                    if (Enum.IsDefined(typeof(EventLevel), value) == true)
-                    {
-                        parsedValue = (EventLevel)Enum.Parse(typeof(EventLevel), value, true);
-                        this.EventListener.LogLevel = parsedValue;
-                    }
-                }
-            }
+            get => this.EventListener.LogLevel.ToString();
+            set => this.EventListener.SetLogLevel(value);
         }
 
         /// <summary>
@@ -178,6 +143,7 @@
                 {
                     if (!this.IsInitialized)
                     {
+                        // Swap out the PortalDiagnosticsQueueSender for the PortalDiagnosticsSender
                         var queueSender = this.Senders.OfType<PortalDiagnosticsQueueSender>().First();
                         queueSender.IsDisabled = true;
                         this.Senders.Remove(queueSender);
@@ -194,10 +160,7 @@
 
                         this.Senders.Add(portalSender);
 
-                        foreach (TraceEvent traceEvent in queueSender.EventData)
-                        {
-                            portalSender.Send(traceEvent);
-                        }
+                        queueSender.FlushQueue(portalSender);
 
                         // set up heartbeat
                         this.HeartbeatProvider.Initialize(configuration);

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/EventMetaData.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/EventMetaData.cs
@@ -16,5 +16,7 @@
         public long Keywords { get; set; }
 
         public EventLevel Level { get; set; }
+
+        public bool IsUserActionable() => (this.Keywords & EventSourceKeywords.UserActionable) == EventSourceKeywords.UserActionable;
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/TraceEvent.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/TraceEvent.cs
@@ -1,11 +1,24 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
 {
+    using System.Globalization;
+    using System.Linq;
+
     /// <summary>
     /// Event Source event wrapper.
     /// Contains description information for trace event.
     /// </summary>
     internal class TraceEvent
     {
+        /// <summary>
+        /// Prefix for user-actionable traces.
+        /// </summary>
+        private const string AiPrefix = "AI: ";
+
+        /// <summary>
+        /// Prefix for non user-actionable traces. "AI Internal".
+        /// </summary>
+        private const string AiNonUserActionable = "AI (Internal): ";
+
         /// <summary>
         /// Gets or sets event metadata.
         /// </summary>
@@ -15,5 +28,19 @@
         /// Gets or sets event parameters.
         /// </summary>
         public object[] Payload { get; set; }
+
+        public override string ToString()
+        {
+            // Add "AI: " prefix (if keyword does not contain UserActionable = (EventKeywords)0x1, than prefix should be "AI (Internal):" )
+            string message = this.MetaData.IsUserActionable()
+                ? AiPrefix
+                : AiNonUserActionable + '[' + this.MetaData.EventSourceName + "] ";
+
+            message += this.Payload != null ?
+                string.Format(CultureInfo.CurrentCulture, this.MetaData.MessageFormat, this.Payload.ToArray()) :
+                this.MetaData.MessageFormat;
+
+            return message;
+        }
     }
 }


### PR DESCRIPTION
Refactoring common implementation from DiagnosticsTelemetryModule and internal classes.
I want to reuse these methods in the newer file logging.

## Changes
- move parsing methods to EventMetaData and TraceEvent
- move Flushing to QueueSender class
- cleanup classes

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
