### PR TITLE
Use DiagnosticListener instance (instead of the name) to distinguish and dedup subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - [Create single request telemetry when URL-rewrite rewrites a request](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1744)
 - [Remove legacy TelemetryConfiguration.Active from AspNetCore SDK](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1953)
 - [Refactor AspNetCore and WorkerService use of Heartbeat (DiagnosticTelemetryModule)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1954)
+- [Fix broken correlation and missing in-proc dependency Azure Blob SDK v12](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1915)
 
 ## Version 2.15.0-beta2
 - [Read all properties of ApplicationInsightsServiceOptions from IConfiguration](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1882)

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -99,6 +99,36 @@
             }
         }
 
+
+        [TestMethod]
+        public void AzureClientSpansAreCollectedMultipleDiagnosticSourcesSameName()
+        {
+            using (var listener1 = new DiagnosticListener("Azure.SomeClient"))
+            using (var listener2 = new DiagnosticListener("Azure.SomeClient"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                var telemetry1 = this.TrackOperation<DependencyTelemetry>(
+                    listener1,
+                    "Azure.SomeClient.Send",
+                    null,
+                    () => { });
+
+                Assert.IsNotNull(telemetry1);
+                Assert.AreEqual("SomeClient.Send", telemetry1.Name);
+
+                var telemetry2 = this.TrackOperation<DependencyTelemetry>(
+                    listener2,
+                    "Azure.SomeClient.Send",
+                    null,
+                    () => { });
+
+                Assert.IsNotNull(telemetry2);
+                Assert.AreEqual("SomeClient.Send", telemetry2.Name);
+            }
+        }
+
         [TestMethod]
         public void AzureClientSpansAreCollectedClientKind()
         {

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs
@@ -15,8 +15,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     /// <typeparamref name="TContext">The type of processing context for given diagnostic source.</typeparamref>
     internal abstract class DiagnosticSourceListenerBase<TContext> : IObserver<DiagnosticListener>, IDisposable
     {
-        protected static readonly ConcurrentDictionary<string, ActiveSubsciptionManager> SubscriptionManagers =
-            new ConcurrentDictionary<string, ActiveSubsciptionManager>();
+        protected static readonly ConcurrentDictionary<DiagnosticListener, ActiveSubsciptionManager> SubscriptionManagers =
+            new ConcurrentDictionary<DiagnosticListener, ActiveSubsciptionManager>();
     
         protected readonly TelemetryClient Client;
         protected readonly TelemetryConfiguration Configuration;
@@ -77,7 +77,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             }
 
             var eventHandler = this.GetEventHandler(value.Name);
-            var manager = SubscriptionManagers.GetOrAdd(value.Name, k => new ActiveSubsciptionManager());
+            var manager = SubscriptionManagers.GetOrAdd(value, k => new ActiveSubsciptionManager());
 
             var individualListener = new IndividualDiagnosticSourceListener(
                 value, 


### PR DESCRIPTION
Fix Issue #1915.

## Changes
Application Insights SDK has a protection mechanism (`SubscriptionManager`) that  allows only one diagnostic source to send events (this is done for the case when multiple apps are hosted in the same process, see more https://github.com/microsoft/ApplicationInsights-aspnetcore/pull/787) which basically means that whichever source was registered first is active one and the rest [are ignored](https://github.com/microsoft/ApplicationInsights-dotnet/blob/5ac6bb98d04b7da6d151c0338efece4c124c750a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs#L205).
This is done with assumption that all diagnostic sources are static and there is only one source with given name in the process.

This breaks Azure SDK that creates multiple Diagnostic Sources instances with the same name and we should allow this scenario:
- it will still protect from multiple apps hosted in the same process (the problem there is 1 diagnostic source instance with multiple subscriptions from multiple Application Insights SDKs hosted in the same process) 
- it will also remove requirement to have static sources only.


### Checklist
- [x] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.


### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
