### PR TITLE
refactor FileDiagnosticsTelemetryModule

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileDiagnosticsTelemetryModule.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileDiagnosticsTelemetryModule.cs
@@ -3,24 +3,22 @@
     using System;
     using System.Diagnostics;
     using System.Diagnostics.Tracing;
-    using System.Globalization;
     using System.IO;
-    using System.Security;
-    using System.Threading;
+
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.FileDiagnosticsModule;
+
+    using static System.FormattableString;
 
     /// <summary>
     /// Diagnostics telemetry module for azure web sites.
     /// </summary>
     public class FileDiagnosticsTelemetryModule : IDisposable, ITelemetryModule
     {
-        private string windowsIdentityName;
-        
+        private readonly TraceSourceForEventSource traceSource = new TraceSourceForEventSource(EventLevel.Error);
+        private readonly DefaultTraceListener listener = new DefaultTraceListener();
+
         private string logFileName;
         private string logFilePath;
-
-        private TraceSourceForEventSource traceSource = new TraceSourceForEventSource(EventLevel.Error);
-        private DefaultTraceListener listener = new DefaultTraceListener();
 
         /// <summary>
         /// Initializes a new instance of the <see cref="FileDiagnosticsTelemetryModule" /> class.
@@ -28,7 +26,8 @@
         public FileDiagnosticsTelemetryModule()
         {
             this.logFilePath = Environment.ExpandEnvironmentVariables("%TEMP%");
-            this.logFileName = "ApplicationInsightsLog_" + Process.GetCurrentProcess().Id.ToString(CultureInfo.InvariantCulture) + ".txt";
+
+            this.logFileName = FileHelper.GenerateFileName();
 
             this.SetAndValidateLogsFolder(this.logFilePath, this.logFileName);
 
@@ -41,10 +40,7 @@
         /// </summary>
         public string Severity
         {
-            get
-            {
-                return this.traceSource.LogLevel.ToString();
-            }
+            get => this.traceSource.LogLevel.ToString();
 
             set
             {
@@ -66,10 +62,7 @@
         /// </summary>
         public string LogFileName
         {
-            get
-            {
-                return this.logFileName;
-            }
+            get => this.logFileName;
 
             set
             {
@@ -85,14 +78,11 @@
         /// </summary>
         public string LogFilePath
         {
-            get
-            {
-                return this.logFilePath;
-            }
+            get => this.logFilePath;
 
             set
             {
-                string expandedPath = Environment.ExpandEnvironmentVariables(value);                
+                string expandedPath = Environment.ExpandEnvironmentVariables(value);
                 if (this.SetAndValidateLogsFolder(expandedPath, this.logFileName))
                 {
                     this.logFilePath = expandedPath;
@@ -101,12 +91,12 @@
         }
 
         /// <summary>
-        /// Initializes the telemetry module.
+        /// No op.
         /// </summary>
         /// <param name="configuration">Telemetry configuration object.</param>
         public void Initialize(TelemetryConfiguration configuration)
         {
-        }        
+        }
 
         /// <summary>
         /// Disposes event listener.
@@ -129,32 +119,6 @@
             }
         }
 
-        /// <summary>
-        /// Throws <see cref="UnauthorizedAccessException" /> if the process lacks the required permissions to access the <paramref name="directory"/>.
-        /// </summary>
-        private static void CheckAccessPermissions(DirectoryInfo directory)
-        {
-            string testFileName = Path.GetRandomFileName();
-            string testFilePath = Path.Combine(directory.FullName, testFileName);
-
-            if (!Directory.Exists(directory.FullName))
-            {
-                Directory.CreateDirectory(directory.FullName);
-            }
-
-            // FileSystemRights.CreateFiles
-            using (var testFile = new FileStream(testFilePath, FileMode.CreateNew, FileAccess.ReadWrite))
-            {
-                // FileSystemRights.Write
-                testFile.Write(new[] { default(byte) }, 0, 1);
-            }
-        }
-
-        private static string GetPathAccessFailureErrorMessage(Exception exp, string path, string file)
-        {
-            return "Path: " + path + "File: " + file + "; Error: " + exp.Message + Environment.NewLine;
-        }
-
         private bool SetAndValidateLogsFolder(string filePath, string fileName)
         {
             bool result = false;
@@ -162,81 +126,31 @@
             {
                 if (!string.IsNullOrWhiteSpace(filePath) && !string.IsNullOrWhiteSpace(fileName))
                 {
+                    // Validate
                     var logsDirectory = new DirectoryInfo(filePath);
-
-                    CheckAccessPermissions(logsDirectory);
+                    FileHelper.TestDirectoryPermissions(logsDirectory);
 
                     string fullLogFileName = Path.Combine(filePath, fileName);
                     CoreEventSource.Log.LogsFileName(fullLogFileName);
 
+                    // Set
                     this.listener.LogFileName = fullLogFileName;
 
                     result = true;
                 }
             }
-            catch (NotSupportedException exp)
+            catch (Exception ex)
             {
-                // The given path's format is not supported
-                CoreEventSource.Log.LogStorageAccessDeniedError(
-                    GetPathAccessFailureErrorMessage(exp, this.logFilePath, this.logFileName),
-                    LazyInitializer.EnsureInitialized(ref this.windowsIdentityName, this.GetCurrentIdentityName));
-            }
-            catch (UnauthorizedAccessException exp)
-            {
-                CoreEventSource.Log.LogStorageAccessDeniedError(
-                    GetPathAccessFailureErrorMessage(exp, this.logFilePath, this.logFileName),
-                    LazyInitializer.EnsureInitialized(ref this.windowsIdentityName, this.GetCurrentIdentityName));
-            }
-            catch (ArgumentException exp)
-            {
-                // Path does not specify a valid file path or contains invalid DirectoryInfo characters.
-                CoreEventSource.Log.LogStorageAccessDeniedError(
-                    GetPathAccessFailureErrorMessage(exp, this.logFilePath, this.logFileName),
-                    LazyInitializer.EnsureInitialized(ref this.windowsIdentityName, this.GetCurrentIdentityName));
-            }
-            catch (DirectoryNotFoundException exp)
-            {
-                // The specified path is invalid, such as being on an unmapped drive.
-                CoreEventSource.Log.LogStorageAccessDeniedError(
-                   GetPathAccessFailureErrorMessage(exp, this.logFilePath, this.logFileName),
-                   LazyInitializer.EnsureInitialized(ref this.windowsIdentityName, this.GetCurrentIdentityName));
-            }
-            catch (IOException exp)
-            {
-                // The subdirectory cannot be created. -or- A file or directory already has the name specified by path. -or-  The specified path, file name, or both exceed the system-defined maximum length. .
-                CoreEventSource.Log.LogStorageAccessDeniedError(
-                   GetPathAccessFailureErrorMessage(exp, this.logFilePath, this.logFileName),
-                   LazyInitializer.EnsureInitialized(ref this.windowsIdentityName, this.GetCurrentIdentityName));
-            }
-            catch (SecurityException exp)
-            {
-                // The caller does not have code access permission to create the directory.
-                CoreEventSource.Log.LogStorageAccessDeniedError(
-                    GetPathAccessFailureErrorMessage(exp, this.logFilePath, this.logFileName),
-                    LazyInitializer.EnsureInitialized(ref this.windowsIdentityName, this.GetCurrentIdentityName));
-            }
+                // NotSupportedException: The given path's format is not supported
+                // UnauthorizedAccessException
+                // ArgumentException: // Path does not specify a valid file path or contains invalid DirectoryInfo characters.
+                // DirectoryNotFoundException: The specified path is invalid, such as being on an unmapped drive.
+                // IOException: The subdirectory cannot be created. -or- A file or directory already has the name specified by path. -or-  The specified path, file name, or both exceed the system-defined maximum length.
+                // SecurityException: The caller does not have code access permission to create the directory.
 
-            return result;
-        }
-
-        private string GetCurrentIdentityName()
-        {
-            string result = string.Empty;
-
-            try
-            {
-#if NETSTANDARD2_0
-                result = System.Environment.UserName;
-#else
-                using (var identity = System.Security.Principal.WindowsIdentity.GetCurrent())
-                {
-                    result = identity.Name;
-                }
-#endif
-            }
-            catch (SecurityException exp)
-            {
-                CoreEventSource.Log.LogWindowsIdentityAccessSecurityException(exp.Message);
+                CoreEventSource.Log.LogStorageAccessDeniedError(
+                    error: Invariant($"Path: {this.logFilePath} File: {this.logFileName}; Error: {ex.Message}{Environment.NewLine}"),
+                    user: FileHelper.IdentityName);
             }
 
             return result;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileHelper.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileHelper.cs
@@ -1,0 +1,80 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO;
+    using System.Security;
+    using System.Threading;
+
+    using Microsoft.ApplicationInsights.Common.Extensions;
+
+    using static System.FormattableString;
+
+    /// <summary>
+    /// This class contains helper methods that can be shared across file loggers.
+    /// </summary>
+    internal static class FileHelper
+    {
+        private static string identityName = null;
+
+        public static string IdentityName => LazyInitializer.EnsureInitialized(ref identityName, GetCurrentIdentityName);
+
+        /// <summary>
+        /// Test that this process can read and write to a given directory.
+        /// </summary>
+        /// <param name="directory">The directory to be evaluated.</param>
+        public static void TestDirectoryPermissions(DirectoryInfo directory)
+        {
+            string testFileName = Path.GetRandomFileName();
+            string testFilePath = Path.Combine(directory.FullName, testFileName);
+
+            if (!Directory.Exists(directory.FullName))
+            {
+                Directory.CreateDirectory(directory.FullName);
+            }
+
+            // Create a test file, will auto-delete this file. 
+            using (var testFile = new FileStream(testFilePath, FileMode.CreateNew, FileAccess.ReadWrite, FileShare.None, 4096, FileOptions.DeleteOnClose))
+            {
+                testFile.Write(new[] { default(byte) }, 0, 1);
+            }
+        }
+
+        /// <summary>
+        /// Generate a file name in the format "ApplicationInsightsLog_20200101_120000_w3wp_12345.txt.
+        /// </summary>
+        /// <remarks>
+        /// File logging can be controlled by an Environment Variable and may affect multiple running applications on a single machine.
+        /// We include the Date, TimeStamp, Process Name, and Process ID to uniquely identify applications.
+        /// </remarks>
+        /// <returns>File name for use in logging.</returns>
+        public static string GenerateFileName()
+        {
+            var process = Process.GetCurrentProcess();
+            return Invariant($"ApplicationInsightsLog_{DateTime.UtcNow.ToInvariantString("yyyyMMdd_HHmmss")}_{process.ProcessName}_{process.Id}.txt");
+        }
+
+        /// <summary>
+        /// Get the current identity.
+        /// </summary>
+        private static string GetCurrentIdentityName()
+        {
+            try
+            {
+#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
+                return System.Environment.UserName;
+#else
+                using (var identity = System.Security.Principal.WindowsIdentity.GetCurrent())
+                {
+                    return identity.Name;
+                }
+#endif
+            }
+            catch (SecurityException exp)
+            {
+                CoreEventSource.Log.LogWindowsIdentityAccessSecurityException(exp.Message);
+                return "Unknown";
+            }
+        }
+    }
+}


### PR DESCRIPTION
Forked from #1724

## Changes
- Refactor common methods out of the FileDiagnosticsTelemetryModule.
- new FileHelper class.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
