### PR TITLE
[Proof of Concept] Performant filelog

### DIFF
--- a/BASE/Microsoft.ApplicationInsights.sln
+++ b/BASE/Microsoft.ApplicationInsights.sln
@@ -42,6 +42,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.ApplicationInsigh
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "TelemetryChannel.Tests", "Test\ServerTelemetryChannel.Test\TelemetryChannel.Tests\TelemetryChannel.Tests.csproj", "{7AB3D817-9CAC-45A7-BA4D-25FA4D690DA4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TestFileLogConsoleApp", "TestFileLogConsoleApp\TestFileLogConsoleApp.csproj", "{5179DF29-0B4B-4A42-9E0A-E972DD714036}"
+EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
 		src\Common\Common\Common.projitems*{3273d899-d9b3-44fe-b3ab-578e18b2ef90}*SharedItemsImports = 5
@@ -202,6 +204,26 @@ Global
 		{7AB3D817-9CAC-45A7-BA4D-25FA4D690DA4}.Release|x64.Build.0 = Release|Any CPU
 		{7AB3D817-9CAC-45A7-BA4D-25FA4D690DA4}.Release|x86.ActiveCfg = Release|Any CPU
 		{7AB3D817-9CAC-45A7-BA4D-25FA4D690DA4}.Release|x86.Build.0 = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|ARM.Build.0 = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|Mixed Platforms.ActiveCfg = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|Mixed Platforms.Build.0 = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|x64.Build.0 = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Debug|x86.Build.0 = Debug|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|ARM.ActiveCfg = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|ARM.Build.0 = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|Mixed Platforms.ActiveCfg = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|Mixed Platforms.Build.0 = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|x64.ActiveCfg = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|x64.Build.0 = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|x86.ActiveCfg = Release|Any CPU
+		{5179DF29-0B4B-4A42-9E0A-E972DD714036}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BASE/TestFileLogConsoleApp/App.config
+++ b/BASE/TestFileLogConsoleApp/App.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<configuration>
+    <startup> 
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8" />
+    </startup>
+</configuration>

--- a/BASE/TestFileLogConsoleApp/Program.cs
+++ b/BASE/TestFileLogConsoleApp/Program.cs
@@ -139,7 +139,7 @@ namespace TestFileLogConsoleApp
             sender2.Flush();
             stopwatch.Stop();
 
-            Console.WriteLine($"Two - MultiThread - Time elapsed: {stopwatch.Elapsed.TotalMilliseconds}ms; Timer invoked {sender2.dequeueInvokedCount} times.");
+            Console.WriteLine($"Two - SingleThread - Time elapsed: {stopwatch.Elapsed.TotalMilliseconds}ms; Timer invoked {sender2.dequeueInvokedCount} times.");
         }
 
         private static void TwoMultiThread()

--- a/BASE/TestFileLogConsoleApp/Program.cs
+++ b/BASE/TestFileLogConsoleApp/Program.cs
@@ -1,0 +1,182 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsModule;
+
+namespace TestFileLogConsoleApp
+{
+    /// <summary>
+    /// THIS APP IS JUST FOR TESTING.
+    /// I WILL DELETE THIS PROJECT WHEN SUBMITTING MY FINAL PR
+    /// </summary>
+    class Program
+    {
+        const string Directory = "C:\\TEMP\\";
+        const int Number = 10000;
+
+        static void Main(string[] args)
+        {
+            Console.WriteLine($"Number {Number}");
+
+            OneSingleThread();
+            OneMultiThread();
+
+            TwoSingleThread();
+            TwoMultiThread();
+
+            Console.ReadLine();
+        }
+
+        private static void TestingFileWrite()
+        {
+
+            ////var config = TelemetryConfiguration.CreateDefault();
+            //var config = TelemetryConfiguration.Active;
+            ////config.InstrumentationKey = "testikey";
+
+            //var old = new FileDiagnosticsTelemetryModule
+            //{
+            //    LogFilePath = "C:\\TEMP\\",
+            //    Severity = "Verbose"
+            //};
+            //old.Initialize(config);
+
+            //TelemetryModules.Instance.Modules.Add(old);
+
+            //var dtm = TelemetryModules.Instance.Modules.OfType<DiagnosticsTelemetryModule>().Single();
+            //dtm.IsFileLogEnabled = true;
+            //dtm.Severity = "Verbose";
+
+            //var client = new TelemetryClient(config);
+
+            //client.TrackEvent("test event");
+            //client.TrackTrace("test trace");
+
+            //Thread.Sleep(10000);
+
+
+            //Console.ReadKey();
+        }
+
+        private static void OneSingleThread()
+        {
+            var sender1 = new FileDiagnosticsSender
+            {
+                LogDirectory = Directory,
+                Enabled = true,
+            };
+
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            for (int i = 0; i < Number; i++)
+            {
+                sender1.Send($"{i:D5}");
+            }
+            stopwatch.Stop();
+
+            Console.WriteLine($"One - SingleThread - Time elapsed: {stopwatch.Elapsed.TotalMilliseconds}ms");
+        }
+
+        private static void OneMultiThread()
+        {
+            var sender1 = new FileDiagnosticsSender
+            {
+                LogDirectory = Directory,
+                Enabled = true,
+            };
+
+
+            var tasks = new List<Task>();
+
+            for (int i = 0; i < Number; i++ )
+            {
+                var message = $"{i:D5}";
+                tasks.Add(new Task(() => sender1.Send(message)));
+            }
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            //tasks.ForEach(x => x.Start());
+            Parallel.ForEach(tasks, x => x.Start());
+            Task.WaitAll(tasks.ToArray());
+
+            stopwatch.Stop();
+
+            Console.WriteLine($"One - MultiThread - Time elapsed: {stopwatch.Elapsed.TotalMilliseconds}ms");
+        }
+
+
+        private static void TwoSingleThread()
+        {
+            var sender2 = new FileDiagnosticsSender2
+            {
+                LogDirectory = Directory,
+                Enabled = true,
+            };
+
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            for (int i = 0; i < Number; i++)
+            {
+                sender2.Send($"{i:D5}");
+            }
+
+            Task.Delay(TimeSpan.FromSeconds(1)).Wait();
+            sender2.Flush();
+            stopwatch.Stop();
+
+            Console.WriteLine($"Two - MultiThread - Time elapsed: {stopwatch.Elapsed.TotalMilliseconds}ms; Timer invoked {sender2.dequeueInvokedCount} times.");
+        }
+
+        private static void TwoMultiThread()
+        {
+            var sender2 = new FileDiagnosticsSender2
+            {
+                LogDirectory = Directory,
+                Enabled = true,
+            };
+
+
+            var tasks = new List<Task>();
+
+            for (int i = 0; i < Number; i++)
+            {
+                var message = $"{i:D5}";
+                tasks.Add(new Task(() => sender2.Send(message)));
+            }
+
+            Stopwatch stopwatch = new Stopwatch();
+            stopwatch.Start();
+
+            //tasks.ForEach(x => x.Start());
+            //Parallel.ForEach(tasks.GetRange(0,100), x => x.Start());
+            //Task.Delay(TimeSpan.FromSeconds(10)).Wait();
+            //Parallel.ForEach(tasks.GetRange(100, 100), x => x.Start());
+            //Task.Delay(TimeSpan.FromSeconds(10)).Wait();
+            //Parallel.ForEach(tasks.GetRange(200, Number-200), x => x.Start());
+
+            Parallel.ForEach(tasks, x => x.Start());
+            Task.Delay(TimeSpan.FromSeconds(1)).Wait();
+            Task.WaitAll(tasks.ToArray());
+
+            sender2.Flush();
+            stopwatch.Stop();
+
+            Console.WriteLine($"Two - MultiThread - Time elapsed: {stopwatch.Elapsed.TotalMilliseconds}ms; Timer invoked {sender2.dequeueInvokedCount} times.");
+        }
+    }
+}

--- a/BASE/TestFileLogConsoleApp/Properties/AssemblyInfo.cs
+++ b/BASE/TestFileLogConsoleApp/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("TestFileLogConsoleApp")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("TestFileLogConsoleApp")]
+[assembly: AssemblyCopyright("Copyright ©  2020")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible
+// to COM components.  If you need to access a type in this assembly from
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("5179df29-0b4b-4a42-9e0a-e972dd714036")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/BASE/TestFileLogConsoleApp/TestFileLogConsoleApp.csproj
+++ b/BASE/TestFileLogConsoleApp/TestFileLogConsoleApp.csproj
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{5179DF29-0B4B-4A42-9E0A-E972DD714036}</ProjectGuid>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>TestFileLogConsoleApp</RootNamespace>
+    <AssemblyName>TestFileLogConsoleApp</AssemblyName>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <Deterministic>true</Deterministic>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="App.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj">
+      <Project>{E9ECEE96-DD50-42F6-9F33-0978CDFA15ED}</Project>
+      <Name>Microsoft.ApplicationInsights</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+</Project>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/FileDiagnosticsSender.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/FileDiagnosticsSender.cs
@@ -11,7 +11,7 @@
     /// <summary>
     /// This sender works with the DiagnosticTelemetryModule. This will subscribe to events and output to a text file log.
     /// </summary>
-    internal class FileDiagnosticsSender : IDiagnosticsSender
+    public class FileDiagnosticsSender : IDiagnosticsSender
     {
         private readonly object lockObj = new object();
         private readonly string logFileName = FileHelper.GenerateFileName();
@@ -62,6 +62,15 @@
         {
             if (this.Enabled)
             {
+                var message = Invariant($"{DateTime.UtcNow.ToInvariantString("o")}: {eventData.MetaData.Level}: {eventData}");
+                this.Send(message);
+            }
+        }
+
+        public void Send(string message)
+        {
+            if (this.Enabled)
+            {
                 // We previously depended on the DefaultTraceListener for writing to file. 
                 // This has some overhead, but the path we were utilizing calls a lock and uses a StreamWriter.
                 // I've copied the implementation below, but this should be replaced to be more performant.
@@ -70,7 +79,6 @@
                 // https://referencesource.microsoft.com/#System/compmod/system/diagnostics/TraceListener.cs,409
                 // https://referencesource.microsoft.com/#System/compmod/system/diagnostics/DefaultTraceListener.cs,131
 
-                var message = Invariant($"{DateTime.UtcNow.ToInvariantString("o")}: {eventData.MetaData.Level}: {eventData}");
 
                 lock (this.lockObj)
                 {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/FileDiagnosticsSender2.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/FileDiagnosticsSender2.cs
@@ -1,0 +1,160 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsModule
+{
+    using System;
+    using System.Collections.Concurrent;
+    using System.IO;
+    using System.Threading;
+
+    using Microsoft.ApplicationInsights.Common.Extensions;
+
+    using static System.FormattableString;
+
+    /// <summary>
+    /// This sender works with the DiagnosticTelemetryModule. This will subscribe to events and output to a text file log.
+    /// </summary>
+    internal class FileDiagnosticsSender2 : IDiagnosticsSender, IDisposable
+    {
+        private readonly string logFileName = FileHelper.GenerateFileName();
+        private readonly ConcurrentQueue<string> queue = new ConcurrentQueue<string>();
+        private readonly TimeSpan dequeueInterval = TimeSpan.FromSeconds(30.0);
+
+        private Timer dequeueTimer;
+
+        private string logDirectory = Environment.ExpandEnvironmentVariables("%TEMP%");
+        private bool isEnabled = false; // TODO: NEED MORE PERFORMANT FILE WRITTER BEFORE ENABLING THIS BY DEFAULT
+
+        public FileDiagnosticsSender2()
+        {
+            this.SetAndValidateLogsFolder(this.LogDirectory, this.logFileName);
+            this.dequeueTimer = new Timer(new TimerCallback(this.Dequeue));
+            this.dequeueTimer.Change(this.dequeueInterval, TimeSpan.FromMilliseconds(0));
+        }
+
+        public string LogDirectory 
+        {
+            get => this.logDirectory;
+            set
+            {
+                if (!this.IsSetByEnvironmentVariable && this.SetAndValidateLogsFolder(value, this.logFileName))
+                {
+                    this.logDirectory = value;
+                }
+            }
+        }
+
+        public bool Enabled 
+        { 
+            get => this.isEnabled;
+            set => this.isEnabled = this.IsSetByEnvironmentVariable ? this.isEnabled : value;
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this class was configured via Environment Variable.
+        /// If this class is set by the environment variable, lock the other properties to prevent TelemetryConfigurationFactory or customer code from overriding.
+        /// We are enabling SysAdmins or DevOps to be able to override this behavior via Environment Variable.
+        /// </summary>
+        internal bool IsSetByEnvironmentVariable { get; set; }
+
+        /// <summary>
+        /// Gets or sets the log file path.
+        /// </summary>
+        private string LogFilePath { get; set; }
+
+        /// <summary>
+        /// Write a trace to file.
+        /// </summary>
+        /// <param name="eventData">TraceEvent to be written to file.</param>
+        public void Send(TraceEvent eventData)
+        {
+            if (this.Enabled)
+            {
+                this.queue.Enqueue(Invariant($"{DateTime.UtcNow.ToInvariantString("o")}: {eventData.MetaData.Level}: {eventData}"));
+            }
+        }
+
+        private static void WriteFileHeader(string logFilePath)
+        {
+            string[] lines =
+            {
+                // this.SelfDiagnosticsConfig,
+                ".NET SDK version: " + SdkVersionUtils.GetSdkVersion(string.Empty),
+                string.Empty,
+            };
+
+            System.IO.File.WriteAllLines(logFilePath, lines);
+        }
+
+        private bool SetAndValidateLogsFolder(string fileDirectory, string fileName)
+        {
+            bool result = false;
+            try
+            {
+                if (!string.IsNullOrWhiteSpace(fileDirectory) && !string.IsNullOrWhiteSpace(fileName))
+                {
+                    // Validate
+                    string expandedDirectory = Environment.ExpandEnvironmentVariables(fileDirectory);
+                    var logsDirectory = new DirectoryInfo(expandedDirectory);
+                    FileHelper.TestDirectoryPermissions(logsDirectory);
+
+                    string fullLogFileName = Path.Combine(expandedDirectory, fileName);
+
+                    // Set
+                    this.LogFilePath = fullLogFileName;
+                    WriteFileHeader(fullLogFileName);
+
+                    result = true;
+                }
+            }
+            catch (Exception)
+            {
+                // NotSupportedException: The given path's format is not supported
+                // UnauthorizedAccessException
+                // ArgumentException: // Path does not specify a valid file path or contains invalid DirectoryInfo characters.
+                // DirectoryNotFoundException: The specified path is invalid, such as being on an unmapped drive.
+                // IOException: The subdirectory cannot be created. -or- A file or directory already has the name specified by path. -or-  The specified path, file name, or both exceed the system-defined maximum length.
+                // SecurityException: The caller does not have code access permission to create the directory.
+
+                // TODO: IS IT SAFE TO LOG HERE?
+                // CoreEventSource.Log.LogStorageAccessDeniedError(
+                //    error: Invariant($"Path: {this.logDirectory} File: {this.logFileName}; Error: {ex.Message}{Environment.NewLine}"),
+                //    user: FileHelper.IdentityName);
+            }
+
+            return result;
+        }
+
+        private void Dequeue(object state)
+        {
+            // TODO: STOP TIMER. I think it auto stops, but need to test and confirm.
+
+            if (!this.queue.IsEmpty)
+            {
+                try
+                {
+                    FileInfo file = new FileInfo(this.LogFilePath);
+                    using (Stream stream = file.Open(FileMode.Append))
+                    using (StreamWriter writer = new StreamWriter(stream))
+                    {
+                        //stream.Position = stream.Length; // I think this is unnecessary if using FileMode.Append
+                        
+                        while (this.queue.TryDequeue(out string message))
+                        {
+                            writer.WriteLine(message);
+                        }
+                    }
+                }
+                catch (Exception)
+                {
+                    // no op
+                }
+            }
+
+            // TODO: RESET TIMER
+        }
+
+        public void Dispose()
+        {
+            this.dequeueTimer.Dispose();
+        }
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/FileDiagnosticsSender2.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/FileDiagnosticsSender2.cs
@@ -137,10 +137,13 @@
             return result;
         }
 
+        /// <summary>
+        /// When the timer ticks, this method will dequeue all items and then restart the timer.
+        /// </summary>
+        /// <param name="state"></param>
         private void Dequeue(object state)
         {
             dequeueInvokedCount++;
-            // TODO: STOP TIMER. I think it auto stops, but need to test and confirm.
 
             if (!this.queue.IsEmpty)
             {
@@ -164,7 +167,7 @@
                 }
             }
 
-            // TODO: RESET TIMER
+            // Reset Timer
             this.dequeueTimer.Change(this.dequeueInterval, this.dequeuePeriod);
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/EventMetaData.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/EventMetaData.cs
@@ -5,7 +5,7 @@
     /// <summary>
     /// Event metadata from event source method attribute.
     /// </summary>
-    internal class EventMetaData
+    public class EventMetaData
     {
         public string EventSourceName { get; set; }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileHelper.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/FileHelper.cs
@@ -51,7 +51,7 @@
         public static string GenerateFileName()
         {
             var process = Process.GetCurrentProcess();
-            return Invariant($"ApplicationInsightsLog_{DateTime.UtcNow.ToInvariantString("yyyyMMdd_HHmmss")}_{process.ProcessName}_{process.Id}.txt");
+            return Invariant($"ApplicationInsightsLog_{DateTime.UtcNow.ToInvariantString("yyyyMMdd_HHmmssfff")}_{process.ProcessName}_{process.Id}.txt");
         }
 
         /// <summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/TraceEvent.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/TraceEvent.cs
@@ -7,7 +7,7 @@
     /// Event Source event wrapper.
     /// Contains description information for trace event.
     /// </summary>
-    internal class TraceEvent
+    public class TraceEvent
     {
         /// <summary>
         /// Prefix for user-actionable traces.


### PR DESCRIPTION
Second half of #1981.

- `FileDiagnosticsSender` uses a lock to write to file.
- `FileDiagnosticsSender2" demonstates using a ConcurrentQueue to collect messages. 
A timer runs at an interval and empties the queue to a file.



Classes were changed to public to expose to my console test app. Please ignore.



These are the timings from 3 runs, comparing the two versions of the file logger.
```
Number 10000
One - SingleThread - Time elapsed: 68193.4176ms
One - MultiThread - Time elapsed: 79463.0364ms
Two - SingleThread - Time elapsed: 1003.8052ms; Timer invoked 2 times.
Two - MultiThread - Time elapsed: 1018.1523ms; Timer invoked 2 times.

One - SingleThread - Time elapsed: 74457.6328ms
One - MultiThread - Time elapsed: 83422.4656ms
Two - SingleThread - Time elapsed: 1020.4489ms; Timer invoked 3 times.
Two - MultiThread - Time elapsed: 1024.5316ms; Timer invoked 3 times.

One - SingleThread - Time elapsed: 69852.2146ms
One - MultiThread - Time elapsed: 81512.8798ms
Two - SingleThread - Time elapsed: 1017.5031ms; Timer invoked 2 times.
Two - MultiThread - Time elapsed: 1017.0706ms; Timer invoked 2 times.
```