### PR TITLE
Perf improvement: Stream Processing (Frugal Tip G06)

### DIFF
--- a/.publicApi/Microsoft.ApplicationInsights.dll/net452/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net452/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 Microsoft.ApplicationInsights.TelemetryClient.TelemetryConfiguration.get -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
+static Microsoft.ApplicationInsights.Extensibility.Implementation.JsonSerializer.DeserializeToStrings(byte[] telemetryItemsData, bool compress = true) -> System.Collections.Generic.IEnumerable<string>

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 Microsoft.ApplicationInsights.TelemetryClient.TelemetryConfiguration.get -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
+static Microsoft.ApplicationInsights.Extensibility.Implementation.JsonSerializer.DeserializeToStrings(byte[] telemetryItemsData, bool compress = true) -> System.Collections.Generic.IEnumerable<string>

--- a/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,2 @@
 Microsoft.ApplicationInsights.TelemetryClient.TelemetryConfiguration.get -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
+static Microsoft.ApplicationInsights.Extensibility.Implementation.JsonSerializer.DeserializeToStrings(byte[] telemetryItemsData, bool compress = true) -> System.Collections.Generic.IEnumerable<string>

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/JsonSerializerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/JsonSerializerTest.cs
@@ -6,8 +6,10 @@
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
     using Newtonsoft.Json.Linq;
-    using System;    
+    using System;
+    using System.Collections.Generic;
     using System.IO;
+    using System.Linq;
     using System.Text;
 
     /// <summary>
@@ -83,12 +85,24 @@
         }
 
         [TestMethod]
-        public void IfCallConvertToArrayAndThanDeserializeYouGetSameResult()
+        public void VerifySerializeAndDeserialize()
         {
             byte[] array = JsonSerializer.ConvertToByteArray("test");
-            string result = JsonSerializer.Deserialize(array);
+            var result = new List<string>(JsonSerializer.DeserializeToStrings(array));
 
-            Assert.AreEqual("test", result);
+            Assert.AreEqual(1, result.Count());
+            Assert.AreEqual("test", result[0]);
+        }
+
+        [TestMethod]
+        public void VerifySerializeAndDeserializeHandlesEmptyString()
+        {
+            byte[] array = JsonSerializer.ConvertToByteArray("test1\n\n\ntest2");
+            var result = new List<string>(JsonSerializer.DeserializeToStrings(array));
+
+            Assert.AreEqual(2, result.Count());
+            Assert.AreEqual("test1", result[0]);
+            Assert.AreEqual("test2", result[1]);
         }
 
         [TestMethod]

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmission.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmission.cs
@@ -2,7 +2,9 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Drawing.Imaging;
     using System.IO;
+    using System.Linq;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
@@ -85,10 +87,9 @@
             else
             {
                 bool compress = this.ContentEncoding == JsonSerializer.CompressionType;
-                string[] payloadItems = JsonSerializer
-                    .Deserialize(this.Content, compress)
-                    .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-                return payloadItems.Length;
+
+                var payloadItems = JsonSerializer.DeserializeToStrings(this.Content, compress);
+                return payloadItems.Count();
             }
         }
     }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/PartialSuccessTransmissionPolicyTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/PartialSuccessTransmissionPolicyTest.cs
@@ -138,11 +138,9 @@
 
             transmitter.OnTransmissionSent(new TransmissionProcessedEventArgs(transmission, null, wrapper));
 
-            string[] newItems = JsonSerializer
-                .Deserialize(enqueuedTransmissions[0].Content)
-                .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+            var newItems = new List<string>(JsonSerializer.DeserializeToStrings(enqueuedTransmissions[0].Content));
 
-            Assert.AreEqual(2, newItems.Length);
+            Assert.AreEqual(2, newItems.Count);
             Assert.IsTrue(newItems[0].Contains("\"name\":\"1\""));
             Assert.IsTrue(newItems[1].Contains("\"name\":\"2\""));
         }

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -279,17 +279,17 @@
             {
                 // We have to decode the payload in order to split
                 bool compress = this.ContentEncoding == JsonSerializer.CompressionType;
-                string[] payloadItems = JsonSerializer
-                    .Deserialize(this.Content, compress)
-                    .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
-                int numItems = calculateLength(payloadItems.Length);
 
-                if (numItems != payloadItems.Length)
+                List<string> payloadItems = new List<string>(JsonSerializer.DeserializeToStrings(this.Content, compress));
+
+                int numItems = calculateLength(payloadItems.Count);
+
+                if (numItems != payloadItems.Count)
                 {
                     string itemsA = string.Empty;
                     string itemsB = string.Empty;
 
-                    for (int i = 0; i < payloadItems.Length; i++)
+                    for (int i = 0; i < payloadItems.Count; i++)
                     {
                         if (i < numItems)
                         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -99,6 +99,7 @@
         /// <param name="telemetryItemsData">Serialized telemetry items.</param>
         /// <param name="compress">Should deserialization also perform decompression.</param>
         /// <returns>Telemetry items serialized as a string.</returns>
+        [Obsolete("Use DeserializeToStrings() instead.")]
         public static string Deserialize(byte[] telemetryItemsData, bool compress = true)
         {
             var memoryStream = new MemoryStream(telemetryItemsData);
@@ -110,6 +111,35 @@
                     decompressedStream.CopyTo(str);
                     byte[] output = str.ToArray();
                     return Encoding.UTF8.GetString(output, 0, output.Length);
+                }
+            }
+        }
+
+        /// <summary>
+        /// Deserializes and decompress the telemetry items into a JSON string.
+        /// </summary>
+        /// <param name="telemetryItemsData">Serialized telemetry items.</param>
+        /// <param name="compress">Should deserialization also perform decompression.</param>
+        /// <returns>Telemetry items serialized as a string.</returns>
+        public static IEnumerable<string> DeserializeToStrings(byte[] telemetryItemsData, bool compress = true)
+        {
+            var memoryStream = new MemoryStream(telemetryItemsData);
+
+            using (Stream decompressedStream = compress ? (Stream)new GZipStream(memoryStream, CompressionMode.Decompress) : memoryStream)
+            {
+                using (StreamReader reader = new StreamReader(decompressedStream))
+                {
+                    string line = reader.ReadLine();
+
+                    while (line != null)
+                    {
+                        if (line.Length != 0)
+                        {
+                            yield return line;
+                        }
+
+                        line = reader.ReadLine();
+                    }
                 }
             }
         }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/JsonSerializer.cs
@@ -116,7 +116,7 @@
         }
 
         /// <summary>
-        /// Deserializes and decompress the telemetry items into a JSON string.
+        /// Deserializes and decompress the telemetry items into a JSON string. Empty lines are omitted.
         /// </summary>
         /// <param name="telemetryItemsData">Serialized telemetry items.</param>
         /// <param name="compress">Should deserialization also perform decompression.</param>
@@ -133,6 +133,7 @@
 
                     while (line != null)
                     {
+                        // this IF filters out empty lines.
                         if (line.Length != 0)
                         {
                             yield return line;

--- a/BASE/src/ServerTelemetryChannel/Implementation/PartialSuccessTransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/PartialSuccessTransmissionPolicy.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;
+    using System.Collections.Generic;
     using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Channel.Implementation;
@@ -48,17 +49,15 @@
             string newTransmissions = null;
             if (backendResponse.ItemsAccepted != backendResponse.ItemsReceived)
             {
-                string[] items = JsonSerializer
-                    .Deserialize(initialTransmission.Content)
-                    .Split(new[] { Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
+                List<string> items = new List<string>(JsonSerializer.DeserializeToStrings(initialTransmission.Content));
 
                 foreach (var error in backendResponse.Errors)
                 {
                     if (error != null)
                     {
-                        if (error.Index >= items.Length || error.Index < 0)
+                        if (error.Index >= items.Count || error.Index < 0)
                         {
-                            TelemetryChannelEventSource.Log.UnexpectedBreezeResponseWarning(items.Length, error.Index);
+                            TelemetryChannelEventSource.Log.UnexpectedBreezeResponseWarning(items.Count, error.Index);
                             continue;
                         }
 
@@ -93,7 +92,7 @@
         {
             if (args.Exception == null && (args.Response == null || args.Response.StatusCode == ResponseStatusCodes.Success))
             {
-                // We successfully sent transmittion
+                // We successfully sent transmission
                 this.backoffLogicManager.ResetConsecutiveErrors();
                 return;
             }


### PR DESCRIPTION
Issue #1993 

Fix for Frugal Tip G06.
LOH allocations are coming from our Json Deserializer.
> There are quite a few copies of uncompressed large data in memory. This hurts CPU, memory allocation, and working set. When the data is large enough, it can even lead to fragmentation and OutOfMemory exception.


## Changes
- Replace MemoryStream with StreamReader
- replace string[] with List<string>


### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
