### PR TITLE
change to which EventSources are subscribed

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -117,15 +117,17 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
                 var senders = new List<IDiagnosticsSender> { senderMock };
                 using (var listener = new DiagnosticsListener(senders))
                 {
+                    Assert.IsTrue(testEventSource.IsEnabled(), "Fail: testEventSource should be enabled.");
+
                     const EventKeywords AllKeyword = (EventKeywords)(-1);
                     // The default level is EventLevel.Error
-                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Error, AllKeyword));
+                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Error, AllKeyword), "Fail: testEventSource should be enabled for EventLevel.Error.");
 
                     // So Verbose should not be enabled
-                    Assert.IsFalse(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword));
+                    Assert.IsFalse(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword), "Fail: testEventSource should not be enabled for EventLevel.Verbose.");
 
                     listener.LogLevel = EventLevel.Verbose;
-                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword));
+                    Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword), "Fail: testEventSource should be enabled for EventLevel.Verbose.");
                 }
             }
         }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -130,7 +130,11 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
             }
         }
 
-        [EventSource(Name = "Microsoft-ApplicationInsights-" + nameof(TestEventSource))]
+        /// <summary>
+        /// Our <see cref="DiagnosticsListener"/> subscribes to a list of known EventSources. 
+        /// This class is meant to mimic one of those classes for testing purposes.
+        /// </summary>
+        [EventSource(Name = "Microsoft-ApplicationInsights-Core")]
         private class TestEventSource : EventSource
         {
         }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -55,10 +55,14 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
             var senders = new List<IDiagnosticsSender> { senderMock };
             using (var listener = new DiagnosticsListener(senders))
             {
+                const EventKeywords AllKeyword = (EventKeywords)(-1);
                 Assert.IsTrue(CoreEventSource.Log.IsEnabled(), "Fail: eventSource should be enabled.");
+                Assert.IsTrue(CoreEventSource.Log.IsEnabled(EventLevel.Error, AllKeyword), "Fail: Error is expected to be enabled by default");
+
 
                 listener.LogLevel = EventLevel.Informational;
-                
+                Assert.IsTrue(CoreEventSource.Log.IsEnabled(EventLevel.Informational, AllKeyword), "Fail: Informational is expected to be enabled");
+
                 CoreEventSource.Log.LogVerbose("Some verbose tracing");
                 Assert.AreEqual(0, senderMock.Messages.Count);
 
@@ -68,6 +72,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
                 senderMock.Messages.Clear();
 
                 listener.LogLevel = EventLevel.Verbose;
+                Assert.IsTrue(CoreEventSource.Log.IsEnabled(EventLevel.Verbose, AllKeyword), "Fail: Verbose is expected to be enabled");
+
                 CoreEventSource.Log.LogVerbose("Some verbose tracing");
                 Assert.AreEqual(1, senderMock.Messages.Count);
 
@@ -79,6 +85,8 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
                 senderMock.Messages.Clear();
 
                 listener.LogLevel = EventLevel.Error;
+                Assert.IsTrue(CoreEventSource.Log.IsEnabled(EventLevel.Error, AllKeyword), "Fail: Error is expected to be enabled");
+
                 CoreEventSource.Log.LogError("Logging an error");
 
                 // If you see the following assert fail, it's because another test has
@@ -98,39 +106,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
                 Assert.AreEqual(1, senderMock.Messages.Count);
             }
         }
-
-        //[TestMethod]
-        //public void TestEventSourceLogLevelWhenEventSourceIsAlreadyCreated()
-        //{
-        //    using (var testEventSource = new CoreEventSource())//= new TestEventSource())
-        //    {
-        //        var senderMock = new DiagnosticsSenderMock();
-        //        var senders = new List<IDiagnosticsSender> { senderMock };
-        //        using (var listener = new DiagnosticsListener(senders))
-        //        {
-        //            Assert.IsTrue(testEventSource.IsEnabled(), "Fail: testEventSource should be enabled.");
-
-        //            const EventKeywords AllKeyword = (EventKeywords)(-1);
-        //            // The default level is EventLevel.Error
-        //            Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Error, AllKeyword), "Fail: testEventSource should be enabled for EventLevel.Error.");
-
-        //            // So Verbose should not be enabled
-        //            Assert.IsFalse(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword), "Fail: testEventSource should not be enabled for EventLevel.Verbose.");
-
-        //            listener.LogLevel = EventLevel.Verbose;
-        //            Assert.IsTrue(testEventSource.IsEnabled(EventLevel.Verbose, AllKeyword), "Fail: testEventSource should be enabled for EventLevel.Verbose.");
-        //        }
-        //    }
-        //}
-
-        ///// <summary>
-        ///// Our <see cref="DiagnosticsListener"/> subscribes to a list of known EventSources. 
-        ///// This class is meant to mimic one of those classes for testing purposes.
-        ///// </summary>
-        //[EventSource(Name = "Microsoft-ApplicationInsights-Core")]
-        //private class TestEventSource : EventSource
-        //{
-        //}
     }
 }
+
 #pragma warning restore 612, 618  // obsolete TelemetryConfigration.Active

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/DiagnosticsListenerTest.cs
@@ -37,8 +37,6 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing
         [TestMethod]
         public void TestListenerWithDifferentSeverity()
         {
-            const EventKeywords AllKeyword = (EventKeywords)(-1);
-
             // Ensure there are no left-over DiagnosticTelemetryModules
             // from previous tests that will mess up this one.
             TelemetryConfiguration.Active.Dispose();

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -15,12 +15,12 @@
 
         private readonly ApplicationNameProvider nameProvider = new ApplicationNameProvider();
 
-#if NETSTANDARD2_0
-        private CoreEventSource()
+        internal CoreEventSource()
         {
+#if NETSTANDARD2_0
             this.IngestionResponseTimeCounter = new EventCounter("IngestionEndpoint-ResponseTimeMsec", this);
-        }
 #endif
+        }
 
         public static bool IsVerboseEnabled
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
@@ -105,6 +105,7 @@
                     case "Microsoft-ApplicationInsights-WindowsServer-Core":
                     case "Microsoft-ApplicationInsights-Extensibility-EventSourceListener":
                     case "Microsoft-ApplicationInsights-AspNetCore":
+                    case "Microsoft-ApplicationInsights-LoggerProvider":
                     case "Microsoft-AspNet-Telemetry-Correlation": // https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/blob/master/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
                         return true;
                     default:

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
@@ -57,7 +57,7 @@
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if (this.ShouldSubscribe(eventSource))
+            if (ShouldSubscribe(eventSource))
             {
                 // If our constructor hasn't run yet (we're in a callback from the base class
                 // constructor), just make a note of the event source. Otherwise logLevel is
@@ -84,7 +84,7 @@
         /// <summary>
         /// This method checks if the given EventSource Name matches known EventSources that we want to subscribe to.
         /// </summary>
-        private bool ShouldSubscribe(EventSource eventSource)
+        private static bool ShouldSubscribe(EventSource eventSource)
         {
             if (eventSource.Name.StartsWith("Microsoft-A", StringComparison.Ordinal))
             {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
@@ -57,8 +57,7 @@
 
         protected override void OnEventSourceCreated(EventSource eventSource)
         {
-            if (eventSource.Name.StartsWith("Microsoft-ApplicationInsights-", StringComparison.Ordinal) ||
-                eventSource.Name.Equals("Microsoft-AspNet-Telemetry-Correlation", StringComparison.Ordinal))
+            if (this.ShouldSubscribe(eventSource))
             {
                 // If our constructor hasn't run yet (we're in a callback from the base class
                 // constructor), just make a note of the event source. Otherwise logLevel is
@@ -80,6 +79,40 @@
             }
 
             base.OnEventSourceCreated(eventSource);
+        }
+
+        /// <summary>
+        /// This method checks if the given EventSource Name matches known EventSources that we want to subscribe to.
+        /// </summary>
+        private bool ShouldSubscribe(EventSource eventSource)
+        {
+            if (eventSource.Name.StartsWith("Microsoft-A", StringComparison.Ordinal))
+            {
+                switch (eventSource.Name)
+                {
+                    case "Microsoft-ApplicationInsights-Core": 
+                    case "Microsoft-ApplicationInsights-Data": 
+                    case "Microsoft-ApplicationInsights-WindowsServer-TelemetryChannel": 
+                    case "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Dependency":
+                    case "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Web":
+                    case "Microsoft-ApplicationInsights-Extensibility-DependencyCollector":
+                    case "Microsoft-ApplicationInsights-Extensibility-EventCounterCollector":
+                    case "Microsoft-ApplicationInsights-Extensibility-HostingStartup":
+                    case "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector":
+                    case "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector-QuickPulse":
+                    case "Microsoft-ApplicationInsights-Extensibility-Web":
+                    case "Microsoft-ApplicationInsights-Extensibility-WindowsServer":
+                    case "Microsoft-ApplicationInsights-WindowsServer-Core":
+                    case "Microsoft-ApplicationInsights-Extensibility-EventSourceListener":
+                    case "Microsoft-ApplicationInsights-AspNetCore":
+                    case "Microsoft-AspNet-Telemetry-Correlation": // https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/blob/master/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+
+            return false;
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnosticsEventListener.cs
@@ -90,22 +90,23 @@
             {
                 switch (eventSource.Name)
                 {
-                    case "Microsoft-ApplicationInsights-Core": 
-                    case "Microsoft-ApplicationInsights-Data": 
-                    case "Microsoft-ApplicationInsights-WindowsServer-TelemetryChannel": 
-                    case "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Dependency":
-                    case "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Web":
-                    case "Microsoft-ApplicationInsights-Extensibility-DependencyCollector":
-                    case "Microsoft-ApplicationInsights-Extensibility-EventCounterCollector":
-                    case "Microsoft-ApplicationInsights-Extensibility-HostingStartup":
-                    case "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector":
-                    case "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector-QuickPulse":
-                    case "Microsoft-ApplicationInsights-Extensibility-Web":
-                    case "Microsoft-ApplicationInsights-Extensibility-WindowsServer":
-                    case "Microsoft-ApplicationInsights-WindowsServer-Core":
-                    case "Microsoft-ApplicationInsights-Extensibility-EventSourceListener":
-                    case "Microsoft-ApplicationInsights-AspNetCore":
-                    case "Microsoft-ApplicationInsights-LoggerProvider":
+                    case "Microsoft-ApplicationInsights-Core": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+                    case "Microsoft-ApplicationInsights-WindowsServer-TelemetryChannel": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/BASE/src/ServerTelemetryChannel/Implementation/TelemetryChannelEventSource.cs
+
+                    // AppMapCorrelation has a shared partial class: https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/Common/AppMapCorrelationEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Dependency": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AppMapCorrelationEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Web": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/Web/Web/Implementation/AppMapCorrelationEventSource.cs
+                    
+                    case "Microsoft-ApplicationInsights-Extensibility-DependencyCollector": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DependencyCollectorEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-EventCounterCollector": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/EventCounterCollector/EventCounterCollector/EventCounterCollectorEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/PerformanceCollectorEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-PerformanceCollector-QuickPulse": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-Web": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/Web/Web/Implementation/WebEventSource.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-WindowsServer": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/WindowsServer/WindowsServer/Implementation/WindowsServerEventSource.cs
+                    case "Microsoft-ApplicationInsights-WindowsServer-Core": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/WEB/Src/WindowsServer/WindowsServer/Implementation/MetricManager.cs
+                    case "Microsoft-ApplicationInsights-Extensibility-EventSourceListener": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/LOGGING/src/EventSource.Shared/EventSource.Shared/Implementation/EventSourceListenerEventSource.cs
+                    case "Microsoft-ApplicationInsights-AspNetCore": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/master/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensibility/Implementation/Tracing/AspNetCoreEventSource.cs
+                    case "Microsoft-ApplicationInsights-LoggerProvider": // https://github.com/microsoft/ApplicationInsights-dotnet/blob/develop/LOGGING/src/ILogger/ApplicationInsightsLoggerEventSource.cs
                     case "Microsoft-AspNet-Telemetry-Correlation": // https://github.com/aspnet/Microsoft.AspNet.TelemetryCorrelation/blob/master/src/Microsoft.AspNet.TelemetryCorrelation/AspNetTelemetryCorrelationEventSource.cs
                         return true;
                     default:

--- a/examples/ETW/Readme.md
+++ b/examples/ETW/Readme.md
@@ -31,6 +31,7 @@ Vance Morrison's blog has several articles for getting started:
 |             | Microsoft-ApplicationInsights-WindowsServer-Core                           	|b38dc757-fc28-52f1-9241-fd6310c28590|
 | | | |
 | Logging SDK | Microsoft-ApplicationInsights-Extensibility-EventSourceListener            	|e0b8ecfa-7c08-54f7-ac08-3cf0f7ba965e|
+|             | Microsoft-ApplicationInsights-LoggerProvider					          	|95aa10d3-5f9e-5213-9cdb-5de65b5dca0d|
 | | | |
 | AspNetCore SDK    | Microsoft-ApplicationInsights-AspNetCore                              |dbf4c9d9-6cb3-54e3-0a54-9d138a74b116|
 | | | |
@@ -43,10 +44,18 @@ Vance Morrison's blog has several articles for getting started:
 |             	| Microsoft-ApplicationInsights-Redfield-VmExtensionHandler                	|7014a441-75d7-444f-b1c6-4b2ec9b06f20   <sup>*1</sup>|
 
 
-
 ### Footnotes
 1. These are custom defined GUIDS. Because they are not generated from the provider name they must be subscribed to via the GUID.
 
+
+### Developer Note
+Provider GUIDs are determined at runtime based on the Provider Name.
+You can lookup any GUID for a Provider Name by using:
+```
+var session = new TraceEventSession("test");
+session.EnableProvider(providerName: "Microsoft-ApplicationInsights-Core");
+```
+Then Debug to inspect the private field: `session.m_enabledProviders`
 
 
 ## Tools to collect ETW

--- a/examples/ETW/Readme.md
+++ b/examples/ETW/Readme.md
@@ -34,6 +34,8 @@ Vance Morrison's blog has several articles for getting started:
 | | | |
 | AspNetCore SDK    | Microsoft-ApplicationInsights-AspNetCore                              |dbf4c9d9-6cb3-54e3-0a54-9d138a74b116|
 | | | |
+| AspNet.TelemetryCorrelation    | Microsoft-AspNet-Telemetry-Correlation                   |ace2021e-e82c-5502-d81d-657f27612673|
+| | | |
 | Extensions  | Microsoft-ApplicationInsights-FrameworkLightup                             	|323adc25-e39b-5c87-8658-2c1af1a92dc5   <sup>*1</sup>|
 |             | Microsoft-ApplicationInsights-IIS-ManagedHttpModuleHelper                  	|61f6ca3b-4b5f-5602-fa60-759a2a2d1fbd   <sup>*1</sup>|
 |             | Microsoft-ApplicationInsights-Redfield-Configurator                        	|090fc833-b744-4805-a6dd-4cb0b840a11f   <sup>*1</sup>|

--- a/examples/ETW/Readme.md
+++ b/examples/ETW/Readme.md
@@ -16,14 +16,12 @@ Vance Morrison's blog has several articles for getting started:
 | Repo       	| Provider Name                                                              	| Provider Guid |
 |------------	|----------------------------------------------------------------------------	|---------------|
 | Base SDK    | Microsoft-ApplicationInsights-Core                                         	|74af9f20-af6a-5582-9382-f21f674fb271|
-|             | Microsoft-ApplicationInsights-Data                                         	|a62adddb-6b4b-519d-7ba1-f983d81623e0|
 |             | Microsoft-ApplicationInsights-WindowsServer-TelemetryChannel               	|4c4280fb-382a-56be-9a13-fab0d03395f6|
 | | | |
 | Web SDK     | Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Dependency   	|08037ff3-aed4-5081-a6e0-f05fa0bd1f42|
 |             | Microsoft-ApplicationInsights-Extensibility-AppMapCorrelation-Web          	|0a458c93-c7fb-5fbe-1135-21b01e192abc|
 |             | Microsoft-ApplicationInsights-Extensibility-DependencyCollector            	|9e925f53-f61b-51a7-d10f-1148a547b70f|
 |             | Microsoft-ApplicationInsights-Extensibility-EventCounterCollector         	|3a5cd921-6470-5a93-a62f-5827813b3968|
-|             | Microsoft-ApplicationInsights-Extensibility-HostingStartup                 	|8be90d99-6348-569a-0517-642982a0623b|
 |             | Microsoft-ApplicationInsights-Extensibility-PerformanceCollector           	|47e5de30-9965-58bd-dfc8-64c697aa1908|
 |             | Microsoft-ApplicationInsights-Extensibility-PerformanceCollector-QuickPulse	|70faf222-f29d-5dee-433d-d3b77846888e|
 |             | Microsoft-ApplicationInsights-Extensibility-Web                            	|d6a4f609-0e40-51c8-0344-8d1a0c91cb10|


### PR DESCRIPTION
We currently collect any EventSource messages in which the source name starts with "Microsoft-ApplicationInsights-". This can collect other non SDK products that we don't want to collect.

## Changes
- Replace a string.StartsWith with specific string match names of EventSources

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
