### PR TITLE
update version of Microsoft.AspNetCore.Hosting to 2.1.0 (and fix major test bug)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - [Fixed a bug which caused ApplicationInsights.config file being read for populating TelemetryConfiguration in .NET Core projects](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1795)
 - [Remove System.RunTime EventCounters by default](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2009)
 - [Ingestion service data delivery status](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1887)
+- [Update version of Microsoft.AspNetCore.Hosting to 2.1.0](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1902)
 
 ## Version 2.15.0-beta2
 - [Read all properties of ApplicationInsightsServiceOptions from IConfiguration](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1882)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -37,7 +37,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'netstandard2.0' AND '$(TargetFramework)' != 'net461' ">
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="1.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />    
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="1.1.2" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461' ">
@@ -54,8 +54,7 @@
 
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461' ">
-    <!-- Need to update this to 2.1.1, but testing with the lower version. -->
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="1.1.3" />
+    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' ">

--- a/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
@@ -35,17 +35,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">

--- a/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
+++ b/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
@@ -14,9 +14,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
     <PackageReference Include="System.Reactive.Linq" Version="3.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/NETCORE/test/FunctionalTests.Utils/InProcessServer.cs
+++ b/NETCORE/test/FunctionalTests.Utils/InProcessServer.cs
@@ -144,9 +144,6 @@ namespace FunctionalTests.Utils
 
         private string Start(string assemblyName)
         {
-            var aiOptions = new ApplicationInsightsServiceOptions();
-            aiOptions.InstrumentationKey = IKey;
-            this.configureApplicationInsights?.Invoke(aiOptions);
             var builder = new WebHostBuilder()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseUrls(this.BaseHost)
@@ -166,10 +163,6 @@ namespace FunctionalTests.Utils
                 {
                     services.Configure<ApplicationInsightsServiceOptions>(this.configureApplicationInsights);
                 }
-
-                // var endpointAddress = new EndpointAddress();
-                // services.AddSingleton<EndpointAddress>(endpointAddress);
-                // services.AddApplicationInsightsTelemetry(aiOptions);
             });
 
             if (this.configureHost != null)

--- a/NETCORE/test/FunctionalTests.Utils/InProcessServer.cs
+++ b/NETCORE/test/FunctionalTests.Utils/InProcessServer.cs
@@ -7,7 +7,10 @@ namespace FunctionalTests.Utils
     using System;
     using System.IO;
     using System.Net;
+    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+    using Microsoft.ApplicationInsights.Channel;
     using Microsoft.AspNetCore.Hosting;
+    using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.DependencyInjection;
     using Xunit.Abstractions;
 
@@ -41,8 +44,10 @@ namespace FunctionalTests.Utils
         private TelemetryHttpListenerObservable listener;
         private readonly Func<IWebHostBuilder, IWebHostBuilder> configureHost;
         private readonly Action<IServiceCollection> configureServices;
+        private readonly Action<ApplicationInsightsServiceOptions> configureApplicationInsights;
 
-        public InProcessServer(string assemblyName, ITestOutputHelper output, Func<IWebHostBuilder, IWebHostBuilder> configureHost = null, Action<IServiceCollection> configureServices = null)
+        public InProcessServer(string assemblyName, ITestOutputHelper output,
+            Action<ApplicationInsightsServiceOptions> configureApplicationInsights = null)
         {
             this.output = output;
 
@@ -51,6 +56,7 @@ namespace FunctionalTests.Utils
             this.url = "http://" + machineName + ":" + random.Next(5000, 14000).ToString();
             this.configureHost = configureHost;
             this.configureServices = configureServices;
+            this.configureApplicationInsights = configureApplicationInsights;
             this.httpListenerConnectionString = LauchApplicationAndStartListener(assemblyName);
         }
 
@@ -79,7 +85,7 @@ namespace FunctionalTests.Utils
             {
                 throw new Exception("Unable to start listener after 3 attempts. Failing. Read logs above for details about the exceptions.");
             }
-            
+
             return listenerConnectionString;
         }
 
@@ -138,12 +144,16 @@ namespace FunctionalTests.Utils
 
         private string Start(string assemblyName)
         {
+            var aiOptions = new ApplicationInsightsServiceOptions();
+            aiOptions.InstrumentationKey = IKey;
+            this.configureApplicationInsights?.Invoke(aiOptions);
             var builder = new WebHostBuilder()
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseUrls(this.BaseHost)
                 .UseKestrel()
                 .UseStartup(assemblyName)
                 .UseEnvironment("Production");
+
             builder.ConfigureServices(services =>
             {
                 services.AddSingleton<IApplicationIdProvider>(provider =>
@@ -151,8 +161,17 @@ namespace FunctionalTests.Utils
                     {
                         Defined = new Dictionary<string, string> {[IKey] = AppId}
                     });
+
+                if (this.configureApplicationInsights != null)
+                {
+                    services.Configure<ApplicationInsightsServiceOptions>(this.configureApplicationInsights);
+                }
+
+                // var endpointAddress = new EndpointAddress();
+                // services.AddSingleton<EndpointAddress>(endpointAddress);
+                // services.AddApplicationInsightsTelemetry(aiOptions);
             });
-            
+
             if (this.configureHost != null)
             {
                 builder = this.configureHost(builder);
@@ -192,7 +211,7 @@ namespace FunctionalTests.Utils
             if (this.listener != null)
             {
                 output.WriteLine(string.Format("{0}: Stopping listener at: {1}", DateTime.Now.ToString("G"), this.httpListenerConnectionString));
-                this.listener.Stop();                
+                this.listener.Stop();
             }
         }
     }

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/MultipleWebHostsTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/MultipleWebHostsTests.cs
@@ -16,7 +16,7 @@ namespace FunctionalTests.WebApi.Tests.FunctionalTest
     {
         private readonly string assemblyName;
         private const string requestPath = "/api/dependency";
-        
+
         public MultipleWebHostsTests(ITestOutputHelper output) : base(output)
         {
             this.assemblyName = this.GetType().GetTypeInfo().Assembly.GetName().Name;
@@ -109,7 +109,7 @@ namespace FunctionalTests.WebApi.Tests.FunctionalTest
                 Assert.NotNull(config1.TelemetryChannel);
 
                 this.ExecuteRequest(server1.BaseHost + requestPath);
-                
+
                 var telemetry = server1.Listener.ReceiveItems(TestListenerTimeoutInMs);
                 this.DebugTelemetryItems(telemetry);
 
@@ -142,16 +142,7 @@ namespace FunctionalTests.WebApi.Tests.FunctionalTest
             setActive.Invoke(null, new object[] { TelemetryConfiguration.CreateDefault() });
 
             var activeConfig = TelemetryConfiguration.Active;
-
-            using (var server = new InProcessServer(assemblyName, this.output, builder =>
-            {
-                return builder.ConfigureServices(
-                    services =>
-                    {
-                        services.AddApplicationInsightsTelemetry(
-                            o => o.EnableActiveTelemetryConfigurationSetup = true);
-                    });
-            }))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableActiveTelemetryConfigurationSetup = true))
             {
                 this.ExecuteRequest(server.BaseHost + requestPath);
 

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCollectionTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCollectionTests.cs
@@ -71,7 +71,7 @@
                 expectedRequestTelemetry.Url = new System.Uri(server.BaseHost + RequestPath);
 
                 Dictionary<string, string> requestHeaders = new Dictionary<string, string>()
-                {                    
+                {
                     { "Request-Context", "appId=value"},
                 };
 
@@ -126,15 +126,7 @@
         [Fact]
         public void TestNoHeadersInjectedInResponseWhenConfiguredAndNoIncomingRequestContext()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    services.AddApplicationInsightsTelemetry(options => { options.RequestCollectionOptions.InjectResponseHeaders = false; });
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.RequestCollectionOptions.InjectResponseHeaders = false))
             {
                 const string RequestPath = "/api/values/1";
 
@@ -151,15 +143,7 @@
         [Fact]
         public void TestNoHeadersInjectedInResponseWhenConfiguredAndWithIncomingRequestContext()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    services.AddApplicationInsightsTelemetry(options => { options.RequestCollectionOptions.InjectResponseHeaders = false; });
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.RequestCollectionOptions.InjectResponseHeaders = false))
             {
                 const string RequestPath = "/api/values/1";
 

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
@@ -27,17 +27,7 @@
         [Fact]
         public void TestRequestWithNoCorrelationHeaders()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    services.AddApplicationInsightsTelemetry();
-                    // disable Dependency tracking (i.e. header injection)
-                    services.Remove(services.FirstOrDefault(sd => sd.ImplementationType == typeof(DependencyTrackingTelemetryModule)));                    
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
             {
                 const string RequestPath = "/api/values/1";
 
@@ -65,18 +55,7 @@
         [Fact]
         public void TestRequestWithRequestIdHeader()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    var aiOptions = new ApplicationInsightsServiceOptions();
-                    // disable Dependency tracking (i.e. header injection)
-                    aiOptions.EnableDependencyTrackingTelemetryModule = false;
-                    services.AddApplicationInsightsTelemetry(aiOptions);
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
             {
                 const string RequestPath = "/api/values";
 
@@ -106,18 +85,7 @@
         [Fact]
         public void TestRequestWithNonW3CCompatibleRequestIdHeader()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    var aiOptions = new ApplicationInsightsServiceOptions();
-                    // disable Dependency tracking (i.e. header injection)
-                    aiOptions.EnableDependencyTrackingTelemetryModule = false;
-                    services.AddApplicationInsightsTelemetry(aiOptions);
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
             {
                 const string RequestPath = "/api/values";
 
@@ -148,18 +116,7 @@
         [Fact]
         public void TestRequestWithNonW3CCompatibleNonHierrachicalRequestIdHeader()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    var aiOptions = new ApplicationInsightsServiceOptions();
-                    // disable Dependency tracking (i.e. header injection)
-                    aiOptions.EnableDependencyTrackingTelemetryModule = false;
-                    services.AddApplicationInsightsTelemetry(aiOptions);
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
             {
                 const string RequestPath = "/api/values";
 
@@ -190,17 +147,7 @@
         [Fact]
         public void TestRequestWithTraceParentHeader()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    services.AddApplicationInsightsTelemetry();
-                    // disable Dependency tracking (i.e. header injection)
-                    services.Remove(services.FirstOrDefault(sd => sd.ImplementationType == typeof(DependencyTrackingTelemetryModule)));
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
             {
                 const string RequestPath = "/api/values";
 
@@ -235,17 +182,7 @@
         [Fact]
         public void TestRequestWithRequestIdAndTraceParentHeader()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    services.AddApplicationInsightsTelemetry();
-                    // disable Dependency tracking (i.e. header injection)
-                    services.Remove(services.FirstOrDefault(sd => sd.ImplementationType == typeof(DependencyTrackingTelemetryModule)));
-                });
-            }
-
-            using (var server = new InProcessServer(assemblyName, this.output, Config))
+            using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
             {
                 const string RequestPath = "/api/values";
 
@@ -282,23 +219,13 @@
         [Fact]
         public void TestRequestWithRequestIdAndTraceParentHeaderWithW3CDisabled()
         {
-            IWebHostBuilder Config(IWebHostBuilder builder)
-            {
-                return builder.ConfigureServices(services =>
-                {
-                    services.AddApplicationInsightsTelemetry();
-
-                    // disable Dependency tracking (i.e. header injection)
-                    services.Remove(services.FirstOrDefault(sd => sd.ImplementationType == typeof(DependencyTrackingTelemetryModule)));
-                });
-            }
             try
             {
                 // disable w3c
                 Activity.DefaultIdFormat = ActivityIdFormat.Hierarchical;
                 Activity.ForceDefaultIdFormat = true;
 
-                using (var server = new InProcessServer(assemblyName, this.output, Config))
+                using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableDependencyTrackingTelemetryModule = false))
                 {
                     const string RequestPath = "/api/values";
 

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestDependencyCorrelationTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestDependencyCorrelationTests.cs
@@ -42,24 +42,7 @@
         {
             const string RequestPath = "/api/values";
 
-            using (var server = new InProcessServer(assemblyName, this.output, builder =>
-            {
-                return builder.ConfigureServices(
-                    services =>
-                    {
-                        services.AddApplicationInsightsTelemetry(
-                            o => o.RequestCollectionOptions.EnableW3CDistributedTracing = true);
-
-                        // enable headers injection on localhost
-                        var dependencyModuleConfigFactoryDescriptor = services.Where(sd => sd.ServiceType == typeof(ITelemetryModuleConfigurator));
-                        services.Remove(dependencyModuleConfigFactoryDescriptor.First());
-
-                        services.ConfigureTelemetryModule<DependencyTrackingTelemetryModule>((module, o) =>
-                        {
-                            module.EnableW3CHeadersInjection = true;
-                        });
-                    });
-            }))
+            using (var server = new InProcessServer(assemblyName, this.output))
             {
                 DependencyTelemetry expected = new DependencyTelemetry
                 {

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -24,12 +24,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
     <PackageReference Include="xunit" Version="2.3.1" />

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/Startup.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/Startup.cs
@@ -21,12 +21,8 @@ namespace FunctionalTests.WebApi.Tests
         {
             var endpointAddress = new EndpointAddress();
             services.AddSingleton<EndpointAddress>(endpointAddress);
-
-            var builder = new ConfigurationBuilder();
-            builder.AddApplicationInsightsSettings(instrumentationKey: InProcessServer.IKey, endpointAddress: endpointAddress.ConnectionString, developerMode: true);
-            services.AddSingleton(typeof(ITelemetryChannel), new InMemoryChannel());
-            services.AddApplicationInsightsTelemetry(builder.Build());
-
+            services.AddSingleton(typeof(ITelemetryChannel), new InMemoryChannel() { EndpointAddress = endpointAddress.ConnectionString, DeveloperMode = true });
+            services.AddApplicationInsightsTelemetry(InProcessServer.IKey);
             services.AddMvc();
         }
 
@@ -37,7 +33,7 @@ namespace FunctionalTests.WebApi.Tests
             {
                 app.UseDeveloperExceptionPage();
             }
-            
+
             app.UseMvc(routes =>
             {
                 // Add the following route for porting Web API 2 controllers.


### PR DESCRIPTION
Fix Issue #1902 .

## Changes
- Update Microsoft.AspNetCore.Hosting to v2.1.0
- Fix major test bug; multiple test hosts were being created which affected test outcome. Fix is to migrate to Integration Tests.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
