### PR TITLE
Emit stack trace when TrackExceptionsAsExceptionTelemetry is set to f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ﻿# Changelog
 
 ## VNext
-- [ILogger LogError and LogWarning variants write exception StackTrace when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2065)
+- [ILogger LogError and LogWarning variants write exception `ExceptionStackTrace` when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2065)
 
 ## Version 2.15.0
 - EventCounterCollector module does not add AggregationInterval as a dimension to the metric.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ﻿# Changelog
 
 ## VNext
-
+- [ILogger LogError and LogWarning variants write exception StackTrace when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2065)
 
 ## Version 2.15.0
 - EventCounterCollector module does not add AggregationInterval as a dimension to the metric.

--- a/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
+++ b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
@@ -96,7 +96,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                         this.PopulateTelemetry(traceTelemetry, state, eventId);
                         if (exception != null)
                         {
-                            traceTelemetry.Properties.Add("ExceptionMessage", exception.Message);
+                            traceTelemetry.Properties.Add("ExceptionMessage", exception.ToInvariantString());
                         }
 
                         this.telemetryClient.TrackTrace(traceTelemetry);

--- a/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
+++ b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
@@ -96,7 +96,8 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                         this.PopulateTelemetry(traceTelemetry, state, eventId);
                         if (exception != null)
                         {
-                            traceTelemetry.Properties.Add("ExceptionMessage", exception.ToInvariantString());
+                            traceTelemetry.Properties.Add("ExceptionMessage", exception.Message);
+                            traceTelemetry.Properties.Add("ExceptionStackTrace", exception.ToInvariantString());
                         }
 
                         this.telemetryClient.TrackTrace(traceTelemetry);

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -144,7 +144,7 @@ namespace Microsoft.ApplicationInsights
             
             Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"].Contains("StackTraceEnabled"));
 
-            Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"].Length > "StackTraceEnabled".Length);
+            Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties.ContainsKey("ExceptionStackTrace"));
 
             void ThrowException()
             {

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -121,6 +121,16 @@ namespace Microsoft.ApplicationInsights
             ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
 
             testLogger.LogInformation("Testing");
+
+            try
+            {
+                ThrowException();
+            }
+            catch (Exception ex)
+            {
+                testLogger.LogError(ex, "LoggerMessage");
+            }
+
             testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
 
             Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
@@ -132,7 +142,14 @@ namespace Microsoft.ApplicationInsights
             Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as TraceTelemetry).SeverityLevel);
             Assert.AreEqual("LoggerMessage", (itemsReceived[1] as TraceTelemetry).Message);
             
-            Assert.AreEqual("ExceptionMessage", (itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"]);
+            Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"].Contains("StackTraceEnabled"));
+
+            Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"].Length > "StackTraceEnabled".Length);
+
+            void ThrowException()
+            {
+                throw new Exception("StackTraceEnabled");
+            }
         }
 
         /// <summary>

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -134,8 +134,6 @@ namespace Microsoft.ApplicationInsights
                 testLogger.LogError(ex, "LoggerMessage");
             }
 
-            testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
-
             Assert.IsInstanceOfType(itemsReceived[0], typeof(TraceTelemetry));
             Assert.IsInstanceOfType(itemsReceived[1], typeof(TraceTelemetry));
 

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -10,6 +10,7 @@ namespace Microsoft.ApplicationInsights
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Logging.ApplicationInsights;
@@ -122,12 +123,14 @@ namespace Microsoft.ApplicationInsights
 
             testLogger.LogInformation("Testing");
 
+            Exception trackingException = null;
             try
             {
                 ThrowException();
             }
             catch (Exception ex)
             {
+                trackingException = ex;
                 testLogger.LogError(ex, "LoggerMessage");
             }
 
@@ -146,9 +149,8 @@ namespace Microsoft.ApplicationInsights
 
             Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties.ContainsKey("ExceptionStackTrace"));
 
-            // This test will break if the code is moved around.
             Assert.AreEqual(
-                "System.Exception: StackTraceEnabled\r\n   at Microsoft.ApplicationInsights.ILoggerIntegrationTests.<ApplicationInsightsLoggerLogsExceptionAsTraceWhenSwitchIsFalse>g__ThrowException|2_2() in E:\\Code\\ApplicationInsights-dotnet-ramjsing\\LOGGING\\test\\ILogger.Tests\\ILoggerIntegrationTests.cs:line 156\r\n   at Microsoft.ApplicationInsights.ILoggerIntegrationTests.ApplicationInsightsLoggerLogsExceptionAsTraceWhenSwitchIsFalse() in E:\\Code\\ApplicationInsights-dotnet-ramjsing\\LOGGING\\test\\ILogger.Tests\\ILoggerIntegrationTests.cs:line 127",
+                trackingException.ToInvariantString(),
                 (itemsReceived[1] as TraceTelemetry).Properties["ExceptionStackTrace"]);
 
             void ThrowException()

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -146,6 +146,11 @@ namespace Microsoft.ApplicationInsights
 
             Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties.ContainsKey("ExceptionStackTrace"));
 
+            // This test will break if the code is moved around.
+            Assert.AreEqual(
+                "System.Exception: StackTraceEnabled\r\n   at Microsoft.ApplicationInsights.ILoggerIntegrationTests.<ApplicationInsightsLoggerLogsExceptionAsTraceWhenSwitchIsFalse>g__ThrowException|2_2() in E:\\Code\\ApplicationInsights-dotnet-ramjsing\\LOGGING\\test\\ILogger.Tests\\ILoggerIntegrationTests.cs:line 156\r\n   at Microsoft.ApplicationInsights.ILoggerIntegrationTests.ApplicationInsightsLoggerLogsExceptionAsTraceWhenSwitchIsFalse() in E:\\Code\\ApplicationInsights-dotnet-ramjsing\\LOGGING\\test\\ILogger.Tests\\ILoggerIntegrationTests.cs:line 127",
+                (itemsReceived[1] as TraceTelemetry).Properties["ExceptionStackTrace"]);
+
             void ThrowException()
             {
                 throw new Exception("StackTraceEnabled");


### PR DESCRIPTION
Fix Issue #2064.

## Changes
ILogger logs StackTraces in TraceTelemetry when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
