### PR TITLE
Avoid emitting {OriginalFormat} as a property name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [ILogger LogError and LogWarning variants write exception `ExceptionStackTrace` when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2065)
+- [The `{OriginalFormat}` field in ILogger will be emitted as `OriginalFormat` with the braces removed](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2071)
 
 ## Version 2.15.0
 - EventCounterCollector module does not add AggregationInterval as a dimension to the metric.

--- a/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
+++ b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
@@ -174,7 +174,14 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                 {
                     foreach (KeyValuePair<string, object> item in stateDictionary)
                     {
-                        dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                        if (item.Key == "{OriginalFormat}")
+                        {
+                            dict["OriginalFormat"] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                        }
+                        else
+                        {
+                            dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                        }
                     }
                 }
 


### PR DESCRIPTION
Customers using the LoggerProvider was surprised by the fact that the ILogger traits `{OriginalFormat}` was exported directly.

## Changes

This PR has provided a workaround to special case the name by removing the braces.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
