### PR TITLE
ILogger provider populates structured logging key/values irrespective…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - [ILogger LogError and LogWarning variants write exception `ExceptionStackTrace` when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2065)
 - [The `{OriginalFormat}` field in ILogger will be emitted as `OriginalFormat` with the braces removed](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2071)
+- ApplicationInsightsLoggerProvider populates structured logging key/values irrespective of whether Scopes are enabled or not.
 
 ## Version 2.15.0
 - EventCounterCollector module does not add AggregationInterval as a dimension to the metric.

--- a/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
+++ b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
@@ -1,6 +1,6 @@
 ﻿// -----------------------------------------------------------------------
 // <copyright file="ApplicationInsightsLogger.cs" company="Microsoft">
-// Copyright (c) Microsoft Corporation. 
+// Copyright (c) Microsoft Corporation.
 // All rights reserved.  2013
 // </copyright>
 // -----------------------------------------------------------------------
@@ -168,23 +168,23 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                 dict["EventName"] = eventId.Name;
             }
 
-            if (this.applicationInsightsLoggerOptions.IncludeScopes)
+            if (state is IReadOnlyCollection<KeyValuePair<string, object>> stateDictionary)
             {
-                if (state is IReadOnlyCollection<KeyValuePair<string, object>> stateDictionary)
+                foreach (KeyValuePair<string, object> item in stateDictionary)
                 {
-                    foreach (KeyValuePair<string, object> item in stateDictionary)
+                    if (item.Key == "{OriginalFormat}")
                     {
-                        if (item.Key == "{OriginalFormat}")
-                        {
-                            dict["OriginalFormat"] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
-                        }
-                        else
-                        {
-                            dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
-                        }
+                        dict["OriginalFormat"] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                    }
+                    else
+                    {
+                        dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
                     }
                 }
+            }
 
+            if (this.applicationInsightsLoggerOptions.IncludeScopes)
+            {
                 if (this.ExternalScopeProvider != null)
                 {
                     StringBuilder stringBuilder = new StringBuilder();

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -32,7 +32,7 @@ namespace Microsoft.ApplicationInsights
         {
             List<ITelemetry> itemsReceived = new List<ITelemetry>();
 
-            // Disable scope
+            // Scopes are enabled.
             IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
                 (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
                 configureTelemetryConfiguration: null,

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -24,6 +24,54 @@ namespace Microsoft.ApplicationInsights
     public class ILoggerIntegrationTests
     {
         /// <summary>
+        /// Ensures that <see cref="ApplicationInsightsLogger"/> populates params for structured logging into custom properties <see cref="ILogger"/>.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void ApplicationInsightsLoggerPopulateStructureLoggingParamsIntoCustomProperties()
+        {
+            List<ITelemetry> itemsReceived = new List<ITelemetry>();
+
+            // Disable scope
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
+                configureTelemetryConfiguration: null,
+                configureApplicationInsightsOptions: (appInsightsLoggerOptions) => appInsightsLoggerOptions.IncludeScopes = true);
+
+            ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+            testLogger.LogInformation("Testing structured with {CustomerName} {Age}", "TestCustomerName", 20);
+
+            Assert.AreEqual("Testing structured with TestCustomerName 20", (itemsReceived[0] as TraceTelemetry).Message);
+            var customProperties = (itemsReceived[0] as TraceTelemetry).Properties;
+            Assert.IsTrue(customProperties["CustomerName"].Equals("TestCustomerName"));
+            Assert.IsTrue(customProperties["Age"].Equals("20"));
+        }
+
+        /// <summary>
+        /// Ensures that <see cref="ApplicationInsightsLogger"/> populates params for structured logging into custom properties <see cref="ILogger"/>.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void ApplicationInsightsLoggerPopulateStructureLoggingParamsIntoCustomPropertiesWhenScopeDisabled()
+        {
+            List<ITelemetry> itemsReceived = new List<ITelemetry>();
+
+            // Disable scope
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
+                (telemetryItem, telemetryProcessor) => itemsReceived.Add(telemetryItem),
+                configureTelemetryConfiguration: null,
+                configureApplicationInsightsOptions: (appInsightsLoggerOptions) => appInsightsLoggerOptions.IncludeScopes = false);
+
+            ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+            testLogger.LogInformation("Testing structured with {CustomerName} {Age}", "TestCustomerName", 20);
+
+            Assert.AreEqual("Testing structured with TestCustomerName 20", (itemsReceived[0] as TraceTelemetry).Message);
+            var customProperties = (itemsReceived[0] as TraceTelemetry).Properties;
+            Assert.IsTrue(customProperties["CustomerName"].Equals("TestCustomerName"));
+            Assert.IsTrue(customProperties["Age"].Equals("20"));
+        }
+
+        /// <summary>
         /// Ensures that <see cref="ApplicationInsightsLogger"/> is invoked when user logs using <see cref="ILogger"/>.
         /// </summary>
         [TestMethod]
@@ -142,7 +190,7 @@ namespace Microsoft.ApplicationInsights
 
             Assert.AreEqual(SeverityLevel.Error, (itemsReceived[1] as TraceTelemetry).SeverityLevel);
             Assert.AreEqual("LoggerMessage", (itemsReceived[1] as TraceTelemetry).Message);
-            
+
             Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties["ExceptionMessage"].Contains("StackTraceEnabled"));
 
             Assert.IsTrue((itemsReceived[1] as TraceTelemetry).Properties.ContainsKey("ExceptionStackTrace"));
@@ -263,7 +311,7 @@ namespace Microsoft.ApplicationInsights
             IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration(
                 (telemetryItem, telemetryProcessor) => { });
 
-            IOptions<ApplicationInsightsLoggerOptions> registeredOptions = 
+            IOptions<ApplicationInsightsLoggerOptions> registeredOptions =
                 serviceProvider.GetRequiredService<IOptions<ApplicationInsightsLoggerOptions>>();
 
             Assert.IsTrue(registeredOptions.Value.TrackExceptionsAsExceptionTelemetry);


### PR DESCRIPTION
… of whether Scopes are enabled or not

Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
