### PR TITLE
Remove unnecessary references in DependencyCollector

### DIFF
--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -36,8 +36,6 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Changes
Microsoft.Extensions.PlatformAbstractions and Microsoft.Extensions.DiagnosticAdapter are no longer being developed and are unnecessary dependencies.

See

* [Microsoft.Extensions.PlatformAbstractions](https://github.com/aspnet/Announcements/issues/237)
* [Microsoft.Extensions.DiagnosticAdapter](https://github.com/aspnet/Announcements/issues/411)