### PR TITLE
Add Support for Cloud Role Name for Quickpulse SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,13 @@
 ﻿# Changelog
 
 ## VNext
+- [QuickPulseTelemetryModule and MonitoringDataPoint have a new Cloud Role Name field for sending with ping and post requests to QuickPulse Service.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2100)
 
 ## Version 2.16.0-beta1
 - [ILogger LogError and LogWarning variants write exception `ExceptionStackTrace` when `TrackExceptionsAsExceptionTelemetry` flag is set to `false`](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2065)
 - [Upgrade to System.Diagnostics.DiagnosticSource v5.0.0-rc.2.20475.5](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2091)
 - [The `{OriginalFormat}` field in ILogger will be emitted as `OriginalFormat` with the braces removed](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2071)
 - ApplicationInsightsLoggerProvider populates structured logging key/values irrespective of whether Scopes are enabled or not.
-- QuickPulseTelemetryModule and MonitoringDataPoint have a new Cloud Role Name field for sending with ping and post requests to QuickPulse Service.
-
 ## Version 2.15.0
 - EventCounterCollector module does not add AggregationInterval as a dimension to the metric.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - [Upgrade to System.Diagnostics.DiagnosticSource v5.0.0-rc.2.20475.5](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2091)
 - [The `{OriginalFormat}` field in ILogger will be emitted as `OriginalFormat` with the braces removed](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2071)
 - ApplicationInsightsLoggerProvider populates structured logging key/values irrespective of whether Scopes are enabled or not.
+- QuickPulseTelemetryModule and MonitoringDataPoint have a new Cloud Role Name field for sending with ping and post requests to QuickPulse Service.
 
 ## Version 2.15.0
 - EventCounterCollector module does not add AggregationInterval as a dimension to the metric.

--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -20,6 +20,8 @@
     {
         private readonly string instanceName;
 
+        private readonly string roleName;
+
         private readonly string streamId;
 
         private readonly string machineName;
@@ -45,6 +47,7 @@
         public QuickPulseServiceClient(
             Uri serviceUri,
             string instanceName,
+            string roleName,
             string streamId,
             string machineName,
             string version,
@@ -55,6 +58,7 @@
         {
             this.ServiceUri = serviceUri;
             this.instanceName = instanceName;
+            this.roleName = roleName;
             this.streamId = streamId;
             this.machineName = machineName;
             this.version = version;
@@ -230,6 +234,7 @@
                 InvariantVersion = MonitoringDataPoint.CurrentInvariantVersion,
                 // InstrumentationKey = instrumentationKey, // ikey is currently set in query string parameter
                 Instance = this.instanceName,
+                RoleName = this.roleName,
                 StreamId = this.streamId,
                 MachineName = this.machineName,
                 Timestamp = timestamp.UtcDateTime,
@@ -268,6 +273,7 @@
                     InvariantVersion = MonitoringDataPoint.CurrentInvariantVersion,
                     InstrumentationKey = instrumentationKey,
                     Instance = this.instanceName,
+                    RoleName = this.roleName,
                     StreamId = this.streamId,
                     MachineName = this.machineName,
                     Timestamp = sample.EndTimestamp.UtcDateTime,

--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -24,6 +24,8 @@
     {
         private readonly string instanceName;
 
+        private readonly string roleName;
+
         private readonly string streamId;
 
         private readonly string machineName;
@@ -51,6 +53,7 @@
         public QuickPulseServiceClient(
             Uri serviceUri,
             string instanceName,
+            string roleName,
             string streamId,
             string machineName,
             string version,
@@ -61,6 +64,7 @@
         {
             this.ServiceUri = serviceUri;
             this.instanceName = instanceName;
+            this.roleName = roleName;
             this.streamId = streamId;
             this.machineName = machineName;
             this.version = version;
@@ -234,6 +238,7 @@
                 InvariantVersion = MonitoringDataPoint.CurrentInvariantVersion,
                 // InstrumentationKey = instrumentationKey, // ikey is currently set in query string parameter
                 Instance = this.instanceName,
+                RoleName = this.roleName,
                 StreamId = this.streamId,
                 MachineName = this.machineName,
                 Timestamp = timestamp.UtcDateTime,
@@ -272,6 +277,7 @@
                     InvariantVersion = MonitoringDataPoint.CurrentInvariantVersion,
                     InstrumentationKey = instrumentationKey,
                     Instance = this.instanceName,
+                    RoleName = this.roleName,
                     StreamId = this.streamId,
                     MachineName = this.machineName,
                     Timestamp = sample.EndTimestamp.UtcDateTime,

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1260,10 +1260,9 @@
             CollectionConfigurationInfo configurationInfo;
             serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
 
-            // SYNC
-            this.WaitForProcessing(requestCount: 1);
 
             // ASSERT
+            this.WaitForProcessing(requestCount: 1);
             Assert.AreEqual(1, this.pings.Count);
             Assert.IsNull(this.pings[0].Item3.RoleName);
         }

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1242,6 +1242,33 @@
         }
 
         [TestMethod]
+        public void QuickPulseServiceClientSubmitsRoleNameWithNullValueValidation()
+        {
+            // ARRANGE
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                null,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            // ACT
+            CollectionConfigurationInfo configurationInfo;
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+
+            // SYNC
+            this.WaitForProcessing(requestCount: 1);
+
+            // ASSERT
+            Assert.AreEqual(1, this.pings.Count);
+            Assert.IsNull(this.pings[0].Item3.RoleName);
+        }
+
+        [TestMethod]
         public void QuickPulseServiceClientSubmitsRoleAndInstanceNameToServiceWithSubmitSamples()
         {
             // ARRANGE

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -1211,7 +1211,7 @@
         }
 
         [TestMethod]
-        public void QuickPulseServiceClientSubmitsInstanceNameToServiceWithPing()
+        public void QuickPulseServiceClientSubmitsRoleAndInstanceNameToServiceWithPing()
         {
             // ARRANGE
             var instanceName = "this instance";
@@ -1242,7 +1242,7 @@
         }
 
         [TestMethod]
-        public void QuickPulseServiceClientSubmitsInstanceNameToServiceWithSubmitSamples()
+        public void QuickPulseServiceClientSubmitsRoleAndInstanceNameToServiceWithSubmitSamples()
         {
             // ARRANGE
             var now = DateTimeOffset.UtcNow;

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -53,6 +53,8 @@
 
         private string lastPingInstance;
 
+        private string lastPingRoleName;
+
         private string lastVersion;
 
         private string lastAuthApiKey;
@@ -90,6 +92,7 @@
             this.submitCount = 0;
             this.lastPingTimestamp = null;
             this.lastPingInstance = string.Empty;
+            this.lastPingRoleName = string.Empty;
             this.lastVersion = string.Empty;
             this.lastAuthApiKey = string.Empty;
             ArrayHelpers.ForEach(QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames, headerName => this.lastOpaqueAuthHeaderValues.Add(headerName, null));
@@ -162,9 +165,10 @@
         {
             // ARRANGE
             string instance = Guid.NewGuid().ToString();
+            string roleName = Guid.NewGuid().ToString();
             var timestamp = DateTimeOffset.UtcNow;
 
-            var serviceClient = new QuickPulseServiceClient(this.TestContext.Properties[ServiceEndpointPropertyName] as Uri, instance, instance, instance, string.Empty, new Clock(), false, 0);
+            var serviceClient = new QuickPulseServiceClient(this.TestContext.Properties[ServiceEndpointPropertyName] as Uri, instance, roleName, instance, instance, string.Empty, new Clock(), false, 0);
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
@@ -179,6 +183,7 @@
             Assert.AreEqual(3, this.pingCount);
             Assert.AreEqual(timestamp.DateTime.ToFileTimeUtc() / 10000, this.lastPingTimestamp.Value.DateTime.ToFileTimeUtc() / 10000);
             Assert.AreEqual(instance, this.lastPingInstance);
+            Assert.AreEqual(roleName, this.lastPingRoleName);
         }
 
         [TestMethod]
@@ -188,6 +193,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -266,6 +272,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 timeProvider,
                 false,
                 0);
@@ -337,6 +344,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -370,6 +378,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -420,6 +429,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -514,6 +524,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -562,6 +573,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -584,6 +596,7 @@
             // ARRANGE
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -614,6 +627,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -640,6 +654,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -662,6 +677,7 @@
             // ARRANGE
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -698,6 +714,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -726,6 +743,7 @@
             // ARRANGE
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -762,6 +780,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -794,6 +813,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0,
@@ -818,6 +838,7 @@
             // ARRANGE
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -853,6 +874,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -894,6 +916,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -946,6 +969,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -985,6 +1009,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1039,6 +1064,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -1072,6 +1098,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1116,6 +1143,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1187,10 +1215,12 @@
         {
             // ARRANGE
             var instanceName = "this instance";
+            var roleName = "this role name";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
                 instanceName,
-                instanceName,
+                roleName,
+                string.Empty,
                 instanceName,
                 string.Empty,
                 new Clock(),
@@ -1208,6 +1238,7 @@
             Assert.AreEqual(1, this.pings.Count);
             Assert.AreEqual(instanceName, this.pings[0].Item1.InstanceName);
             Assert.AreEqual(instanceName, this.pings[0].Item3.Instance);
+            Assert.AreEqual(roleName, this.pings[0].Item3.RoleName);
         }
 
         [TestMethod]
@@ -1216,9 +1247,11 @@
             // ARRANGE
             var now = DateTimeOffset.UtcNow;
             var instanceName = "this instance";
+            var roleName = "this role name";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
                 instanceName,
+                roleName,
                 instanceName,
                 instanceName,
                 string.Empty,
@@ -1242,6 +1275,7 @@
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.AreEqual(instanceName, this.samples[0].Item3.Instance);
+            Assert.AreEqual(roleName, this.samples[0].Item3.RoleName);
         }
 
         [TestMethod]
@@ -1251,6 +1285,7 @@
             var streamId = "this stream";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 streamId,
                 string.Empty,
@@ -1280,6 +1315,7 @@
             var streamId = "this stream";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 streamId,
                 string.Empty,
@@ -1315,6 +1351,7 @@
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 machineName,
                 string.Empty,
                 new Clock(),
@@ -1342,6 +1379,7 @@
             var machineName = "this machine";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 machineName,
@@ -1378,6 +1416,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -1402,6 +1441,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1439,6 +1479,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 timeProvider,
                 false,
                 0);
@@ -1462,6 +1503,7 @@
             var timeProvider = new ClockMock();
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1503,6 +1545,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 version,
                 new Clock(),
                 false,
@@ -1528,6 +1571,7 @@
             var version = "this version";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1567,6 +1611,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -1591,6 +1636,7 @@
             var authApiKey = "this api key";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1624,6 +1670,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1663,6 +1710,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1713,6 +1761,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -1743,6 +1792,7 @@
             var now = DateTimeOffset.UtcNow;
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1811,6 +1861,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 false,
                 0);
@@ -1841,6 +1892,7 @@
             var ikey = "some ikey";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1879,6 +1931,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                string.Empty,
                 new Clock(),
                 true,
                 7);
@@ -1909,6 +1962,7 @@
             var ikey = "some ikey";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -1949,6 +2003,7 @@
             var ikey = "some ikey";
             var serviceClient = new QuickPulseServiceClient(
                 this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
                 string.Empty,
                 string.Empty,
                 string.Empty,
@@ -2052,6 +2107,7 @@
 
                                 this.lastPingTimestamp = dataPoint.Timestamp;
                                 this.lastPingInstance = dataPoint.Instance;
+                                this.lastPingRoleName = dataPoint.RoleName;
                                 this.lastVersion = dataPoint.Version;
                             }
 

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/Service contract/MonitoringDataPoint.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/Service contract/MonitoringDataPoint.cs
@@ -33,6 +33,9 @@
         public string Instance { get; set; }
 
         [DataMember]
+        public string RoleName { get; set; }
+
+        [DataMember]
         public string StreamId { get; set; }
 
         [DataMember]

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -170,10 +170,6 @@
                             this.DisableTopCpuProcesses,
                             this.AuthenticationApiKey);
 
-
-
-
-
                         QuickPulseEventSource.Log.TroubleshootingMessageEvent("Validating configuration...");
                         ValidateConfiguration(configuration);
                         this.config = configuration;

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -406,7 +406,7 @@
             // create the default production implementation of the service client with the best service endpoint we could get
             CloudContext cloudContext = GetCloudContext(configuration);
             string instanceName = string.IsNullOrWhiteSpace(cloudContext?.RoleInstance) ? Environment.MachineName : cloudContext.RoleInstance;
-            string roleName = cloudContext?.RoleName;
+            string roleName = cloudContext?.RoleName ?? string.Empty;
             string streamId = GetStreamId();
             var assemblyVersion = SdkVersionUtils.GetSdkVersion(null);
             bool isWebApp = PerformanceCounterUtility.IsWebAppRunningInAzure();

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.ApplicationInsights.Extensibility.Implementation;
-
-namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse
+﻿namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse
 {
     using System;
     using System.Collections.Generic;
@@ -14,6 +12,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Quick
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Filtering;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse;
@@ -278,6 +277,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Quick
 
             return fakeItem.Context?.Cloud;
         }
+
         private static string GetStreamId()
         {
             return Guid.NewGuid().ToStringInvariant("N");

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -276,6 +276,7 @@
 
             return string.IsNullOrWhiteSpace(fakeItem.Context?.Cloud?.RoleInstance) ? Environment.MachineName : fakeItem.Context.Cloud.RoleInstance;
         }
+
         private static string GetRoleName(TelemetryConfiguration configuration)
         {
             // we need to initialize an item to get instance information

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -170,6 +170,10 @@
                             this.DisableTopCpuProcesses,
                             this.AuthenticationApiKey);
 
+
+
+
+
                         QuickPulseEventSource.Log.TroubleshootingMessageEvent("Validating configuration...");
                         ValidateConfiguration(configuration);
                         this.config = configuration;
@@ -275,6 +279,22 @@
             }
 
             return string.IsNullOrWhiteSpace(fakeItem.Context?.Cloud?.RoleInstance) ? Environment.MachineName : fakeItem.Context.Cloud.RoleInstance;
+        }
+        private static string GetRoleName(TelemetryConfiguration configuration)
+        {
+            // we need to initialize an item to get instance information
+            var fakeItem = new EventTelemetry();
+
+            try
+            {
+                new TelemetryClient(configuration).Initialize(fakeItem);
+            }
+            catch (Exception)
+            {
+                // we don't care what happened there
+            }
+
+            return fakeItem.Context?.Cloud?.RoleName;
         }
 
         private static string GetStreamId()
@@ -404,6 +424,7 @@
 
             // create the default production implementation of the service client with the best service endpoint we could get
             string instanceName = GetInstanceName(configuration);
+            string roleName = GetRoleName(configuration);
             string streamId = GetStreamId();
             var assemblyVersion = SdkVersionUtils.GetSdkVersion(null);
             bool isWebApp = PerformanceCounterUtility.IsWebAppRunningInAzure();
@@ -411,6 +432,7 @@
             this.ServiceClient = new QuickPulseServiceClient(
                 serviceEndpointUri,
                 instanceName,
+                roleName,
                 streamId,
                 this.ServerId,
                 assemblyVersion,


### PR DESCRIPTION
Fix Issue # .

## Changes
Added support for Cloud Role Name for Quickpulse SDK

### Checklist
- [x] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
