### PR TITLE
Endpoint and ping interval hints for QuickPulseModule.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-﻿# Changelog
+# Changelog
 
 ## VNext
 - [Add RoleName as a header with Ping Reuests to QuickPulse.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2113)
-- [QuickPulseTelemetryModule takes hints from the service regarding the endpoint to ping and how often to ping it]()
+- [QuickPulseTelemetryModule takes hints from the service regarding the endpoint to ping and how often to ping it](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2120)
 
 ## Version 2.16.0
 - [QuickPulseTelemetryModule and MonitoringDataPoint have a new Cloud Role Name field for sending with ping and post requests to QuickPulse Service.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2100)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [Add RoleName as a header with Ping Reuests to QuickPulse.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2113)
+- [QuickPulseTelemetryModule takes hints from the service regarding the endpoint to ping and how often to ping it]()
 
 ## Version 2.16.0
 - [QuickPulseTelemetryModule and MonitoringDataPoint have a new Cloud Role Name field for sending with ping and post requests to QuickPulse Service.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2100)

--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -7,7 +7,7 @@
     using System.Linq;
     using System.Net;
     using System.Runtime.Serialization.Json;
-
+    using System.Threading;
     using Microsoft.ApplicationInsights.Extensibility.Filtering;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers;
@@ -44,6 +44,8 @@
 
         private readonly Dictionary<string, string> authOpaqueHeaderValues = new Dictionary<string, string>(StringComparer.Ordinal);
 
+        private Uri currentServiceUri;
+
         public QuickPulseServiceClient(
             Uri serviceUri,
             string instanceName,
@@ -56,7 +58,7 @@
             int processorCount,
             TimeSpan? timeout = null)
         {
-            this.ServiceUri = serviceUri;
+            this.CurrentServiceUri = serviceUri;
             this.instanceName = instanceName;
             this.roleName = roleName;
             this.streamId = streamId;
@@ -73,19 +75,24 @@
             }
         }
 
-        public Uri ServiceUri { get; }
+        public Uri CurrentServiceUri
+        {
+            get => Volatile.Read(ref this.currentServiceUri);
+            private set => Volatile.Write(ref this.currentServiceUri, value);
+        }
 
         public bool? Ping(
             string instrumentationKey,
             DateTimeOffset timestamp,
             string configurationETag,
             string authApiKey,
-            out CollectionConfigurationInfo configurationInfo)
+            out CollectionConfigurationInfo configurationInfo,
+            out TimeSpan? servicePollingIntervalHint)
         {
             var requestUri = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}/ping?ikey={1}",
-                this.ServiceUri.AbsoluteUri.TrimEnd('/'),
+                this.CurrentServiceUri.AbsoluteUri.TrimEnd('/'),
                 Uri.EscapeUriString(instrumentationKey));
 
             return this.SendRequest(
@@ -94,6 +101,7 @@
                 configurationETag,
                 authApiKey,
                 out configurationInfo,
+                out servicePollingIntervalHint,
                 requestStream => this.WritePingData(timestamp, requestStream));
         }
 
@@ -108,7 +116,7 @@
             var requestUri = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}/post?ikey={1}",
-                this.ServiceUri.AbsoluteUri.TrimEnd('/'),
+                this.CurrentServiceUri.AbsoluteUri.TrimEnd('/'),
                 Uri.EscapeUriString(instrumentationKey));
 
             return this.SendRequest(
@@ -117,6 +125,7 @@
                 configurationETag,
                 authApiKey,
                 out configurationInfo,
+                out _,
                 requestStream => this.WriteSamples(samples, instrumentationKey, requestStream, collectionConfigurationErrors));
         }
 
@@ -130,6 +139,7 @@
             string configurationETag,
             string authApiKey,
             out CollectionConfigurationInfo configurationInfo,
+            out TimeSpan? servicePollingIntervalHint,
             Action<Stream> onWriteRequestBody)
         {
             try
@@ -149,10 +159,11 @@
                         if (response == null)
                         {
                             configurationInfo = null;
+                            servicePollingIntervalHint = null;
                             return null;
                         }
 
-                        return this.ProcessResponse(response, configurationETag, out configurationInfo);
+                        return this.ProcessResponse(response, configurationETag, out configurationInfo, out servicePollingIntervalHint);
                     }
                 }
             }
@@ -162,13 +173,15 @@
             }
 
             configurationInfo = null;
+            servicePollingIntervalHint = null;
             return null;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Dispose is known to perform safely on Stream and StreamReader types.")]
-        private bool? ProcessResponse(HttpWebResponse response, string configurationETag, out CollectionConfigurationInfo configurationInfo)
+        private bool? ProcessResponse(HttpWebResponse response, string configurationETag, out CollectionConfigurationInfo configurationInfo, out TimeSpan? servicePollingIntervalHint)
         {
             configurationInfo = null;
+            servicePollingIntervalHint = null;
 
             bool isSubscribed;
             if (!bool.TryParse(response.GetResponseHeader(QuickPulseConstants.XMsQpsSubscribedHeaderName), out isSubscribed))
@@ -200,6 +213,16 @@
             }
 
             string configurationETagHeaderValue = response.GetResponseHeader(QuickPulseConstants.XMsQpsConfigurationETagHeaderName);
+
+            if (long.TryParse(response.GetResponseHeader(QuickPulseConstants.XMsQpsServicePollingIntervalHintHeaderName), out long servicePollingIntervalHintInMs))
+            {
+                servicePollingIntervalHint = TimeSpan.FromMilliseconds(servicePollingIntervalHintInMs);
+            }
+
+            if (Uri.TryCreate(response.GetResponseHeader(QuickPulseConstants.XMsQpsServiceEndpointRedirectHeaderName), UriKind.Absolute, out Uri serviceEndpointRedirect))
+            {
+                this.CurrentServiceUri = serviceEndpointRedirect;
+            }
 
             try
             {

--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -48,9 +48,9 @@
 
         private readonly Dictionary<string, string> authOpaqueHeaderValues = new Dictionary<string, string>(StringComparer.Ordinal);
 
-        private Uri currentServiceUri;
-
         private readonly HttpClient httpClient = new HttpClient();
+
+        private Uri currentServiceUri;
 
         public QuickPulseServiceClient(
             Uri serviceUri,

--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -48,6 +48,8 @@
 
         private readonly Dictionary<string, string> authOpaqueHeaderValues = new Dictionary<string, string>(StringComparer.Ordinal);
 
+        private Uri currentServiceUri;
+
         private readonly HttpClient httpClient = new HttpClient();
 
         public QuickPulseServiceClient(
@@ -62,7 +64,7 @@
             int processorCount,
             TimeSpan? timeout = null)
         {
-            this.ServiceUri = serviceUri;
+            this.CurrentServiceUri = serviceUri;
             this.instanceName = instanceName;
             this.roleName = roleName;
             this.streamId = streamId;
@@ -79,19 +81,24 @@
             }
         }
 
-        public Uri ServiceUri { get; }
+        public Uri CurrentServiceUri
+        {
+            get => Volatile.Read(ref this.currentServiceUri);
+            private set => Volatile.Write(ref this.currentServiceUri, value);
+        }
 
         public bool? Ping(
             string instrumentationKey,
             DateTimeOffset timestamp,
             string configurationETag,
             string authApiKey,
-            out CollectionConfigurationInfo configurationInfo)
+            out CollectionConfigurationInfo configurationInfo,
+            out TimeSpan? servicePollingIntervalHint)
         {
             var requestUri = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}/ping?ikey={1}",
-                this.ServiceUri.AbsoluteUri.TrimEnd('/'),
+                this.CurrentServiceUri.AbsoluteUri.TrimEnd('/'),
                 Uri.EscapeUriString(instrumentationKey));
 
             return this.SendRequest(
@@ -100,6 +107,7 @@
                 configurationETag,
                 authApiKey,
                 out configurationInfo,
+                out servicePollingIntervalHint,
                 requestStream => this.WritePingData(timestamp, requestStream));
         }
 
@@ -114,7 +122,7 @@
             var requestUri = string.Format(
                 CultureInfo.InvariantCulture,
                 "{0}/post?ikey={1}",
-                this.ServiceUri.AbsoluteUri.TrimEnd('/'),
+                this.CurrentServiceUri.AbsoluteUri.TrimEnd('/'),
                 Uri.EscapeUriString(instrumentationKey));
 
             return this.SendRequest(
@@ -123,6 +131,7 @@
                 configurationETag,
                 authApiKey,
                 out configurationInfo,
+                out _,
                 requestStream => this.WriteSamples(samples, instrumentationKey, requestStream, collectionConfigurationErrors));
         }
 
@@ -138,6 +147,7 @@
             string configurationETag,
             string authApiKey,
             out CollectionConfigurationInfo configurationInfo,
+            out TimeSpan? servicePollingIntervalHint,
             Action<Stream> onWriteRequestBody)
         {
             try
@@ -159,10 +169,11 @@
                             if (response == null)
                             {
                                 configurationInfo = null;
+                                servicePollingIntervalHint = null;
                                 return null;
                             }
 
-                            return this.ProcessResponse(response, configurationETag, out configurationInfo);
+                            return this.ProcessResponse(response, configurationETag, out configurationInfo, out servicePollingIntervalHint);
                         }
                     }
                 }
@@ -173,13 +184,15 @@
             }
 
             configurationInfo = null;
+            servicePollingIntervalHint = null;
             return null;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2202:Do not dispose objects multiple times", Justification = "Dispose is known to perform safely on Stream and StreamReader types.")]
-        private bool? ProcessResponse(HttpResponseMessage response, string configurationETag, out CollectionConfigurationInfo configurationInfo)
+        private bool? ProcessResponse(HttpResponseMessage response, string configurationETag, out CollectionConfigurationInfo configurationInfo, out TimeSpan? servicePollingIntervalHint)
         {
             configurationInfo = null;
+            servicePollingIntervalHint = null;
 
             if (!bool.TryParse(response.Headers.GetValueSafe(QuickPulseConstants.XMsQpsSubscribedHeaderName), out bool isSubscribed))
             {
@@ -204,6 +217,16 @@
             }
 
             string configurationETagHeaderValue = response.Headers.GetValueSafe(QuickPulseConstants.XMsQpsConfigurationETagHeaderName);
+
+            if (long.TryParse(response.Headers.GetValueSafe(QuickPulseConstants.XMsQpsServicePollingIntervalHintHeaderName), out long servicePollingIntervalHintInMs))
+            {
+                servicePollingIntervalHint = TimeSpan.FromMilliseconds(servicePollingIntervalHintInMs);
+            }
+
+            if (Uri.TryCreate(response.Headers.GetValueSafe(QuickPulseConstants.XMsQpsServiceEndpointRedirectHeaderName), UriKind.Absolute, out Uri serviceEndpointRedirect))
+            {
+                this.CurrentServiceUri = serviceEndpointRedirect;
+            }
 
             try
             {

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/Mocks/QuickPulseServiceClientMock.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/Mocks/QuickPulseServiceClientMock.cs
@@ -27,6 +27,10 @@
 
         public CollectionConfigurationError[] CollectionConfigurationErrors { get; private set; }
 
+        public TimeSpan? ServicePollingIntervalHint { private get; set; }
+
+        public Uri CurrentServiceUriMockValue { private get; set; }
+
         public bool? ReturnValueFromSubmitSample { private get; set; }
 
         public int? LastSampleBatchSize { get; private set; }
@@ -50,7 +54,7 @@
             }
         }
 
-        public Uri ServiceUri { get; }
+        public Uri CurrentServiceUri { get; private set; }
 
         public void Reset()
         {
@@ -70,7 +74,8 @@
             DateTimeOffset timestamp,
             string configurationETag,
             string authApiKey,
-            out CollectionConfigurationInfo configurationInfo)
+            out CollectionConfigurationInfo configurationInfo,
+            out TimeSpan? servicePollingIntervalHint)
         {
             lock (this.ResponseLock)
             {
@@ -90,6 +95,8 @@
                 }
 
                 configurationInfo = this.CollectionConfigurationInfo?.ETag == configurationETag ? null : this.CollectionConfigurationInfo;
+                servicePollingIntervalHint = this.ServicePollingIntervalHint;
+                this.CurrentServiceUri = this.CurrentServiceUriMockValue;
 
                 return this.ReturnValueFromPing;
             }

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -172,9 +172,9 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo);
-            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo);
-            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 3);
@@ -581,7 +581,7 @@
             // ACT
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString()); };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -608,7 +608,7 @@
             // ACT
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString()); };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -635,7 +635,7 @@
             // ACT
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, "bla"); };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -662,7 +662,7 @@
             // ACT
             this.pingResponse = r => { };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -823,7 +823,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -900,7 +900,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo);
+            serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -991,7 +991,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo);
+            serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1082,7 +1082,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("ikey", now, "ETag2", string.Empty, out configurationInfo);
+            serviceClient.Ping("ikey", now, "ETag2", string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1229,7 +1229,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1258,7 +1258,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
 
             // ASSERT
@@ -1323,7 +1323,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1388,7 +1388,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1451,7 +1451,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1514,7 +1514,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), timeProvider.UtcNow, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping(Guid.NewGuid().ToString(), timeProvider.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1581,7 +1581,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1646,7 +1646,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("some ikey", now, string.Empty, authApiKey, out configurationInfo);
+            serviceClient.Ping("some ikey", now, string.Empty, authApiKey, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1714,10 +1714,10 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // received the proper headers, now re-submit them
-            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo);
+            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 2);
@@ -1803,7 +1803,7 @@
             // ACT
             CollectionConfigurationInfo configurationInfo;
             serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
-            serviceClient.Ping(string.Empty, now, "ETag1", string.Empty, out configurationInfo);
+            serviceClient.Ping(string.Empty, now, "ETag1", string.Empty, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -2057,6 +2057,195 @@
             // ASSERT
             Assert.AreEqual(1, this.samples.Count);
             Assert.IsTrue(this.samples[0].Item3.TopCpuDataAccessDenied);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientReturnsServicePollingIntervalHintWhenValid()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            int ms = 12345;
+            this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsServicePollingIntervalHintHeaderName, ms.ToString());
+            };
+
+            // ACT
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out TimeSpan? servicePollingIntervalHint);
+
+            // ASSERT
+            Assert.AreEqual(TimeSpan.FromMilliseconds(ms), servicePollingIntervalHint);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientReturnsNullForServicePollingIntervalHintWhenNaN()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsServicePollingIntervalHintHeaderName, "not a number");
+            };
+
+            // ACT
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out TimeSpan? servicePollingIntervalHint);
+
+            // ASSERT
+            Assert.IsNull(servicePollingIntervalHint);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientReturnsNullForServicePollingIntervalHintWhenEmpty()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsServicePollingIntervalHintHeaderName, string.Empty);
+            };
+
+            // ACT
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out TimeSpan? servicePollingIntervalHint);
+
+            // ASSERT
+            Assert.IsNull(servicePollingIntervalHint);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientUpdatesServiceEndpointWhenRedirectValid()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            string endpointRedirect = "https://bing.com";
+            this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsServiceEndpointRedirectHeaderName, endpointRedirect);
+            };
+
+            // ACT
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out _);
+
+            // SYNC
+            this.WaitForProcessing(1);
+
+            // ASSERT
+            Assert.AreEqual(new Uri(endpointRedirect), serviceClient.CurrentServiceUri);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientIgnoresServiceEndpointWhenRedirectInvalid()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            Uri initialEndpoint = serviceClient.CurrentServiceUri;
+
+            this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsServiceEndpointRedirectHeaderName, "/not-a-valid-absolute-url");
+            };
+
+            // ACT
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out _);
+
+            // SYNC
+            this.WaitForProcessing(1);
+
+            // ASSERT
+            Assert.AreEqual(initialEndpoint, serviceClient.CurrentServiceUri);
+        }
+
+        [TestMethod]
+        public void QuickPulseServiceClientIgnoresServiceEndpointWhenRedirectEmpty()
+        {
+            // ARRANGE
+            var now = DateTimeOffset.UtcNow;
+            var serviceClient = new QuickPulseServiceClient(
+                this.TestContext.Properties[ServiceEndpointPropertyName] as Uri,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                string.Empty,
+                new Clock(),
+                false,
+                0);
+
+            Uri initialEndpoint = serviceClient.CurrentServiceUri;
+
+            this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsServiceEndpointRedirectHeaderName, string.Empty);
+            };
+
+            // ACT
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out _);
+
+            // SYNC
+            this.WaitForProcessing(1);
+
+            // ASSERT
+            Assert.AreEqual(initialEndpoint, serviceClient.CurrentServiceUri);
         }
 
         public void Dispose()

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/IQuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/IQuickPulseServiceClient.cs
@@ -8,9 +8,10 @@
     internal interface IQuickPulseServiceClient : IDisposable
     {
         /// <summary>
-        /// Gets the QPS URI.
+        /// Gets the current QPS URI.
         /// </summary>
-        Uri ServiceUri { get; }
+        /// <remarks>This value may be dynamically updated with each request from within the instance.</remarks>
+        Uri CurrentServiceUri { get; }
 
         /// <summary>
         /// Pings QPS to check if it expects data right now.
@@ -20,13 +21,15 @@
         /// <param name="configurationETag">Current configuration ETag that the client has.</param>
         /// <param name="authApiKey">Authentication API key.</param>
         /// <param name="configurationInfo">When available, the deserialized response data received from the server.</param>
+        /// <param name="servicePollingIntervalHint">When available, a hint regarding what the period should be when pinging the server going forward.</param>
         /// <returns><b>true</b> if data is expected, otherwise <b>false</b>.</returns>
         bool? Ping(
             string instrumentationKey,
             DateTimeOffset timestamp,
             string configurationETag,
             string authApiKey,
-            out CollectionConfigurationInfo configurationInfo);
+            out CollectionConfigurationInfo configurationInfo,
+            out TimeSpan? servicePollingIntervalHint);
 
         /// <summary>
         /// Submits a data samples to QPS.

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseConstants.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseConstants.cs
@@ -51,6 +51,18 @@
         internal const string XMsQpsAuthApiKeyHeaderName = "x-ms-qps-auth-api-key";
 
         /// <summary>
+        /// Service polling interval hint.
+        /// </summary>
+        /// <remarks>Contains a recommended time (in milliseconds) before we ping the service again.</remarks>
+        internal const string XMsQpsServicePollingIntervalHintHeaderName = "x-ms-qps-service-polling-interval-hint";
+
+        /// <summary>
+        /// Service endpoint redirect.
+        /// </summary>
+        /// <remarks>Contains a URI of the service endpoint we must permanently use <b>for the particular resource</b>.</remarks>
+        internal const string XMsQpsServiceEndpointRedirectHeaderName = "x-ms-qps-service-endpoint-redirect";
+
+        /// <summary>
         /// The following authentication headers must be received and submitted back to the service with no modification.
         /// </summary>
         internal static readonly string[] XMsQpsAuthOpaqueHeaderNames =


### PR DESCRIPTION
## Changes
QuickPulseModule now accepts
- a hint from the service as to the interval for ping requests when data collection is inactive (in support of upcoming COGS reduction change)
- an endpoint redirect (in support of upcoming regionalized QPS design)

### Checklist
- [x ] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
