### PR TITLE
Update how BuildNumbers are calculated

### DIFF
--- a/.props/_GlobalStaticVersion.props
+++ b/.props/_GlobalStaticVersion.props
@@ -11,9 +11,9 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>16</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
+    <SemanticVersionMinor>17</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone></PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
+    <PreReleaseMilestone>beta1</PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
     <PreReleaseMilestone Condition="'$(NightlyBuild)' == 'True'">nightly</PreReleaseMilestone> <!-- Overwrite this property for nightly builds from the DEVELOP branch. -->
     <!-- 
       Date when Semantic Version was changed. 
@@ -22,13 +22,16 @@
       as it will restart file versions so 2.4.0-beta1 may have higher 
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
-    <SemanticVersionDate>2020-09-08</SemanticVersionDate>
+    <SemanticVersionDate>2020-12-01</SemanticVersionDate>
 
     <!--
-      Pre-release version is used to distinguish internally built NuGet packages.
-      Pre-release version = Minutes since semantic version was set, divided by 5 (to make it fit in a UInt16 (max 65535 = ~7 months).
+      BuildNumber uniquely identifies all builds (The max allowed value is UInt16.MaxValue = 65535).
+      The BuildNumber is used for nightly build package name and DLL assembly version.
+      NuGet uses alphanumeric sorting, so this value is padded with zeros.
+      BuildNumber = Hours since semantic version was set, divided by 12 (~89 years).
     -->
-    <BuildNumber>$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(SemanticVersionDate)))).TotalMinutes), 5).ToString('F0'))</BuildNumber>
+    <BuildNumberHours>$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Parse($(SemanticVersionDate)))).TotalHours), 12))</BuildNumberHours>
+    <BuildNumber>$([System.Math]::Floor($(BuildNumberHours)).ToString('F0').PadLeft(5, '0'))</BuildNumber>
 
     <VersionPrefix>$(SemanticVersionMajor).$(SemanticVersionMinor).$(SemanticVersionPatch)</VersionPrefix>
     <VersionSuffix>$(PreReleaseMilestone)</VersionSuffix>

--- a/.scripts/release_NupkgAudit.ps1
+++ b/.scripts/release_NupkgAudit.ps1
@@ -181,7 +181,7 @@ function Get-DoesDllVersionsMatch ([string]$dllPath) {
 
     $message = "File Version: '$fileVersion' Assembly Version: '$assemblyVersion";
     $requirement = "Versions should match."
-    Test-Condition ($fileVersion.Equals($assemblyVersion)) $message $requirement;
+    Test-Condition ([version]$fileVersion -eq [version]$assemblyVersion) $message $requirement;
 }
 
 function Get-IsValidPackageId([xml]$nuspecXml) {


### PR DESCRIPTION
Change to the way we calculate the build number.

Formerly, we calculated builds as the TotalMinutes between DateTime.Now and the semantic version time stamp, divided by 5.
This meant that every 5 minutes the build number changes.
This was hurting nightly nupkgs because our assembly version and packages names weren't matching.
(Stable Releases were unaffected because we don't include the BuildNumber in those package names)

This PR changes the calculation to be TotalHours / 12.
