### PR TITLE
Fix: telemetry parent id when using W3C activity format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-
+[Fix: telemetry parent id when using W3C activity format in TelemetryDiagnosticSourceListener](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2142)
 
 ## Version 2.17.0-beta1
 - [Fix: Missing Dependencies when using Microsoft.Data.SqlClient v2.0.0](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2032)

--- a/WEB/Src/DependencyCollector/DependencyCollector/TelemetryDiagnosticSourceListener.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/TelemetryDiagnosticSourceListener.cs
@@ -50,8 +50,23 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             }
 
             // properly fill dependency telemetry operation context
-            telemetry.Context.Operation.Id = currentActivity.RootId;
-            telemetry.Context.Operation.ParentId = currentActivity.ParentId;
+            if (currentActivity.IdFormat == ActivityIdFormat.W3C)
+            {
+                telemetry.Context.Operation.Id = currentActivity.TraceId.ToHexString();
+                if (currentActivity.ParentSpanId != default)
+                {
+                    telemetry.Context.Operation.ParentId = currentActivity.ParentSpanId.ToHexString();
+                }
+
+                telemetry.Id = currentActivity.SpanId.ToHexString();
+            }
+            else
+            {
+                telemetry.Id = currentActivity.Id;
+                telemetry.Context.Operation.Id = currentActivity.RootId;
+                telemetry.Context.Operation.ParentId = currentActivity.ParentId;
+            }
+
             telemetry.Timestamp = currentActivity.StartTimeUtc;
 
             telemetry.Properties["DiagnosticSource"] = diagnosticListener.Name;


### PR DESCRIPTION
Fix Issue #2142 

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.