### PR TITLE
Add ingestion response duration to data delivery status (TransmissionStatusEventArgs)

### DIFF
--- a/.publicApi/Microsoft.ApplicationInsights.dll/net452/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net452/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.ApplicationInsights.Channel.TransmissionStatusEventArgs.ResponseDurationInMs.get -> long
+Microsoft.ApplicationInsights.Channel.TransmissionStatusEventArgs.TransmissionStatusEventArgs(Microsoft.ApplicationInsights.Extensibility.Implementation.HttpWebResponseWrapper response, long responseDurationInMs) -> void

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.ApplicationInsights.Channel.TransmissionStatusEventArgs.ResponseDurationInMs.get -> long
+Microsoft.ApplicationInsights.Channel.TransmissionStatusEventArgs.TransmissionStatusEventArgs(Microsoft.ApplicationInsights.Extensibility.Implementation.HttpWebResponseWrapper response, long responseDurationInMs) -> void

--- a/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.ApplicationInsights.Channel.TransmissionStatusEventArgs.ResponseDurationInMs.get -> long
+Microsoft.ApplicationInsights.Channel.TransmissionStatusEventArgs.TransmissionStatusEventArgs(Microsoft.ApplicationInsights.Extensibility.Implementation.HttpWebResponseWrapper response, long responseDurationInMs) -> void

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/TransmissionTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/TransmissionTest.cs
@@ -528,6 +528,7 @@
                     {
                         Assert.IsTrue(sender is Transmission);
                         Assert.AreEqual((int)HttpStatusCode.OK, args.Response.StatusCode);
+                        Assert.AreNotEqual(0, args.ResponseDurationInMs);
                     };
 
                     // ACT
@@ -559,6 +560,7 @@
                     transmission.TransmissionStatusEvent += delegate (object sender, TransmissionStatusEventArgs args)
                     {
                         Assert.AreEqual((int)HttpStatusCode.RequestTimeout, args.Response.StatusCode);
+                        Assert.AreEqual(0, args.ResponseDurationInMs);
                     };
 
                     // ACT
@@ -589,6 +591,7 @@
                     transmission.TransmissionStatusEvent += delegate (object sender, TransmissionStatusEventArgs args)
                     {
                         Assert.AreEqual(999, args.Response.StatusCode);
+                        Assert.AreEqual(0, args.ResponseDurationInMs);
                     };
 
                     // ACT

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -156,6 +156,7 @@
                 {
                     HttpRequestMessage request = this.CreateRequestMessage(this.EndpointAddress, contentStream);
                     HttpWebResponseWrapper wrapper = null;
+                    long responseDurationInMs = 0;
 
                     try
                     {
@@ -171,7 +172,8 @@
                             using (var response = await client.SendAsync(request, ct.Token).ConfigureAwait(false))
                             {
                                 stopwatch.Stop();
-                                CoreEventSource.Log.IngestionResponseTime(response != null ? (int)response.StatusCode : -1, stopwatch.ElapsedMilliseconds);
+                                responseDurationInMs = stopwatch.ElapsedMilliseconds;
+                                CoreEventSource.Log.IngestionResponseTime(response != null ? (int)response.StatusCode : -1, responseDurationInMs);
                                 // Log ingestion respose time as event counter metric.
                                 CoreEventSource.Log.IngestionResponseTimeEventCounter(stopwatch.ElapsedMilliseconds);
 
@@ -225,7 +227,7 @@
                         try
                         {
                             // Initiates event notification to subscriber with Transmission and TransmissionStatusEventArgs.
-                            this.TransmissionStatusEvent?.Invoke(this, new TransmissionStatusEventArgs(wrapper ?? new HttpWebResponseWrapper() { StatusCode = 999 }));
+                            this.TransmissionStatusEvent?.Invoke(this, new TransmissionStatusEventArgs(wrapper ?? new HttpWebResponseWrapper() { StatusCode = 999 }, responseDurationInMs));
                         }
                         catch (Exception ex)
                         {

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/TransmissionStatusEventArgs.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/TransmissionStatusEventArgs.cs
@@ -12,14 +12,30 @@
         /// Initializes a new instance of the <see cref="TransmissionStatusEventArgs"/> class.
         /// </summary>
         /// <param name="response">Response from ingestion endpoint.</param>
-        public TransmissionStatusEventArgs(HttpWebResponseWrapper response)
+        [ObsoleteAttribute("This constructor is deprecated. Please use a constructor that accepts response and responseDurationInMs instead.", false)]
+        public TransmissionStatusEventArgs(HttpWebResponseWrapper response) : this(response, default)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TransmissionStatusEventArgs"/> class.
+        /// </summary>
+        /// <param name="response">Response from ingestion endpoint.</param>
+        /// <param name="responseDurationInMs">Response duration in milliseconds.</param>
+        public TransmissionStatusEventArgs(HttpWebResponseWrapper response, long responseDurationInMs)
         {
             this.Response = response;
+            this.ResponseDurationInMs = responseDurationInMs;
         }
 
         /// <summary>
         /// Gets the response from ingestion endpoint.
         /// </summary>
         public HttpWebResponseWrapper Response { get; }
+
+        /// <summary>
+        /// Gets response duration in milliseconds.
+        /// </summary>
+        public long ResponseDurationInMs { get; }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 [Fix: telemetry parent id when using W3C activity format in TelemetryDiagnosticSourceListener](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2142)
+[Add ingestion response duration for transmission to data delivery status - TransmissionStatusEventArgs](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2157)
 
 ## Version 2.17.0-beta1
 - [Fix: Missing Dependencies when using Microsoft.Data.SqlClient v2.0.0](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2032)


### PR DESCRIPTION
Adds ingestion response duration for transmission in milliseconds to #1887 

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [X] I ran Unit Tests locally.
- [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

