### PR TITLE
Fix PropertyFetcher error when used with multiple types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## VNext
 
+- [Fix PropertyFetcher error when used with multiple types](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2194)
+
 ## Version 2.17.0
 - [Fix: telemetry parent id when using W3C activity format in TelemetryDiagnosticSourceListener](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2142)
 - [Add ingestion response duration for transmission to data delivery status - TransmissionStatusEventArgs](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2157)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/PropertyFetcher.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/PropertyFetcher.cs
@@ -44,11 +44,11 @@
         {
             public PropertyFetch(Type type)
             {
-                Type = type;
+                this.Type = type;
             }
 
             /// <summary>
-            /// The type of the object that the property is fetched from. For well-known static methods that
+            /// Gets the type of the object that the property is fetched from. For well-known static methods that
             /// aren't actually property getters this will return null.
             /// </summary>
             internal Type Type { get; }

--- a/WEB/Src/Common/PropertyFetcher.cs
+++ b/WEB/Src/Common/PropertyFetcher.cs
@@ -11,7 +11,7 @@
     internal class PropertyFetcher
     {
         private readonly string propertyName;
-        private PropertyFetch innerFetcher;
+        private volatile PropertyFetch innerFetcher;
 
         public PropertyFetcher(string propertyName)
         {
@@ -20,33 +20,47 @@
 
         public object Fetch(object obj)
         {
-            if (this.innerFetcher == null)
+            PropertyFetch fetch = this.innerFetcher;
+            Type objType = obj?.GetType();
+
+            if (fetch == null || fetch.Type != objType)
             {
-                this.innerFetcher = PropertyFetch.FetcherForProperty(obj?.GetType()?.GetTypeInfo()?.GetDeclaredProperty(this.propertyName));
+                this.innerFetcher = fetch = PropertyFetch.FetcherForProperty(objType, objType?.GetTypeInfo()?.GetDeclaredProperty(this.propertyName));
             }
 
-            return this.innerFetcher?.Fetch(obj);
+            return fetch?.Fetch(obj);
         }
 
         // see https://github.com/dotnet/corefx/blob/master/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs
         private class PropertyFetch
         {
+            public PropertyFetch(Type type)
+            {
+                Type = type;
+            }
+
+            /// <summary>
+            /// The type of the object that the property is fetched from. For well-known static methods that
+            /// aren't actually property getters this will return null.
+            /// </summary>
+            internal Type Type { get; }
+
             /// <summary>
             /// Create a property fetcher from a .NET Reflection PropertyInfo class that
             /// represents a property of a particular type.  
             /// </summary>
-            public static PropertyFetch FetcherForProperty(PropertyInfo propertyInfo)
+            public static PropertyFetch FetcherForProperty(Type type, PropertyInfo propertyInfo)
             {
                 if (propertyInfo == null)
                 {
                     // returns null on any fetch.
-                    return new PropertyFetch();
+                    return new PropertyFetch(type);
                 }
 
                 var typedPropertyFetcher = typeof(TypedFetchProperty<,>);
                 var instantiatedTypedPropertyFetcher = typedPropertyFetcher.GetTypeInfo().MakeGenericType(
                     propertyInfo.DeclaringType, propertyInfo.PropertyType);
-                return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, propertyInfo);
+                return (PropertyFetch)Activator.CreateInstance(instantiatedTypedPropertyFetcher, type, propertyInfo);
             }
 
             /// <summary>
@@ -61,7 +75,7 @@
             {
                 private readonly Func<TObject, TProperty> propertyFetch;
 
-                public TypedFetchProperty(PropertyInfo property)
+                public TypedFetchProperty(Type type, PropertyInfo property) : base(type)
                 {
                     this.propertyFetch = (Func<TObject, TProperty>)property.GetMethod.CreateDelegate(typeof(Func<TObject, TProperty>));
                 }

--- a/WEB/Src/Common/PropertyFetcher.cs
+++ b/WEB/Src/Common/PropertyFetcher.cs
@@ -36,11 +36,11 @@
         {
             public PropertyFetch(Type type)
             {
-                Type = type;
+                this.Type = type;
             }
 
             /// <summary>
-            /// The type of the object that the property is fetched from. For well-known static methods that
+            /// Gets the type of the object that the property is fetched from. For well-known static methods that
             /// aren't actually property getters this will return null.
             /// </summary>
             internal Type Type { get; }

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/PropertyFetcherTests.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/PropertyFetcherTests.cs
@@ -1,0 +1,36 @@
+﻿namespace Microsoft.ApplicationInsights.Tests
+{
+    using System;
+    using System.Linq;
+    using System.Net.Http;
+    using System.Net.Http.Headers;
+    using Microsoft.ApplicationInsights.Common;
+    using Microsoft.ApplicationInsights.DependencyCollector.Implementation;
+    using VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class PropertyFetcherTests
+    {
+        [TestMethod]
+        public void FetchWithMultipleObjectTypes()
+        {
+            PropertyFetcher fetcher = new PropertyFetcher("Name");
+
+            string value1 = (string)fetcher.Fetch(new TestClass1 { Name = "Value1" });
+            string value2 = (string)fetcher.Fetch(new TestClass2 { Name = "Value2" });
+
+            Assert.AreEqual("Value1", value1);
+            Assert.AreEqual("Value2", value2);
+        }
+
+        private class TestClass1
+        {
+            public string Name { get; set; }
+        }
+
+        private class TestClass2
+        {
+            public string Name { get; set; }
+        }
+    }
+}


### PR DESCRIPTION
Fix Issue #2194 .

## Changes
Update PropertyFetch to support getting property from multiple types. The change in this PR updates PropertyFetch to match what is in runtime - https://github.com/dotnet/corefx/blob/b8b81a66738bb10ef0790023598396861d92b2c4/src/System.Diagnostics.DiagnosticSource/src/System/Diagnostics/DiagnosticSourceEventSource.cs#L854-L865

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
