### PR TITLE
update and consolidate xunit dependencies

### DIFF
--- a/WEB/Src/Web/Web.Tests/Web.Tests.csproj
+++ b/WEB/Src/Web/Web.Tests/Web.Tests.csproj
@@ -38,6 +38,10 @@
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="Shared" />
 </Project>

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/AzureInstanceMetadataTests.cs
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/AzureInstanceMetadataTests.cs
@@ -210,7 +210,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer
         public void AzureIMSGetFieldByNameFailsWithException()
         {
             AzureInstanceComputeMetadata md = new AzureInstanceComputeMetadata();
-            Assert.Throws(typeof(ArgumentOutOfRangeException), () => md.GetValueForField("not-a-field"));
+            Assert.Throws<ArgumentOutOfRangeException>(() => md.GetValueForField("not-a-field"));
         }
 
         [TestMethod]

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/FirstChanceExceptionStatisticsTelemetryModuleTest.cs
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/FirstChanceExceptionStatisticsTelemetryModuleTest.cs
@@ -117,17 +117,17 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                 }
             }
 
-            Assert.Equal(1, metrics.Count);
+            Assert.Single(metrics);
             Assert.Equal("Exceptions thrown", metrics[0].Key.Name);
 
             var dims = metrics[0].Key.Dimensions;
             Assert.Equal(1, dims.Count);
 
-            Assert.True(dims["problemId"].StartsWith(typeof(Exception).FullName, StringComparison.Ordinal));
+            Assert.StartsWith(typeof(Exception).FullName, dims["problemId"], StringComparison.Ordinal);
 
             int nameStart = dims["problemId"].IndexOf(" at ", StringComparison.OrdinalIgnoreCase) + 4;
 
-            Assert.True(dims["problemId"].Substring(nameStart).StartsWith(typeof(FirstChanceExceptionStatisticsTelemetryModuleTest).FullName + "." + nameof(this.FirstChanceExceptionStatisticsTelemetryModuleTracksMetricWithTypeAndMethodOnException), StringComparison.Ordinal));
+            Assert.StartsWith(typeof(FirstChanceExceptionStatisticsTelemetryModuleTest).FullName + "." + nameof(this.FirstChanceExceptionStatisticsTelemetryModuleTracksMetricWithTypeAndMethodOnException), dims["problemId"].Substring(nameStart), StringComparison.Ordinal);
         }
 
         [TestMethod]
@@ -175,7 +175,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                 }
             }
 
-            Assert.Equal(1, metrics.Count);
+            Assert.Single(metrics);
             Assert.Equal("Exceptions thrown", metrics[0].Key.Name);
 
             var dims = metrics[0].Key.Dimensions;
@@ -221,7 +221,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                 }
             }
 
-            Assert.Equal(1, metrics.Count);
+            Assert.Single(metrics);
             Assert.Equal("Exceptions thrown", metrics[0].Key.Name);
 
             var dims = metrics[0].Key.Dimensions;
@@ -265,7 +265,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                 }
             }
 
-            Assert.Equal(1, metrics.Count);
+            Assert.Single(metrics);
             Assert.Equal("Exceptions thrown", metrics[0].Key.Name);
 
             var dims = metrics[0].Key.Dimensions;
@@ -520,7 +520,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer
                 }
             }
 
-            Assert.Equal(1, metrics.Count);
+            Assert.Single(metrics);
             Assert.Equal("Exceptions thrown", metrics[0].Key.Name);
 
             Assert.Equal(1, metrics[0].Value, 15);

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -15,11 +15,11 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.1.2" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
-    <PackageReference Include="xunit.abstractions" Version="2.0.1" />
-    <PackageReference Include="xunit.assert" Version="2.3.1" />
-    <PackageReference Include="xunit.core" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.core" Version="2.3.1" />
-    <PackageReference Include="xunit.extensibility.execution" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">


### PR DESCRIPTION
This supersedes #2219 and #2210.

Dependabot is trying to update all of our xunit dependencies.
It appears that WindowsServer.Test had several individual xunit dependencies but not the root library.

According to [Xunit Getting Started Guide](https://xunit.net/docs/getting-started/netfx/visual-studio) only two dependencies are recommended:

```
    <PackageReference Include="xunit" Version="2.4.1" />
    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
      <PrivateAssets>all</PrivateAssets>
    </PackageReference>
```

Xunit includes an Analyzer. I've also made the recommended fixes.