### PR TITLE
Fix flaky test - FlushAsyncTransmissionWithThrottle

### DIFF
--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionSenderTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionSenderTest.cs
@@ -342,6 +342,7 @@
                 transmission.IsFlushAsyncInProgress = true;
                 sender.Enqueue(() => transmission);
 
+                Assert.IsTrue(eventIsRaised.Wait(50));
                 // Both accepted and rejected transmission has flush task
                 Assert.IsTrue(eventArgs[0].Transmission.IsFlushAsyncInProgress);
                 Assert.IsTrue(eventArgs[1].Transmission.IsFlushAsyncInProgress);


### PR DESCRIPTION
Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

* Fix flaky test 
* Mark `SerializeNewTransmission` as static to suppress warning 