### PR TITLE
general maintenance

### DIFF
--- a/.props/_GlobalStaticVersion.props
+++ b/.props/_GlobalStaticVersion.props
@@ -11,9 +11,9 @@
       Update for every public release. 
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>17</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
+    <SemanticVersionMinor>18</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone></PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
+    <PreReleaseMilestone>beta1</PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
     <PreReleaseMilestone Condition="'$(NightlyBuild)' == 'True'">nightly</PreReleaseMilestone> <!-- Overwrite this property for nightly builds from the DEVELOP branch. -->
     <!-- 
       Date when Semantic Version was changed. 
@@ -22,7 +22,7 @@
       as it will restart file versions so 2.4.0-beta1 may have higher 
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
-    <SemanticVersionDate>2020-12-01</SemanticVersionDate>
+    <SemanticVersionDate>2020-02-19</SemanticVersionDate>
 
     <!--
       BuildNumber uniquely identifies all builds (The max allowed value is UInt16.MaxValue = 65535).

--- a/.props/_GlobalStaticVersion.props
+++ b/.props/_GlobalStaticVersion.props
@@ -22,7 +22,7 @@
       as it will restart file versions so 2.4.0-beta1 may have higher 
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
-    <SemanticVersionDate>2020-02-19</SemanticVersionDate>
+    <SemanticVersionDate>2021-02-19</SemanticVersionDate>
 
     <!--
       BuildNumber uniquely identifies all builds (The max allowed value is UInt16.MaxValue = 65535).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## VNext
 
 - [Fix PropertyFetcher error when used with multiple types](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2194)
-- [New Task Based Flush API - FlushAsync] (https://github.com/microsoft/ApplicationInsights-dotnet/issues/1743)
+- [New Task Based Flush API - FlushAsync](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1743)
 
 ## Version 2.17.0
 - [Fix: telemetry parent id when using W3C activity format in TelemetryDiagnosticSourceListener](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2142)
@@ -12,7 +12,7 @@
 
 ## Version 2.17.0-beta1
 - [Fix: Missing Dependencies when using Microsoft.Data.SqlClient v2.0.0](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2032)
-- [Add RoleName as a header with Ping Reuests to QuickPulse.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2113)
+- [Add RoleName as a header with Ping Requests to QuickPulse.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2113)
 - [QuickPulseTelemetryModule takes hints from the service regarding the endpoint to ping and how often to ping it](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2120)
 - [Upgrade Log4Net to version 2.0.10 to address CVE-2018-1285](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2149)
 
@@ -62,11 +62,11 @@
 
 ## Version 2.14.0-beta5
 - [Stop collecting EventCounters from Microsoft.AspNetCore.Hosting](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1759)
-- [Enable ILogger provider for apps targetting .NET Framework](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1312)
+- [Enable ILogger provider for apps targeting .NET Framework](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1312)
 
 ## Version 2.14.0-beta4
 - [Fix: SQL dependency names are bloated when running under the .NET Framework and using Microsoft.Data.SqlClient package](https://github.com/microsoft/ApplicationInsights-dotnet/pull/1723)
-- [Fix: Disabling HeartBeats in Asp.Net Core projects causes Error traces every heart beat interval (15 minutes defualt)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1681)
+- [Fix: Disabling HeartBeats in Asp.Net Core projects causes Error traces every heart beat interval (15 minutes default)](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1681)
 - [Standard Metric extractor (Exception,Trace) populates all standard dimensions.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1738)
 - [Add an explicit reference to System.Memory v4.5.4. This fixes a bug in System.Diagnostics.DiagnosticSource. We will remove this dependency when DiagnosticSource is re-released.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1707)
 

--- a/LOGGING/Logging.sln
+++ b/LOGGING/Logging.sln
@@ -83,7 +83,6 @@ Global
 		test\CommonTestShared\CommonTestShared.projitems*{d46fdab7-289d-4990-8289-c0b0fdb3b8ab}*SharedItemsImports = 5
 		test\Shared\Adapters.Shared.Tests.projitems*{d46fdab7-289d-4990-8289-c0b0fdb3b8ab}*SharedItemsImports = 5
 		src\CommonShared\CommonShared.projitems*{e3766dd1-f376-43f8-b242-6cf06e186179}*SharedItemsImports = 5
-		..\BASE\src\Common\Common\Common.projitems*{ed1e83b0-8656-4e2d-bb8b-158a84c45477}*SharedItemsImports = 5
 		test\Shared\Adapters.Shared.Tests.projitems*{fa775630-7917-4a99-a78c-fba46edf685c}*SharedItemsImports = 13
 		test\CommonTestShared\CommonTestShared.projitems*{fe9b0be5-6ddd-41a2-adab-fdae3017fe47}*SharedItemsImports = 5
 		test\Shared\Adapters.Shared.Tests.projitems*{fe9b0be5-6ddd-41a2-adab-fdae3017fe47}*SharedItemsImports = 5

--- a/NETCORE/ApplicationInsights.AspNetCore.sln
+++ b/NETCORE/ApplicationInsights.AspNetCore.sln
@@ -61,13 +61,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionalTests.MVC.Tests",
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FunctionalTests.WebApi.Tests", "test\FunctionalTests.WebApi.Tests\FunctionalTests.WebApi.Tests.csproj", "{E78404EA-CBAA-4366-B659-C3A46BC9DF15}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "IntegrationTests.WebApp", "test\IntegrationTests.WebApp\IntegrationTests.WebApp.csproj", "{AFB5577E-1560-468C-91C7-042080202478}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "IntegrationTests.WebApp", "test\IntegrationTests.WebApp\IntegrationTests.WebApp.csproj", "{AFB5577E-1560-468C-91C7-042080202478}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution
-		..\BASE\src\Common\Common\Common.projitems*{0c91d961-b21e-4760-a192-14193f10b831}*SharedItemsImports = 5
 		..\WEB\Src\Common\Common.projitems*{1056392c-387c-4530-ba3f-aa687ea453ae}*SharedItemsImports = 5
-		..\BASE\src\Common\Common\Common.projitems*{2c7ceedd-bb15-48df-b12a-b268e9d74859}*SharedItemsImports = 5
 		..\WEB\Src\Common\Common.projitems*{3c157fc2-2e52-45fc-87e8-76e4fced4260}*SharedItemsImports = 5
 		..\WEB\Src\PerformanceCollector\Perf.Shared.NetFull\Perf.Shared.NetFull.projitems*{3c157fc2-2e52-45fc-87e8-76e4fced4260}*SharedItemsImports = 5
 		..\LOGGING\src\CommonShared\CommonShared.projitems*{4a9ec531-f8b2-4cd1-bd6b-745f33e52e7b}*SharedItemsImports = 5

--- a/WEB/Src/Microsoft.ApplicationInsights.Web.sln
+++ b/WEB/Src/Microsoft.ApplicationInsights.Web.sln
@@ -73,9 +73,7 @@ Global
 		PerformanceCollector\Perf.Shared.NetFull\Perf.Shared.NetFull.projitems*{00bf736c-b562-4251-9836-ef80282956af}*SharedItemsImports = 5
 		PerformanceCollector\Perf.Shared.NetFull\Perf.Shared.NetFull.projitems*{0196259c-3582-4f4e-a01f-a8f9ae83b0f3}*SharedItemsImports = 13
 		TestFramework\Shared\TestFramework.Shared.projitems*{1231d63b-e7fa-4ba7-9916-fa7325db936d}*SharedItemsImports = 5
-		..\..\BASE\src\Common\Common\Common.projitems*{2bb7f06b-f094-417f-8c1b-7fcca1192e17}*SharedItemsImports = 5
 		Common\Common.projitems*{30ae1a5d-775a-4dec-9f87-849d8ae93e3a}*SharedItemsImports = 5
-		..\..\BASE\src\Common\Common\Common.projitems*{41301181-f4be-4c36-b78d-a29c55cb0469}*SharedItemsImports = 5
 		Common\Common.projitems*{80f0481a-66c7-4442-96d3-5fd841132c4b}*SharedItemsImports = 5
 		Common\Common.projitems*{94127fd9-e516-4891-98d4-ef7523117f32}*SharedItemsImports = 5
 		Common\Common.projitems*{95d90911-2909-4914-920e-7710f7bb6c32}*SharedItemsImports = 5


### PR DESCRIPTION
- opened most commonly used *.sln files and allowed VS to correct markup.
- changed version to 2.18. Set Semantic Date to one day after previous release
- fixed some spelling and formatting in the changelog.
