### PR TITLE
Add config parser class for SelfDiagnostics

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnosticsInternals/SelfDiagnosticsConfigParserTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnosticsInternals/SelfDiagnosticsConfigParserTest.cs
@@ -1,0 +1,75 @@
+﻿namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Tracing.SelfDiagnosticsInternals
+{
+    using Xunit;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.SelfDiagnosticsInternals;
+
+    public class SelfDiagnosticsConfigParserTest
+    {
+        [Fact]
+        public void SelfDiagnosticsConfigParser_TryParseFilePath_Success()
+        {
+            string configJson = "{ \t \n "
+                                + "\t    \"LogDirectory\" \t : \"Diagnostics\", \n"
+                                + "FileSize \t : \t \n"
+                                + " 1024 \n}\n";
+            Assert.True(SelfDiagnosticsConfigParser.TryParseLogDirectory(configJson, out string logDirectory));
+            Assert.Equal("Diagnostics", logDirectory);
+        }
+
+        [Fact]
+        public void SelfDiagnosticsConfigParser_TryParseFilePath_MissingField()
+        {
+            string configJson = @"{
+                    ""path"": ""Diagnostics"",
+                    ""FileSize"": 1024
+                    }";
+            Assert.False(SelfDiagnosticsConfigParser.TryParseLogDirectory(configJson, out string logDirectory));
+        }
+
+        [Fact]
+        public void SelfDiagnosticsConfigParser_TryParseFileSize()
+        {
+            string configJson = @"{
+                    ""LogDirectory"": ""Diagnostics"",
+                    ""FileSize"": 1024
+                    }";
+            Assert.True(SelfDiagnosticsConfigParser.TryParseFileSize(configJson, out int fileSize));
+            Assert.Equal(1024, fileSize);
+        }
+
+        [Fact]
+        public void SelfDiagnosticsConfigParser_TryParseFileSize_CaseInsensitive()
+        {
+            string configJson = @"{
+                    ""LogDirectory"": ""Diagnostics"",
+                    ""fileSize"" :
+                                   2048
+                    }";
+            Assert.True(SelfDiagnosticsConfigParser.TryParseFileSize(configJson, out int fileSize));
+            Assert.Equal(2048, fileSize);
+        }
+
+        [Fact]
+        public void SelfDiagnosticsConfigParser_TryParseFileSize_MissingField()
+        {
+            string configJson = @"{
+                    ""LogDirectory"": ""Diagnostics"",
+                    ""size"": 1024
+                    }";
+            Assert.False(SelfDiagnosticsConfigParser.TryParseFileSize(configJson, out int fileSize));
+        }
+
+        [Fact]
+        public void SelfDiagnosticsConfigParser_TryParseLogLevel()
+        {
+            string configJson = @"{
+                    ""LogDirectory"": ""Diagnostics"",
+                    ""FileSize"": 1024,
+                    ""LogLevel"": ""Error""
+                    }";
+            Assert.True(SelfDiagnosticsConfigParser.TryParseLogLevel(configJson, out string logLevelString));
+            Assert.Equal("Error", logLevelString);
+        }
+    }
+}

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -22,6 +22,7 @@
     <PackageReference Include="Moq" Version="4.10.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="2.2.3" />
     <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
+	<PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnosticsInternals/SelfDiagnosticsConfigParser.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnosticsInternals/SelfDiagnosticsConfigParser.cs
@@ -1,0 +1,128 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.SelfDiagnosticsInternals
+{
+    using System;
+    using System.Diagnostics.Tracing;
+    using System.IO;
+    using System.Text;
+    using System.Text.RegularExpressions;
+
+    internal class SelfDiagnosticsConfigParser
+    {
+        public const string ConfigFileName = "OTEL_DIAGNOSTICS.json";
+        private const int FileSizeLowerLimit = 1024;  // Lower limit for log file size in KB: 1MB
+        private const int FileSizeUpperLimit = 128 * 1024;  // Upper limit for log file size in KB: 128MB
+
+        /// <summary>
+        /// ConfigBufferSize is the maximum bytes of config file that will be read.
+        /// </summary>
+        private const int ConfigBufferSize = 4 * 1024;
+
+        private static readonly Regex LogDirectoryRegex = new Regex(
+            @"""LogDirectory""\s*:\s*""(?<LogDirectory>.*?)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex FileSizeRegex = new Regex(
+            @"""FileSize""\s*:\s*(?<FileSize>\d+)", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        private static readonly Regex LogLevelRegex = new Regex(
+            @"""LogLevel""\s*:\s*""(?<LogLevel>.*?)""", RegexOptions.IgnoreCase | RegexOptions.Compiled);
+
+        // This class is called in SelfDiagnosticsConfigRefresher.UpdateMemoryMappedFileFromConfiguration
+        // in both main thread and the worker thread.
+        // In theory the variable won't be access at the same time because worker thread first Task.Delay for a few seconds.
+        private byte[] configBuffer;
+
+        public bool TryGetConfiguration(out string logDirectory, out int fileSizeInKB, out EventLevel logLevel)
+        {
+            logDirectory = null;
+            fileSizeInKB = 0;
+            logLevel = EventLevel.LogAlways;
+            try
+            {
+                var configFilePath = ConfigFileName;
+
+                // First check using current working directory
+                if (!File.Exists(configFilePath))
+                {
+#if NET452
+                    configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFileName);
+#else
+                    configFilePath = Path.Combine(AppContext.BaseDirectory, ConfigFileName);
+#endif
+
+                    // Second check using application base directory
+                    if (!File.Exists(configFilePath))
+                    {
+                        return false;
+                    }
+                }
+
+                using (FileStream file = File.Open(configFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete))
+                {
+                    var buffer = this.configBuffer;
+                    if (buffer == null)
+                    {
+                        buffer = new byte[ConfigBufferSize]; // Fail silently if OOM
+                        this.configBuffer = buffer;
+                    }
+
+                    file.Read(buffer, 0, buffer.Length);
+                    string configJson = Encoding.UTF8.GetString(buffer);
+                    if (!TryParseLogDirectory(configJson, out logDirectory))
+                    {
+                        return false;
+                    }
+
+                    if (!TryParseFileSize(configJson, out fileSizeInKB))
+                    {
+                        return false;
+                    }
+
+                    if (fileSizeInKB < FileSizeLowerLimit)
+                    {
+                        fileSizeInKB = FileSizeLowerLimit;
+                    }
+
+                    if (fileSizeInKB > FileSizeUpperLimit)
+                    {
+                        fileSizeInKB = FileSizeUpperLimit;
+                    }
+
+                    if (!TryParseLogLevel(configJson, out var logLevelString))
+                    {
+                        return false;
+                    }
+
+                    logLevel = (EventLevel)Enum.Parse(typeof(EventLevel), logLevelString);
+                    return true;
+                }
+            }
+            catch (Exception)
+            {
+                // do nothing on failure to open/read/parse config file
+            }
+
+            return false;
+        }
+
+        internal static bool TryParseLogDirectory(string configJson, out string logDirectory)
+        {
+            var logDirectoryResult = LogDirectoryRegex.Match(configJson);
+            logDirectory = logDirectoryResult.Groups["LogDirectory"].Value;
+            return logDirectoryResult.Success && !string.IsNullOrWhiteSpace(logDirectory);
+        }
+
+        internal static bool TryParseFileSize(string configJson, out int fileSizeInKB)
+        {
+            fileSizeInKB = 0;
+            var fileSizeResult = FileSizeRegex.Match(configJson);
+            return fileSizeResult.Success && int.TryParse(fileSizeResult.Groups["FileSize"].Value, out fileSizeInKB);
+        }
+
+        internal static bool TryParseLogLevel(string configJson, out string logLevel)
+        {
+            var logLevelResult = LogLevelRegex.Match(configJson);
+            logLevel = logLevelResult.Groups["LogLevel"].Value;
+            return logLevelResult.Success && !string.IsNullOrWhiteSpace(logLevel);
+        }
+    }
+}


### PR DESCRIPTION
Issue #2238. Parses the self diagnostics configuration file. This class will be called by ConfigRefresher class after reading file.

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #2238
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
