### PR TITLE
Cosmetics/technical debt  - use pattern matching

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -400,8 +400,7 @@
 
             exceptions.Add(exceptionDetails);
 
-            AggregateException aggregate = exception as AggregateException;
-            if (aggregate != null)
+            if (exception is AggregateException aggregate)
             {
                 foreach (Exception inner in aggregate.InnerExceptions)
                 {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/PageViewData.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/PageViewData.cs
@@ -21,8 +21,8 @@
         protected override void ApplyProperties(EventData other)
         {
             base.ApplyProperties(other);
-            PageViewData otherPageView = other as PageViewData;
-            if (otherPageView != null)
+
+            if (other is PageViewData otherPageView)
             {
                 otherPageView.url = this.url;
                 otherPageView.duration = this.duration;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/PageViewPerfData.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/PageViewPerfData.cs
@@ -20,8 +20,8 @@
         protected override void ApplyProperties(EventData other)
         {
             base.ApplyProperties(other);
-            PageViewPerfData otherPageViewPerf = other as PageViewPerfData;
-            if (otherPageViewPerf != null)
+
+            if (other is PageViewPerfData otherPageViewPerf)
             {
                 otherPageViewPerf.domProcessing = this.domProcessing;
                 otherPageViewPerf.perfTotal = this.perfTotal;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TaskTimerInternal.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TaskTimerInternal.cs
@@ -110,8 +110,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
         /// <param name="exception">Exception to log.</param>
         private static void LogException(Exception exception)
         {
-            var aggregateException = exception as AggregateException;
-            if (aggregateException != null)
+            if (exception is AggregateException aggregateException)
             {
                 aggregateException = aggregateException.Flatten();
                 foreach (Exception e in aggregateException.InnerExceptions)

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -247,10 +247,9 @@
                         }
                     }
                 }
-                
+
                 // Either name was not specified, or we have encountered it first time--need to create new sink instance.
-                var sink = LoadInstance(addElement, typeof(TelemetrySink), null, new object[] { telemetryConfiguration, null }, null) as TelemetrySink;
-                if (sink != null)
+                if (LoadInstance(addElement, typeof(TelemetrySink), null, new object[] { telemetryConfiguration, null }, null) is TelemetrySink sink)
                 {
                     telemetryConfiguration.TelemetrySinks.Add(sink);
                 }
@@ -364,8 +363,7 @@
 
         private static void InitializeComponent(object component, TelemetryConfiguration configuration)
         {
-            var configurable = component as ITelemetryModule;
-            if (configurable != null)
+            if (component is ITelemetryModule configurable)
             {
                 try
                 {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
@@ -76,9 +76,7 @@
                 {
                     foreach (ITelemetryProcessor processor in processors)
                     {
-                        IDisposable disposableProcessor = processor as IDisposable;
-
-                        if (disposableProcessor != null)
+                        if (processor is IDisposable disposableProcessor)
                         {
                             disposableProcessor.Dispose();
                         }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/AutocollectedMetricsExtraction/AutocollectedMetricsExtractor.cs
@@ -522,8 +522,7 @@
         /// <param name="fromItem">The item from which to extract metrics.</param>
         private void ExtractMetrics(ITelemetry fromItem)
         {
-            ISupportSampling potentiallySampledItem = fromItem as ISupportSampling;
-            if (potentiallySampledItem != null && false == this.EnsureItemNotSampled(potentiallySampledItem))
+            if (fromItem is ISupportSampling potentiallySampledItem && false == this.EnsureItemNotSampled(potentiallySampledItem))
             {
                 return;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/DependencyDurationBucketExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/DependencyDurationBucketExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var dep = item as DependencyTelemetry;
-            if (dep != null)
+            if (item is DependencyTelemetry dep)
             {
                 return DurationBucketizer.GetPerformanceBucket(dep.Duration);
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/DependencyResultCodeDimensionExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/DependencyResultCodeDimensionExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var dep = item as DependencyTelemetry;
-            if (dep != null)
+            if (item is DependencyTelemetry dep)
             {
                 return dep.ResultCode;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/SuccessDimensionExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/SuccessDimensionExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var dep = item as DependencyTelemetry;
-            if (dep != null)
+            if (item is DependencyTelemetry dep)
             {
                 bool dependencyFailed = (dep.Success != null) && (dep.Success == false);
                 string dependencySuccessString = dependencyFailed ? bool.FalseString : bool.TrueString;

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/TargetDimensionExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/TargetDimensionExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var dep = item as DependencyTelemetry;
-            if (dep != null)
+            if (item is DependencyTelemetry dep)
             {
                 return dep.Target;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/TypeDimensionExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/DependencyExtractor/TypeDimensionExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var dep = item as DependencyTelemetry;
-            if (dep != null)
+            if (item is DependencyTelemetry dep)
             {
                 return dep.Type;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestExtractor/DurationBucketExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestExtractor/DurationBucketExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var req = item as RequestTelemetry;
-            if (req != null)
+            if (item is RequestTelemetry req)
             {
                 return DurationBucketizer.GetPerformanceBucket(req.Duration);
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestExtractor/RequestResponseCodeDimensionExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestExtractor/RequestResponseCodeDimensionExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var req = item as RequestTelemetry;
-            if (req != null)
+            if (item is RequestTelemetry req)
             {
                 return req.ResponseCode;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestExtractor/RequestSuccessDimensionExtractor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/AutocollectedMetricsExtraction/RequestExtractor/RequestSuccessDimensionExtractor.cs
@@ -14,8 +14,7 @@
 
         public string ExtractDimension(ITelemetry item)
         {
-            var req = item as RequestTelemetry;
-            if (req != null)
+            if (item is RequestTelemetry req)
             {
                 bool isFailed = req.Success.HasValue
                                 ? (req.Success.Value == false)

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Implementation/Util.cs
@@ -173,8 +173,7 @@
             }
             else
             {
-                string stringValue = metricValue as string;
-                if (stringValue != null)
+                if (metricValue is string stringValue)
                 {
                     double doubleValue;
                     if (Double.TryParse(stringValue, NumberStyles.Any, CultureInfo.InvariantCulture, out doubleValue))

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricConfiguration.cs
@@ -157,8 +157,7 @@
         {
             if (obj != null)
             {
-                var otherConfig = obj as MetricConfiguration;
-                if (otherConfig != null)
+                if (obj is MetricConfiguration otherConfig)
                 {
                     return this.Equals(otherConfig);
                 }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricIdentifier.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricIdentifier.cs
@@ -505,9 +505,7 @@
         /// <returns>Whether the specified other object is equal to this object based on the respective namespaces, IDs and dimension names.</returns>
         public override bool Equals(object otherObj)
         {
-            MetricIdentifier otherMetricIdentifier = otherObj as MetricIdentifier;
-
-            if (otherMetricIdentifier != null)
+            if (otherObj is MetricIdentifier otherMetricIdentifier)
             {
                 return this.Equals(otherMetricIdentifier);
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricSeriesConfigurationForMeasurement.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricSeriesConfigurationForMeasurement.cs
@@ -67,8 +67,7 @@
         {
             if (obj != null)
             {
-                var otherConfig = obj as MetricSeriesConfigurationForMeasurement;
-                if (otherConfig != null)
+                if (obj is MetricSeriesConfigurationForMeasurement otherConfig)
                 {
                     return this.Equals(otherConfig);
                 }

--- a/BASE/src/ServerTelemetryChannel/Implementation/TaskTimerInternal.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TaskTimerInternal.cs
@@ -111,8 +111,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implement
         /// <param name="exception">Exception to log.</param>
         private static void LogException(Exception exception)
         {
-            var aggregateException = exception as AggregateException;
-            if (aggregateException != null)
+            if (exception is AggregateException aggregateException)
             {
                 aggregateException = aggregateException.Flatten();
                 foreach (Exception e in aggregateException.InnerExceptions)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-
+- Reduce technical debt: Use pattern matching
 
 
 ## Version 2.18.0-beta1

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
@@ -110,8 +110,7 @@
 
         private void PopulateTelemetry(ITelemetry telemetry, IReadOnlyList<KeyValuePair<string, object>> stateDictionary, EventId eventId)
         {
-            var telemetryWithProperties = telemetry as ISupportProperties;
-            if (telemetryWithProperties != null)
+            if (telemetry is ISupportProperties telemetryWithProperties)
             {
                 IDictionary<string, string> dict = telemetryWithProperties.Properties;
                 dict["CategoryName"] = this.categoryName;

--- a/NETCORE/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/NETCORE/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -265,8 +265,7 @@ namespace Microsoft.Extensions.DependencyInjection
 
                 foreach (ITelemetryProcessor processor in configuration.TelemetryProcessors)
                 {
-                    ITelemetryModule module = processor as ITelemetryModule;
-                    if (module != null)
+                    if (processor is ITelemetryModule module)
                     {
                         module.Initialize(configuration);
                     }
@@ -303,8 +302,7 @@ namespace Microsoft.Extensions.DependencyInjection
         {
             if (this.applicationInsightsServiceOptions.EnableQuickPulseMetricStream)
             {
-                QuickPulseTelemetryModule quickPulseModule = this.modules.FirstOrDefault((module) => module.GetType() == typeof(QuickPulseTelemetryModule)) as QuickPulseTelemetryModule;
-                if (quickPulseModule != null)
+                if (this.modules.FirstOrDefault((module) => module.GetType() == typeof(QuickPulseTelemetryModule)) is QuickPulseTelemetryModule quickPulseModule)
                 {
                     QuickPulseTelemetryProcessor processor = null;
                     configuration.DefaultTelemetrySink.TelemetryProcessorChainBuilder.Use((next) =>

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Filter.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Filter.cs
@@ -243,9 +243,7 @@
 
         private static MethodInfo GetMethodInfo<T, TResult>(Expression<Func<T, TResult>> expression)
         {
-            var member = expression.Body as MethodCallExpression;
-
-            if (member != null)
+            if (expression.Body is MethodCallExpression member)
             {
                 return member.Method;
             }
@@ -255,9 +253,7 @@
 
         private static MethodInfo GetMethodInfo<T1, T2, TResult>(Expression<Func<T1, T2, TResult>> expression)
         {
-            var member = expression.Body as MethodCallExpression;
-
-            if (member != null)
+            if (expression.Body is MethodCallExpression member)
             {
                 return member.Method;
             }


### PR DESCRIPTION
## Changes
This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "Convert 'as' expression type check and the following null check into pattern matching"  [rule](https://www.jetbrains.com/help/resharper/UsePatternMatching.html) reported by ReSharper.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.