### PR TITLE
fix Test projects dependency, Microsoft.AspNetCore.App

### DIFF
--- a/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
+++ b/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
@@ -41,7 +41,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.27" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="2.1.1" />
   </ItemGroup>
 

--- a/NETCORE/test/IntegrationTests.WebApp/IntegrationTests.WebApp.csproj
+++ b/NETCORE/test/IntegrationTests.WebApp/IntegrationTests.WebApp.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.27" />
+    <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.1.2" PrivateAssets="All" />
 
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="5.0.0" />


### PR DESCRIPTION

Fix for the following compiler warnings:





- Warning	NETSDK1071:	A PackageReference to 'Microsoft.AspNetCore.App' specified a Version of 2.1.27. Specifying the version of this package is not recommended. For more information, see https://aka.ms/sdkimplicitrefs	



- Warning	NU1608: Detected package version outside of dependency constraint: Microsoft.AspNetCore.App 2.1.27 requires System.Runtime.CompilerServices.Unsafe (>= 4.5.3 && < 4.6.0) but version System.Runtime.CompilerServices.Unsafe 5.0.0 was resolved.	



- Warning	NU1608:	Detected package version outside of dependency constraint: Microsoft.AspNetCore.App 2.1.27 requires System.Security.Permissions (>= 4.5.0 && < 4.6.0) but version System.Security.Permissions 4.7.0 was resolved.	


