### PR TITLE
cleanup frameworks in AspNetCore

### DIFF
--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -150,9 +150,7 @@
 
                     // NetStandard2.0 has a package reference to Microsoft.Extensions.Logging.ApplicationInsights, and
                     // enables ApplicationInsightsLoggerProvider by default.
-#if NETSTANDARD2_0 || NET461
                     AddApplicationInsightsLoggerProvider(services);
-#endif
                 }
 
                 return services;

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
@@ -37,6 +37,7 @@
             {
                 configBuilder.AddConfiguration(this.userConfiguration);
             }
+
             configBuilder.AddJsonFile("appsettings.json", true)
                          .AddJsonFile(string.Format(CultureInfo.InvariantCulture, "appsettings.{0}.json", this.hostingEnvironment.EnvironmentName), true)
                          .AddEnvironmentVariables();

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
@@ -33,12 +33,10 @@
         {
             var configBuilder = new ConfigurationBuilder()
                 .SetBasePath(this.hostingEnvironment.ContentRootPath ?? Directory.GetCurrentDirectory());
-#if NETSTANDARD2_0 || NET461
             if (this.userConfiguration != null)
             {
                 configBuilder.AddConfiguration(this.userConfiguration);
             }
-#endif
             configBuilder.AddJsonFile("appsettings.json", true)
                          .AddJsonFile(string.Format(CultureInfo.InvariantCulture, "appsettings.{0}.json", this.hostingEnvironment.EnvironmentName), true)
                          .AddEnvironmentVariables();

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/RequestCollectionOptions.cs
@@ -17,11 +17,7 @@
 
             // In NetStandard20, ApplicationInsightsLoggerProvider is enabled by default,
             // which captures Exceptions. Disabling it in RequestCollectionModule to avoid duplication.
-#if NETSTANDARD2_0 || NET461
             this.TrackExceptions = false;
-#else
-            this.TrackExceptions = true;
-#endif
         }
 
         /// <summary>

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLogger.cs
@@ -19,7 +19,7 @@
     [SuppressMessage("Documentation Rules", "SA1614:ElementParameterDocumentationMustHaveText", Justification = "This class is obsolete and will not be completely documented.")]
     internal class ApplicationInsightsLogger : ILogger
     {
-#if NET461
+#if NETFRAMEWORK
         /// <summary>
         /// SDK Version Prefix.
         /// </summary>

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerProvider.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Logging/Implementation/ApplicationInsightsLoggerProvider.cs
@@ -9,11 +9,12 @@
     /// <summary>
     /// <see cref="ILoggerProvider"/> implementation that creates returns instances of <see cref="ApplicationInsightsLogger"/>.
     /// </summary>
-#if !NETSTANDARD2_0 && !NET461
-    // For NETSTANDARD2.0 and NET461 We take dependency on Microsoft.Extensions.Logging.ApplicationInsights which has ApplicationInsightsProvider having the same ProviderAlias and don't want to clash with this ProviderAlias.
-    [ProviderAlias("ApplicationInsights")]
-#endif
+    /// <remarks>
+    /// THIS CLASS IS OBSOLETE.
+    /// For NETSTANDARD2.0 and NET461 We take dependency on Microsoft.Extensions.Logging.ApplicationInsights which has ApplicationInsightsProvider having the same ProviderAlias and don't want to clash with this ProviderAlias.
+    /// </remarks>
     [SuppressMessage("Documentation Rules", "SA1614:ElementParameterDocumentationMustHaveText", Justification = "This class is obsolete and will not be completely documented.")]
+    [Obsolete] 
     internal class ApplicationInsightsLoggerProvider : ILoggerProvider
     {
         private readonly TelemetryClient telemetryClient;

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -37,7 +37,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR '$(TargetFramework)' == 'net461' ">
+  <ItemGroup>
     <!--
     Microsoft.AspNetCore.Http has a vulnerability https://msrc.microsoft.com/update-guide/vulnerability/CVE-2020-1045
     System.Text.Encodings.Web has a vulnerability https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-26701 

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/SdkVersionUtils.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/SdkVersionUtils.cs
@@ -8,7 +8,7 @@
     /// </summary>
     internal class SdkVersionUtils
     {
-#if NET461
+#if NETFRAMEWORK
         /// <summary>
         /// SDK Version Prefix.
         /// </summary>

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -59,10 +59,8 @@
         private const string DeveloperModeForWebSites = "APPINSIGHTS_DEVELOPER_MODE";
         private const string EndpointAddressForWebSites = "APPINSIGHTS_ENDPOINTADDRESS";
 
-#if NETSTANDARD2_0 || NET461
         private const string ApplicationInsightsSectionFromConfig = "ApplicationInsights";
         private const string TelemetryChannelSectionFromConfig = "ApplicationInsights:TelemetryChannel";
-#endif
 
         [SuppressMessage("Microsoft.Performance", "CA1823:AvoidUnusedPrivateFields", Justification = "Used in NetStandard2.0 build.")]
         private const string EventSourceNameForSystemRuntime = "System.Runtime";
@@ -242,10 +240,8 @@
         {
             try
             {
-#if NETSTANDARD2_0 || NET461
                 config.GetSection(ApplicationInsightsSectionFromConfig).Bind(serviceOptions);
                 config.GetSection(TelemetryChannelSectionFromConfig).Bind(serviceOptions);
-#endif
 
                 if (config.TryGetValue(primaryKey: ConnectionStringEnvironmentVariable, backupKey: ConnectionStringFromConfig, value: out string connectionStringValue))
                 {
@@ -405,7 +401,6 @@
         [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "services parameter is used in only NetStandard 2.0 build.")]
         private static void AddApplicationInsightsLoggerProvider(IServiceCollection services)
         {
-#if NETSTANDARD2_0 || NET461
             services.AddLogging(loggingBuilder =>
             {
                 loggingBuilder.AddApplicationInsights();
@@ -435,7 +430,6 @@
                             LogLevel.Warning,
                             null)));
             });
-#endif
         }
     }
 }

--- a/NETCORE/src/Shared/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
+++ b/NETCORE/src/Shared/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializer.cs
@@ -43,7 +43,7 @@ namespace Microsoft.ApplicationInsights.WorkerService.TelemetryInitializers
             string hostName = Dns.GetHostName();
 
             // Issue #61: For dnxcore machine name does not have domain name like in full framework
-#if NET461
+#if NETFRAMEWORK
             string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;
             if (!hostName.EndsWith(domainName, StringComparison.OrdinalIgnoreCase))
             {

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
@@ -101,9 +101,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// Else, it invokes services.AddApplicationInsightsTelemetry(configuration) where IConfiguration object is supplied by caller.
         /// </param>
         [Theory]
-#if !NET46
-        [InlineData(true)]
-#endif
         [InlineData(false)]
         public static void RegistersTelemetryConfigurationFactoryMethodThatReadsInstrumentationKeyFromConfiguration(bool useDefaultConfig)
         {
@@ -214,9 +211,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// Else, it invokes services.AddApplicationInsightsTelemetry(configuration) where IConfiguration object is supplied by caller.
         /// </param>
         [Theory]
-#if !NET46
-        [InlineData(true)]
-#endif
         [InlineData(false)]
         public static void RegistersTelemetryConfigurationFactoryMethodThatReadsEndpointAddressFromConfiguration(bool useDefaultConfig)
         {
@@ -697,12 +691,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// </param>
         /// <param name="isEnable">Sets the value for property EnableLegacyCorrelationHeadersInjection.</param>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void RegistersTelemetryConfigurationFactoryMethodThatPopulatesDependencyCollectorWithCustomValues(string configType, bool isEnable)
@@ -1020,11 +1012,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                                                                                                             == typeof(RequestTrackingTelemetryModule));
 
             Assert.True(requestTrackingModule.CollectionOptions.InjectResponseHeaders);
-#if NETCOREAPP || NET461
             Assert.False(requestTrackingModule.CollectionOptions.TrackExceptions);
-#else
-                Assert.True(requestTrackingModule.CollectionOptions.TrackExceptions);
-#endif
         }
 
         /// <summary>
@@ -1039,12 +1027,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// </param>
         /// <param name="isEnable">Sets the value for property InjectResponseHeaders, TrackExceptions and EnableW3CDistributedTracing.</param>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void ConfigureRequestTrackingTelemetryCustomOptions(string configType, bool isEnable)
@@ -1141,12 +1127,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// </param>
         /// <param name="isEnable">Sets the value for property EnableAdaptiveSampling.</param>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void DoesNotAddSamplingToConfigurationIfExplicitlyControlledThroughParameter(string configType, bool isEnable)
@@ -1357,12 +1341,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// </param>
         /// <param name="isEnable">Sets the value for property AddAutoCollectedMetricExtractor.</param>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void DoesNotAddAutoCollectedMetricsExtractorToConfigurationIfExplicitlyControlledThroughParameter(string configType, bool isEnable)
@@ -1410,12 +1392,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         /// </param>
         /// <param name="isEnable">Sets the value for property EnableAuthenticationTrackingJavaScript.</param>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableAuthenticationTrackingJavaScript(string configType, bool isEnable)
@@ -1529,8 +1509,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             loggerProvider.AddApplicationInsights(serviceProvider, (s, level) => true, null);
             loggerProvider.AddApplicationInsights(serviceProvider, (s, level) => true, null);
         }
-
-#if NETCOREAPP || NET461
 
         /// <summary>
         /// Creates two copies of ApplicationInsightsServiceOptions. First object is created by calling services.AddApplicationInsightsTelemetry() or services.AddApplicationInsightsTelemetry(config).
@@ -1723,6 +1701,5 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             Assert.Equal(appSettingsConfig["ApplicationInsights:InstrumentationKey"], telemetryConfiguration.InstrumentationKey);
         }
-#endif
     }
 }

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/BaseTestClass.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/BaseTestClass.cs
@@ -59,10 +59,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 config = new ConfigurationBuilder().Build();
             }
 
-#if NET46
-            // In NET46, we don't read from default configuration or bind configuration. 
-            services.AddApplicationInsightsTelemetry(config);
-#else
+
             if (useDefaultConfig)
             {
                 services.AddSingleton<IConfiguration>(config);
@@ -72,7 +69,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             {
                 services.AddApplicationInsightsTelemetry(config);
             }
-#endif
+
             if (serviceOptions != null)
             {
                 services.Configure(serviceOptions);

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsServiceOptionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsServiceOptionsTests.cs
@@ -100,10 +100,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
                 config = configBuilder.Build();
             }
 
-#if NET46
-            // In NET46, we don't read from default configuration or bind configuration. 
-            services.AddApplicationInsightsTelemetry(config);
-#else
             if (useDefaultConfig)
             {
                 services.AddSingleton<IConfiguration>(config);
@@ -113,7 +109,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
             {
                 services.AddApplicationInsightsTelemetry(config);
             }
-#endif
 
             servicesConfig?.Invoke(services);
 
@@ -135,12 +130,11 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// Enabling this will copy the AspNetCore config to the TC.Active static instance.
         /// </summary>
         [Theory]
-#if !NET46
+
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableTelemetryConfigurationActive(string configType, bool isEnable)
@@ -190,12 +184,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable PerformanceCounterCollectionModule by setting EnablePerformanceCounterCollectionModule.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisablePerfCollectorModule(string configType, bool isEnable)
@@ -234,12 +226,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable DependencyTrackingTelemetryModule by setting EnableDependencyTrackingTelemetryModule.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableDependencyCollectorModule(string configType, bool isEnable)
@@ -255,12 +245,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable QuickPulseCollectorModule by setting EnableQuickPulseMetricStream.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableQuickPulseCollectorModule(string configType, bool isEnable)
@@ -276,12 +264,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable AzureInstanceMetadataModule by setting EnableAzureInstanceMetadataTelemetryModule.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableAzureInstanceMetadataModule(string configType, bool isEnable)
@@ -297,12 +283,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable RequestTrackingTelemetryModule by setting EnableRequestTrackingTelemetryModule.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableRequestCounterCollectorModule(string configType, bool isEnable)
@@ -318,12 +302,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable AppServiceHeartbeatModule by setting EnableAppServicesHeartbeatTelemetryModule.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableAppServiceHeartbeatModule(string configType, bool isEnable)
@@ -339,12 +321,10 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         /// User could enable or disable <see cref="DiagnosticsTelemetryModule"/> by setting <see cref="ApplicationInsightsServiceOptions.EnableDiagnosticsTelemetryModule"/>.
         /// </summary>
         [Theory]
-#if !NET46
         [InlineData("DefaultConfiguration", true)]
         [InlineData("DefaultConfiguration", false)]
         [InlineData("SuppliedConfiguration", true)]
         [InlineData("SuppliedConfiguration", false)]
-#endif
         [InlineData("Code", true)]
         [InlineData("Code", false)]
         public static void UserCanEnableAndDisableDiagnosticsTelemetryModule(string configType, bool isEnable)

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -14,12 +14,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Update="content\*">
-      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
-  </ItemGroup>
-
-  <ItemGroup>
     <ProjectReference Include="..\..\src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.csproj" />
   </ItemGroup>
 

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/SdkVersionTestUtils.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/SdkVersionTestUtils.cs
@@ -2,7 +2,7 @@
 {
     public class SdkVersionTestUtils
     {
-#if NET452 || NET46 || NET461
+#if NETFRAMEWORK
         public const string VersionPrefix = "aspnet5f:";
 #else
         public const string VersionPrefix = "aspnet5c:";

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/DomainNameRoleInstanceTelemetryInitializerTests.cs
@@ -24,7 +24,7 @@
 
             string hostName = Dns.GetHostName();
 
-#if NET46 || NET461
+#if NETFRAMEWORK
             string domainName = IPGlobalProperties.GetIPGlobalProperties().DomainName;
             if (hostName.EndsWith(domainName, StringComparison.OrdinalIgnoreCase) == false)
             {


### PR DESCRIPTION
I'm having problems with #2277 .
This PR is to cleanup existing frameworks in the AspNetCore projects.

## Changes
- Remove unnecessary preprocessors.
    - `#if NETSTANDARD2_0 || NET461` These are the only two frameworks in this project.
- Replace `#NET461` with `#NETFRAMEWORK`

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
