### PR TITLE
cleanup Base SDK Frameworks

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/TransmissionTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/TransmissionTest.cs
@@ -386,7 +386,7 @@
 
             }
 
-#if NETCOREAPP2_1 || NETCOREAPP3_1
+#if NETCOREAPP
             [TestMethod]
             public async Task SendAsyncLogsIngestionReponseTimeEventCounter()
             {
@@ -425,9 +425,7 @@
                         // Max should be more than 30 ms, as we introduced a delay of 30ms in SendAsync.
 #if NETCOREAPP2_1
                         Assert.IsTrue((float)payload["Max"] >= 30);
-#endif
-
-#if NETCOREAPP3_1
+#elif NETCOREAPP3_1
                         Assert.IsTrue((double)payload["Max"] >= 30);
 #endif
                     }
@@ -474,9 +472,7 @@
                         // Mean should be more than 30 ms, as we introduced a delay of 30ms in SendAsync.
 #if NETCOREAPP2_1
                         Assert.IsTrue((float)payload["Mean"] >= 30);
-#endif
-
-#if NETCOREAPP3_1
+#elif NETCOREAPP3_1
                         Assert.IsTrue((double)payload["Mean"] >= 30);
 #endif
                     }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Platform/PlatformImplementationTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Platform/PlatformImplementationTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
 {
-#if !NETCOREAPP
+#if NETFRAMEWORK
     using System;
     using System.IO;
     using System.Security;

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Platform/PlatformReferencesTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Platform/PlatformReferencesTests.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Platform
 {
-#if !NETCOREAPP
+#if NETFRAMEWORK
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
 

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/RichPayloadEventSourceTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/RichPayloadEventSourceTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 {
-#if !NETCOREAPP
+#if NETFRAMEWORK
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.Tracing;

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/FailOnAssertSetup.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/FailOnAssertSetup.cs
@@ -4,7 +4,7 @@
 
 namespace Microsoft.ApplicationInsights
 {
-#if !NETCOREAPP
+#if NETFRAMEWORK
     using System;
     using System.Diagnostics;
     using System.Linq;

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/BackoffLogicManagerTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/BackoffLogicManagerTest.cs
@@ -94,7 +94,7 @@
             [TestMethod]
             public void UpperBoundOfDelayIsMaxDelay()
             {
-#if !NETCOREAPP
+#if NETFRAMEWORK
                 var manager = new BackoffLogicManager(TimeSpan.Zero, TimeSpan.Zero);
 
                 PrivateObject wrapper = new PrivateObject(manager);

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TelemetryBufferTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TelemetryBufferTest.cs
@@ -30,7 +30,7 @@
                 AssertEx.Throws<ArgumentNullException>(() => new TelemetryBuffer(null, new StubApplicationLifecycle()));
             }
 
-#if !NETCOREAPP
+#if NETFRAMEWORK
             [TestMethod]
             public void ConstructorThrowsArgumentNullExceptionWhenApplicationLifecycleIsNull()
             {

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/WebApplicationLifecycleTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/WebApplicationLifecycleTest.cs
@@ -1,6 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
-#if !NETCOREAPP
+#if NETFRAMEWORK
     using System;
     using System.Threading.Tasks;
     using System.Web.Hosting;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -397,7 +397,7 @@
                 {
                     instance = TimeSpan.Parse(valueString, CultureInfo.InvariantCulture);
                 }
-#if NET452 || NET46
+#if NETFRAMEWORK
                 else if (expectedType.IsEnum)
 #else
                 else if (expectedType.GetTypeInfo().IsEnum)

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/BaseDefaultHeartbeatPropertyProvider.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/BaseDefaultHeartbeatPropertyProvider.cs
@@ -84,14 +84,14 @@
         /// <returns>a string representing the version of the current .NET framework.</returns>
         private static string GetRuntimeFrameworkVer()
         {
-#if NET452 || NET46
+#if NETFRAMEWORK
             Assembly assembly = typeof(Object).GetTypeInfo().Assembly;
             AssemblyFileVersionAttribute objectAssemblyFileVer =
                         assembly.GetCustomAttributes(typeof(AssemblyFileVersionAttribute))
                                 .Cast<AssemblyFileVersionAttribute>()
                                 .FirstOrDefault();
             return objectAssemblyFileVer != null ? objectAssemblyFileVer.Version : "undefined";
-#elif NETSTANDARD2_0
+#elif NETSTANDARD
             return System.Runtime.InteropServices.RuntimeInformation.FrameworkDescription;
 #else
 #error Unrecognized framework
@@ -127,11 +127,11 @@
         private static string GetRuntimeOsType()
         {
             string osValue = "unknown";
-#if NET452 || NET46
+#if NETFRAMEWORK
 
             osValue = Environment.OSVersion.Platform.ToString();
 
-#elif NETSTANDARD2_0
+#elif NETSTANDARD
             
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
             {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/WeakConcurrentRandom.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/WeakConcurrentRandom.cs
@@ -72,7 +72,7 @@ namespace Microsoft.ApplicationInsights.Extensibility.Implementation
 
         public static WeakConcurrentRandom Instance
         {
-#if NET452 || NET46
+#if NETFRAMEWORK
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
             get

--- a/BASE/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/PreciseTimestamp.cs
@@ -2,7 +2,7 @@
 {
     using System;
     using System.Diagnostics;
-#if NET452 || NET46
+#if NETFRAMEWORK
     using System.Diagnostics.CodeAnalysis;
     using System.Threading;
 #endif
@@ -14,7 +14,7 @@
         /// </summary>
         internal static readonly double StopwatchTicksToTimeSpanTicks = (double)TimeSpan.TicksPerSecond / Stopwatch.Frequency;
 
-#if NET452 || NET46
+#if NETFRAMEWORK
         private static readonly Timer SyncTimeUpdater;
         private static TimeSync timeSync = new TimeSync();
 
@@ -30,7 +30,7 @@
         /// </summary>
         public static DateTimeOffset GetUtcNow()
         {
-#if NET452 || NET46
+#if NETFRAMEWORK
             // DateTime.UtcNow accuracy on .NET Framework is ~16ms, this method 
             // uses combination of Stopwatch and DateTime to calculate accurate UtcNow.
 
@@ -46,7 +46,7 @@
 #endif
         }
 
-#if NET452 || NET46
+#if NETFRAMEWORK
         private static void Sync()
         {
             // wait for DateTime.UtcNow update to the next granular value

--- a/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -262,7 +262,7 @@
         {
             string baseDirectory = string.Empty;
 
-#if !NETSTANDARD
+#if NETFRAMEWORK
             baseDirectory = AppDomain.CurrentDomain.BaseDirectory;
 #else
             baseDirectory = AppContext.BaseDirectory;

--- a/BASE/src/ServerTelemetryChannel/Implementation/TelemetryBuffer.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TelemetryBuffer.cs
@@ -34,7 +34,7 @@
                 throw new ArgumentNullException(nameof(serializer));
             }
 
-#if !NETSTANDARD
+#if NETFRAMEWORK
             // We don't have implementation for IApplicationLifecycle for .NET Core
             if (applicationLifecycle == null)
             {

--- a/BASE/src/ServerTelemetryChannel/Implementation/WeakConcurrentRandom.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/WeakConcurrentRandom.cs
@@ -66,7 +66,7 @@
 
         public static WeakConcurrentRandom Instance
         {
-#if NET452 || NET46
+#if NETFRAMEWORK
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
             get

--- a/BASE/src/ServerTelemetryChannel/Implementation/WebApplicationLifecycle.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/WebApplicationLifecycle.cs
@@ -1,4 +1,4 @@
-﻿#if !NETSTANDARD
+﻿#if NETFRAMEWORK
 namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
 {
     using System;

--- a/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
+++ b/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
@@ -31,7 +31,7 @@
         /// <summary>
         /// Initializes a new instance of the <see cref="ServerTelemetryChannel"/> class.
         /// </summary>
-#if !NETSTANDARD
+#if NETFRAMEWORK
         [SuppressMessage("Microsoft.Reliability", "CA2000:DisposeObjectsBeforeLosingScope", Justification = "WebApplicationLifecycle is needed for the life of the application.")]
         public ServerTelemetryChannel() : this(new Network(), new WebApplicationLifecycle())
 #else
@@ -45,7 +45,7 @@
         {
             var policies = new TransmissionPolicy[] 
             { 
-#if !NETSTANDARD
+#if NETFRAMEWORK
                 // We don't have implementation for IApplicationLifecycle for .NET Core
                 new ApplicationLifecycleTransmissionPolicy(applicationLifecycle),
 #endif


### PR DESCRIPTION
I'm having problems with #2277 .
This PR is to cleanup existing frameworks in the Base projects.

## Changes
- use `#NETFRAMEWORK` instead of `#!NETCORE` 
- replace `#if NET452 || NET46` with `#NETFRAMEWORK`

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
