### PR TITLE
AAD: with QuickPulse

### DIFF
--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetFull/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -388,8 +388,6 @@
                     MonitoringDataPoint.CurrentInvariantVersion.ToString(CultureInfo.InvariantCulture));
             }
 
-            // TODO: THIS NEEDS TO CHANGE. IF THE TOKEN IS NOT AVAILABLE, NO NOT SEND. SHOULD NOT MAKE THIS IN THIS METHOD.
-            // The AAD token is an optional feature. Only include if it is provided.
             if (!string.IsNullOrEmpty(authToken))
             {
                 request.Headers.Add(QuickPulseConstants.AuthorizationHeaderName, QuickPulseConstants.AuthorizationTokenPrefix + authToken);

--- a/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Shared.NetStandard/Implementation/QuickPulse/QuickPulseServiceClient.cs
@@ -416,8 +416,6 @@
                     MonitoringDataPoint.CurrentInvariantVersion.ToString(CultureInfo.InvariantCulture));
             }
 
-            // TODO: THIS NEEDS TO CHANGE. IF THE TOKEN IS NOT AVAILABLE, NO NOT SEND. SHOULD NOT MAKE THIS IN THIS METHOD.
-            // The AAD token is an optional feature. Only include if it is provided.
             if (!string.IsNullOrEmpty(authToken))
             {
                 request.Headers.TryAddWithoutValidation(QuickPulseConstants.AuthorizationHeaderName, QuickPulseConstants.AuthorizationTokenPrefix + authToken);

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/Mocks/QuickPulseServiceClientMock.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/Mocks/QuickPulseServiceClientMock.cs
@@ -74,6 +74,7 @@
             DateTimeOffset timestamp,
             string configurationETag,
             string authApiKey,
+            string authToken,
             out CollectionConfigurationInfo configurationInfo,
             out TimeSpan? servicePollingIntervalHint)
         {
@@ -107,6 +108,7 @@
             string instrumentationKey,
             string configurationETag,
             string authApiKey,
+            string authToken,
             out CollectionConfigurationInfo configurationInfo,
             CollectionConfigurationError[] collectionConfigurationErrors)
         {

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseCollectionStateManagerTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseCollectionStateManagerTests.cs
@@ -4,6 +4,7 @@
     using System.Collections.Generic;
     using System.Linq;
 
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Filtering;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse;
@@ -22,10 +23,10 @@
         private const string UpdatedConfigurationMessage = "UpdatedConfiguration";
 
         private static readonly CollectionConfigurationInfo EmptyCollectionConfigurationInfo = new CollectionConfigurationInfo()
-                                                                                                   {
-                                                                                                       ETag = string.Empty,
-                                                                                                       Metrics = new CalculatedMetricInfo[0]
-                                                                                                   };
+        {
+            ETag = string.Empty,
+            Metrics = new CalculatedMetricInfo[0]
+        };
 
         [TestMethod]
         public void QuickPulseCollectionStateManagerDoesNothingWithoutInstrumentationKey()
@@ -54,6 +55,7 @@
             var serviceClient = new QuickPulseServiceClientMock();
 
             var manager = new QuickPulseCollectionStateManager(
+                TelemetryConfiguration.CreateDefault(),
                 serviceClient,
                 new Clock(),
                 QuickPulseTimings.Default,
@@ -334,7 +336,7 @@
             timeProvider.FastForward(TimeSpan.FromSeconds(2));
             Assert.AreEqual(timings.ServicePollingBackedOffInterval, manager.UpdateState("some ikey", string.Empty));
         }
-        
+
         [TestMethod]
         public void QuickPulseCollectionStateManagerPingDoesNotBackOffOnFirstPing()
         {
@@ -378,7 +380,7 @@
             // ASSERT
             Assert.AreEqual(timings.ServicePollingInterval, manager.UpdateState(string.Empty, string.Empty));
         }
-        
+
         [TestMethod]
         public void QuickPulseCollectionStateManagerSubmitBacksOff()
         {
@@ -680,7 +682,7 @@
             Assert.AreEqual(Predicate.Equal.ToString(), errors[3].Data["FilterPredicate"]);
             Assert.AreEqual("Request1", errors[3].Data["FilterComparand"]);
         }
-        
+
         [TestMethod]
         public void QuickPulseCollectionStateManagerRespectsServicePollingIntervalHint()
         {
@@ -693,7 +695,7 @@
             var manager = CreateManager(serviceClient, timeProvider, actions, returnedSamples, timings);
             TimeSpan intervalHint1 = TimeSpan.FromSeconds(65);
             TimeSpan intervalHint2 = TimeSpan.FromSeconds(75);
-            
+
             // ACT
             serviceClient.ReturnValueFromPing = false;
 
@@ -726,20 +728,21 @@
             List<CollectionConfigurationInfo> collectionConfigurationInfos = null)
         {
             var manager = new QuickPulseCollectionStateManager(
+                TelemetryConfiguration.CreateDefault(),
                 serviceClient,
                 timeProvider,
                 timings ?? QuickPulseTimings.Default,
                 () => actions.Add(StartCollectionMessage),
                 () => actions.Add(StopCollectionMessage),
                 () =>
-                    {
-                        actions.Add(CollectMessage);
+                {
+                    actions.Add(CollectMessage);
 
-                        CollectionConfigurationError[] errors;
-                        var now = DateTimeOffset.UtcNow;
-                        return
-                            new[]
-                            {
+                    CollectionConfigurationError[] errors;
+                    var now = DateTimeOffset.UtcNow;
+                    return
+                        new[]
+                        {
                                 new QuickPulseDataSample(
                                     new QuickPulseDataAccumulator(
                                         new CollectionConfiguration(EmptyCollectionConfigurationInfo, out errors, timeProvider))
@@ -751,21 +754,21 @@
                                     new Dictionary<string, Tuple<PerformanceCounterData, double>>(),
                                     Enumerable.Empty<Tuple<string, int>>(),
                                     false)
-                            }.ToList();
-                    },
+                        }.ToList();
+                },
                 samples =>
-                    {
-                        returnedSamples?.AddRange(samples);
-                    },
+                {
+                    returnedSamples?.AddRange(samples);
+                },
                 collectionConfigurationInfo =>
-                    {
-                        actions.Add(UpdatedConfigurationMessage);
-                        collectionConfigurationInfos?.Add(collectionConfigurationInfo);
+                {
+                    actions.Add(UpdatedConfigurationMessage);
+                    collectionConfigurationInfos?.Add(collectionConfigurationInfo);
 
-                        CollectionConfigurationError[] errors;
-                        new CollectionConfiguration(collectionConfigurationInfo, out errors, timeProvider);
-                        return errors;
-                    },
+                    CollectionConfigurationError[] errors;
+                    new CollectionConfiguration(collectionConfigurationInfo, out errors, timeProvider);
+                    return errors;
+                },
                 _ => { });
 
             return manager;

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseServiceClientTests.cs
@@ -101,24 +101,24 @@
             this.emulateTimeout = false;
 
             this.pingResponse = response =>
-                {
-                    response.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
+            {
+                response.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
 
-                    foreach (string headerName in QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames)
-                    {
-                        response.Headers.Add(headerName, opaqueAuthHeaderValuesToRespondWith[headerName]);
-                    }
-                };
+                foreach (string headerName in QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames)
+                {
+                    response.Headers.Add(headerName, opaqueAuthHeaderValuesToRespondWith[headerName]);
+                }
+            };
 
             this.submitResponse = response =>
-                {
-                    response.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
+            {
+                response.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
 
-                    foreach (string headerName in QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames)
-                    {
-                        response.Headers.Add(headerName, opaqueAuthHeaderValuesToRespondWith[headerName]);
-                    }
-                };
+                foreach (string headerName in QuickPulseConstants.XMsQpsAuthOpaqueHeaderNames)
+                {
+                    response.Headers.Add(headerName, opaqueAuthHeaderValuesToRespondWith[headerName]);
+                }
+            };
 
             // dynamic port range is [49152, 65535]
             int port;
@@ -172,9 +172,9 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
-            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
-            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(string.Empty, timestamp, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 3);
@@ -244,6 +244,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -319,6 +320,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -362,7 +364,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample1 }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample1 }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -412,7 +414,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample1, sample2 }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample1, sample2 }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -486,7 +488,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -553,7 +555,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample1, sample2 }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample1, sample2 }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -581,7 +583,7 @@
             // ACT
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString()); };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -608,7 +610,7 @@
             // ACT
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString()); };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -635,7 +637,7 @@
             // ACT
             this.pingResponse = r => { r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, "bla"); };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -662,7 +664,7 @@
             // ACT
             this.pingResponse = r => { };
             CollectionConfigurationInfo configurationInfo;
-            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            bool? response = serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -694,6 +696,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -727,6 +730,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -760,6 +764,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -793,6 +798,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -823,7 +829,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(string.Empty, DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -857,6 +863,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 new CollectionConfigurationError[0]);
 
@@ -884,23 +891,23 @@
                 0);
 
             this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
+
+                var collectionConfigurationInfo = new CollectionConfigurationInfo()
                 {
-                    r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
-                    r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
-
-                    var collectionConfigurationInfo = new CollectionConfigurationInfo()
-                    {
-                        ETag = "ETag2",
-                        Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
-                    };
-
-                    var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
-                    serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+                    ETag = "ETag2",
+                    Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
                 };
+
+                var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
+                serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+            };
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("ikey", now, "ETag1", string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -933,23 +940,23 @@
                     false);
 
             this.submitResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
+
+                var collectionConfigurationInfo = new CollectionConfigurationInfo()
                 {
-                    r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, false.ToString());
-                    r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
-
-                    var collectionConfigurationInfo = new CollectionConfigurationInfo()
-                    {
-                        ETag = "ETag2",
-                        Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
-                    };
-
-                    var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
-                    serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+                    ETag = "ETag2",
+                    Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
                 };
+
+                var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
+                serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+            };
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -975,23 +982,23 @@
                 0);
 
             this.pingResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
+
+                var collectionConfigurationInfo = new CollectionConfigurationInfo()
                 {
-                    r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
-                    r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
-
-                    var collectionConfigurationInfo = new CollectionConfigurationInfo()
-                    {
-                        ETag = "ETag2",
-                        Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
-                    };
-
-                    var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
-                    serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+                    ETag = "ETag2",
+                    Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
                 };
+
+                var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
+                serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+            };
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("ikey", now, "ETag1", string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("ikey", now, "ETag1", string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1026,23 +1033,23 @@
                     false);
 
             this.submitResponse = r =>
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
+
+                var collectionConfigurationInfo = new CollectionConfigurationInfo()
                 {
-                    r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
-                    r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
-
-                    var collectionConfigurationInfo = new CollectionConfigurationInfo()
-                    {
-                        ETag = "ETag2",
-                        Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
-                    };
-
-                    var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
-                    serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+                    ETag = "ETag2",
+                    Metrics = new[] { new CalculatedMetricInfo() { Id = "Id1" } }
                 };
+
+                var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
+                serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+            };
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1070,19 +1077,19 @@
                 0);
 
             this.pingResponse = r =>
-                {
-                    r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
-                    r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
 
-                    var collectionConfigurationInfo = new CollectionConfigurationInfo() { ETag = "ETag2", Metrics = null };
+                var collectionConfigurationInfo = new CollectionConfigurationInfo() { ETag = "ETag2", Metrics = null };
 
-                    var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
-                    serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
-                };
+                var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
+                serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+            };
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("ikey", now, "ETag2", string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("ikey", now, "ETag2", string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1115,19 +1122,19 @@
                     false);
 
             this.submitResponse = r =>
-                {
-                    r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
-                    r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
+            {
+                r.Headers.Add(QuickPulseConstants.XMsQpsSubscribedHeaderName, true.ToString());
+                r.Headers.Add(QuickPulseConstants.XMsQpsConfigurationETagHeaderName, "ETag2");
 
-                    var collectionConfigurationInfo = new CollectionConfigurationInfo() { ETag = "ETag2", Metrics = null };
+                var collectionConfigurationInfo = new CollectionConfigurationInfo() { ETag = "ETag2", Metrics = null };
 
-                    var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
-                    serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
-                };
+                var serializer = new DataContractJsonSerializer(typeof(CollectionConfigurationInfo));
+                serializer.WriteObject(r.OutputStream, collectionConfigurationInfo);
+            };
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag2", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag2", string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1195,7 +1202,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1229,7 +1236,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1258,7 +1265,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
 
             // ASSERT
@@ -1293,7 +1300,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1323,7 +1330,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1360,7 +1367,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1388,7 +1395,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1424,7 +1431,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1451,7 +1458,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(Guid.NewGuid().ToString(), DateTimeOffset.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1486,7 +1493,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1514,7 +1521,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping(Guid.NewGuid().ToString(), timeProvider.UtcNow, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping(Guid.NewGuid().ToString(), timeProvider.UtcNow, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1552,7 +1559,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1581,7 +1588,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1616,7 +1623,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1646,7 +1653,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("some ikey", now, string.Empty, authApiKey, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("some ikey", now, string.Empty, authApiKey, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1681,7 +1688,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, authApiKey, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, authApiKey, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1714,10 +1721,10 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // received the proper headers, now re-submit them
-            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.Ping("some ikey", now, string.Empty, string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 2);
@@ -1761,10 +1768,10 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // received the proper headers, now re-submit them
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 2);
@@ -1802,8 +1809,8 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
-            serviceClient.Ping(string.Empty, now, "ETag1", string.Empty, out configurationInfo, out TimeSpan? _);
+            serviceClient.SubmitSamples(new[] { sample }, string.Empty, "ETag1", string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.Ping(string.Empty, now, "ETag1", string.Empty, null, out configurationInfo, out TimeSpan? _);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1855,6 +1862,7 @@
                 string.Empty,
                 string.Empty,
                 string.Empty,
+                null,
                 out configurationInfo,
                 collectionConfigurationErrors);
 
@@ -1902,7 +1910,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1937,7 +1945,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -1972,7 +1980,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -2009,7 +2017,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -2049,7 +2057,7 @@
 
             // ACT
             CollectionConfigurationInfo configurationInfo;
-            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, out configurationInfo, new CollectionConfigurationError[0]);
+            serviceClient.SubmitSamples(new[] { sample }, ikey, string.Empty, string.Empty, null, out configurationInfo, new CollectionConfigurationError[0]);
 
             // SYNC
             this.WaitForProcessing(requestCount: 1);
@@ -2083,7 +2091,7 @@
             };
 
             // ACT
-            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out TimeSpan? servicePollingIntervalHint);
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, null, out _, out TimeSpan? servicePollingIntervalHint);
 
             // ASSERT
             Assert.AreEqual(TimeSpan.FromMilliseconds(ms), servicePollingIntervalHint);
@@ -2112,7 +2120,7 @@
             };
 
             // ACT
-            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out TimeSpan? servicePollingIntervalHint);
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, null, out _, out TimeSpan? servicePollingIntervalHint);
 
             // ASSERT
             Assert.IsNull(servicePollingIntervalHint);
@@ -2141,7 +2149,7 @@
             };
 
             // ACT
-            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out TimeSpan? servicePollingIntervalHint);
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, null, out _, out TimeSpan? servicePollingIntervalHint);
 
             // ASSERT
             Assert.IsNull(servicePollingIntervalHint);
@@ -2171,7 +2179,7 @@
             };
 
             // ACT
-            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out _);
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, null, out _, out _);
 
             // SYNC
             this.WaitForProcessing(1);
@@ -2205,7 +2213,7 @@
             };
 
             // ACT
-            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out _);
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, null, out _, out _);
 
             // SYNC
             this.WaitForProcessing(1);
@@ -2239,7 +2247,7 @@
             };
 
             // ACT
-            serviceClient.Ping("ikey", now, string.Empty, string.Empty, out _, out _);
+            serviceClient.Ping("ikey", now, string.Empty, string.Empty, null, out _, out _);
 
             // SYNC
             this.WaitForProcessing(1);

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/IQuickPulseServiceClient.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/IQuickPulseServiceClient.cs
@@ -20,6 +20,7 @@
         /// <param name="timestamp">Timestamp to pass to the server.</param>
         /// <param name="configurationETag">Current configuration ETag that the client has.</param>
         /// <param name="authApiKey">Authentication API key.</param>
+        /// <param name="authToken">Authorization token to be included on Http messages.</param>
         /// <param name="configurationInfo">When available, the deserialized response data received from the server.</param>
         /// <param name="servicePollingIntervalHint">When available, a hint regarding what the period should be when pinging the server going forward.</param>
         /// <returns><b>true</b> if data is expected, otherwise <b>false</b>.</returns>
@@ -28,6 +29,7 @@
             DateTimeOffset timestamp,
             string configurationETag,
             string authApiKey,
+            string authToken,
             out CollectionConfigurationInfo configurationInfo,
             out TimeSpan? servicePollingIntervalHint);
 
@@ -38,6 +40,7 @@
         /// <param name="instrumentationKey">InstrumentationKey for which to submit data samples.</param>
         /// <param name="configurationETag">Current configuration ETag that the client has.</param>
         /// <param name="authApiKey">Authentication API key.</param>
+        /// <param name="authToken">Authorization token to be included on Http messages.</param>
         /// <param name="configurationInfo">When available, the deserialized response data received from the server.</param>
         /// <param name="collectionConfigurationErrors">Errors to be reported back to the server.</param>
         /// <returns><b>true</b> if the client is expected to keep sending data samples, <b>false</b> otherwise.</returns>
@@ -46,6 +49,7 @@
             string instrumentationKey,
             string configurationETag,
             string authApiKey,
+            string authToken,
             out CollectionConfigurationInfo configurationInfo,
             CollectionConfigurationError[] collectionConfigurationErrors);
     }

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -34,8 +34,10 @@
 
         private readonly List<CollectionConfigurationError> collectionConfigurationErrors = new List<CollectionConfigurationError>();
 
+        private readonly TelemetryConfiguration telemetryConfiguration;
+
         private DateTimeOffset lastSuccessfulPing;
-        
+
         private DateTimeOffset lastSuccessfulSubmit;
 
         private bool isCollectingData;
@@ -47,74 +49,31 @@
         private TimeSpan? latestServicePollingIntervalHint = null;
 
         public QuickPulseCollectionStateManager(
-            IQuickPulseServiceClient serviceClient, 
-            Clock timeProvider, 
-            QuickPulseTimings timings, 
-            Action onStartCollection, 
-            Action onStopCollection, 
-            Func<IList<QuickPulseDataSample>> onSubmitSamples, 
+            TelemetryConfiguration telemetryConfiguration,
+            IQuickPulseServiceClient serviceClient,
+            Clock timeProvider,
+            QuickPulseTimings timings,
+            Action onStartCollection,
+            Action onStopCollection,
+            Func<IList<QuickPulseDataSample>> onSubmitSamples,
             Action<IList<QuickPulseDataSample>> onReturnFailedSamples,
             Func<CollectionConfigurationInfo, CollectionConfigurationError[]> onUpdatedConfiguration,
             Action<Uri> onUpdatedServiceEndpoint)
         {
-            if (serviceClient == null)
-            {
-                throw new ArgumentNullException(nameof(serviceClient));
-            }
-
-            if (timeProvider == null)
-            {
-                throw new ArgumentNullException(nameof(timeProvider));
-            }
-
-            if (timings == null)
-            {
-                throw new ArgumentNullException(nameof(timings));
-            }
-            
-            if (onStartCollection == null)
-            {
-                throw new ArgumentNullException(nameof(onStartCollection));
-            }
-
-            if (onStopCollection == null)
-            {
-                throw new ArgumentNullException(nameof(onStopCollection));
-            }
-
-            if (onSubmitSamples == null)
-            {
-                throw new ArgumentNullException(nameof(onSubmitSamples));
-            }
-
-            if (onReturnFailedSamples == null)
-            {
-                throw new ArgumentNullException(nameof(onReturnFailedSamples));
-            }
-
-            if (onUpdatedConfiguration == null)
-            {
-                throw new ArgumentNullException(nameof(onUpdatedConfiguration));
-            }
-
-            if (onUpdatedServiceEndpoint == null)
-            {
-                throw new ArgumentNullException(nameof(onUpdatedServiceEndpoint));
-            }
-
-            this.serviceClient = serviceClient;
-            this.timeProvider = timeProvider;
-            this.timings = timings;
-            this.onStartCollection = onStartCollection;
-            this.onStopCollection = onStopCollection;
-            this.onSubmitSamples = onSubmitSamples;
-            this.onReturnFailedSamples = onReturnFailedSamples;
-            this.onUpdatedConfiguration = onUpdatedConfiguration;
-            this.onUpdatedServiceEndpoint = onUpdatedServiceEndpoint;
+            this.telemetryConfiguration = telemetryConfiguration ?? throw new ArgumentNullException(nameof(telemetryConfiguration));
+            this.serviceClient = serviceClient ?? throw new ArgumentNullException(nameof(serviceClient));
+            this.timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+            this.timings = timings ?? throw new ArgumentNullException(nameof(timings));
+            this.onStartCollection = onStartCollection ?? throw new ArgumentNullException(nameof(onStartCollection));
+            this.onStopCollection = onStopCollection ?? throw new ArgumentNullException(nameof(onStopCollection));
+            this.onSubmitSamples = onSubmitSamples ?? throw new ArgumentNullException(nameof(onSubmitSamples));
+            this.onReturnFailedSamples = onReturnFailedSamples ?? throw new ArgumentNullException(nameof(onReturnFailedSamples));
+            this.onUpdatedConfiguration = onUpdatedConfiguration ?? throw new ArgumentNullException(nameof(onUpdatedConfiguration));
+            this.onUpdatedServiceEndpoint = onUpdatedServiceEndpoint ?? throw new ArgumentNullException(nameof(onUpdatedServiceEndpoint));
 
             this.coolDownTimeout = TimeSpan.FromMilliseconds(timings.CollectionInterval.TotalMilliseconds / 20);
         }
-        
+
         public bool IsCollectingData
         {
             get
@@ -179,6 +138,7 @@
                     instrumentationKey,
                     this.currentConfigurationETag,
                     authApiKey,
+                    this.telemetryConfiguration.CredentialEnvelope?.GetToken(),
                     out configurationInfo,
                     this.collectionConfigurationErrors.ToArray());
 
@@ -213,11 +173,12 @@
                     this.timeProvider.UtcNow,
                     this.currentConfigurationETag,
                     authApiKey,
+                    this.telemetryConfiguration.CredentialEnvelope?.GetToken(),
                     out configurationInfo,
                     out TimeSpan? servicePollingIntervalHint);
 
                 this.latestServicePollingIntervalHint = servicePollingIntervalHint ?? this.latestServicePollingIntervalHint;
-                
+
                 QuickPulseEventSource.Log.PingSentEvent(this.currentConfigurationETag, configurationInfo?.ETag, startCollection.ToString());
 
                 switch (startCollection)
@@ -280,7 +241,7 @@
                 this.currentConfigurationETag = configurationInfo.ETag;
             }
         }
-        
+
         private TimeSpan DetermineBackOffs()
         {
             if (this.IsCollectingData)

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -110,7 +110,6 @@
             string authToken = null;
             if (this.telemetryConfiguration.CredentialEnvelope != null)
             {
-                // TODO: NEED TO VERIFY THIS IS NOT TRACKED AS A DEPENDENCY
                 authToken = this.telemetryConfiguration.CredentialEnvelope.GetToken();
                 if (authToken == null)
                 {

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -110,6 +110,7 @@
             string authToken = null;
             if (this.telemetryConfiguration.CredentialEnvelope != null)
             {
+                // TODO: NEED TO VERIFY THIS IS NOT TRACKED AS A DEPENDENCY
                 authToken = this.telemetryConfiguration.CredentialEnvelope.GetToken();
                 if (authToken == null)
                 {

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -107,6 +107,18 @@
                 this.firstStateUpdate = false;
             }
 
+            string authToken = null;
+            if (this.telemetryConfiguration.CredentialEnvelope != null)
+            {
+                authToken = this.telemetryConfiguration.CredentialEnvelope.GetToken();
+                if (authToken == null)
+                {
+                    // If a credential has been set on the configuration and we fail to get a token, do net send.
+                    QuickPulseEventSource.Log.FailedToGetAuthToken();
+                    return this.DetermineBackOffs();
+                }
+            }
+
             CollectionConfigurationInfo configurationInfo;
             if (this.IsCollectingData)
             {
@@ -138,7 +150,7 @@
                     instrumentationKey,
                     this.currentConfigurationETag,
                     authApiKey,
-                    this.telemetryConfiguration.CredentialEnvelope?.GetToken(),
+                    authToken,
                     out configurationInfo,
                     this.collectionConfigurationErrors.ToArray());
 
@@ -173,7 +185,7 @@
                     this.timeProvider.UtcNow,
                     this.currentConfigurationETag,
                     authApiKey,
-                    this.telemetryConfiguration.CredentialEnvelope?.GetToken(),
+                    authToken,
                     out configurationInfo,
                     out TimeSpan? servicePollingIntervalHint);
 

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseConstants.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseConstants.cs
@@ -5,6 +5,10 @@
     /// </summary>
     internal static class QuickPulseConstants
     {
+        internal const string AuthorizationHeaderName = "Authorization";
+
+        internal const string AuthorizationTokenPrefix = "Bearer ";
+
         /// <summary>
         /// Subscribed header.
         /// </summary>

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -161,7 +161,11 @@
             this.WriteEvent(23, oldEtag ?? string.Empty, newEtag ?? string.Empty, configuration ?? string.Empty, e ?? string.Empty, this.applicationNameProvider.Name);
         }
 
-        [Event(24, Message = "QuickPulse failed to get an auth token. Check error log for full exception.", Level = EventLevel.Error)]
+        /// <summary>
+        /// Logs an error indicating that the QuickPulseServiceClient could not acquire an auth token.
+        /// Full exception is logged in the Base SDK at <see cref="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.CoreEventSource.FailedToGetToken"/>.
+        /// </summary>
+        [Event(24, Message = "QuickPulse failed to get an auth token. Check 'CoreEventSource.FailedToGetToken' for full exception.", Level = EventLevel.Error)]
         public void FailedToGetAuthToken(string applicationName = "dummy")
         {
             this.WriteEvent(24, this.applicationNameProvider.Name);

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseEventSource.cs
@@ -161,6 +161,12 @@
             this.WriteEvent(23, oldEtag ?? string.Empty, newEtag ?? string.Empty, configuration ?? string.Empty, e ?? string.Empty, this.applicationNameProvider.Name);
         }
 
+        [Event(24, Message = "QuickPulse failed to get an auth token. Check error log for full exception.", Level = EventLevel.Error)]
+        public void FailedToGetAuthToken(string applicationName = "dummy")
+        {
+            this.WriteEvent(24, this.applicationNameProvider.Name);
+        }
+
         #endregion
 
         public class Keywords

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryModule.cs
@@ -195,6 +195,7 @@
                         this.InitializeServiceClient(configuration);
                         
                         this.stateManager = new QuickPulseCollectionStateManager(
+                            configuration,
                             this.ServiceClient,
                             this.timeProvider,
                             this.timings,


### PR DESCRIPTION
Parent issue #2190.
These changes are originally from #2220. 

## Changes
- Changes to the `QuickPulseServiceClient` to support `TelemetryConfiguration.CredentialEnvelope`

## TODO
- Needs more unit tests to confirm configuration and behavior. I can't find any QuickPulse tests that validate request headers.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
