### PR TITLE
Fix AzureSdkDiagnosticListener from crashing user app

### DIFF
--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -119,7 +119,6 @@
                 Assert.AreEqual(sendActivity.SpanId.ToHexString(), telemetry.Id);
 
                 Assert.AreEqual("v1", telemetry.Properties["k1"]);
-
                 Assert.IsTrue(telemetry.Properties.TryGetValue("tracestate", out var tracestate));
                 Assert.AreEqual("state=some", tracestate);
             }
@@ -873,7 +872,6 @@
                     .AddTag("serviceRequestId", "service-request-id");
 
                 listener.StopActivity(httpActivity, payload);
-
                 var telemetry = this.sentItems.Last() as DependencyTelemetry;
 
                 Assert.IsNotNull(telemetry);

--- a/WEB/Src/DependencyCollector/DependencyCollector/HttpCoreDiagnosticSourceListener.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/HttpCoreDiagnosticSourceListener.cs
@@ -82,8 +82,8 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         private readonly bool injectRequestIdInW3CMode = true;
 
         public HttpCoreDiagnosticSourceListener(
-            TelemetryConfiguration configuration, 
-            bool setComponentCorrelationHttpHeaders, 
+            TelemetryConfiguration configuration,
+            bool setComponentCorrelationHttpHeaders,
             IEnumerable<string> correlationDomainExclusionList,
             bool injectLegacyHeaders,
             bool injectRequestIdInW3CMode,
@@ -97,7 +97,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             this.setComponentCorrelationHttpHeaders = setComponentCorrelationHttpHeaders;
             this.correlationDomainExclusionList = correlationDomainExclusionList ?? Enumerable.Empty<string>();
             this.injectLegacyHeaders = injectLegacyHeaders;
-            this.httpInstrumentationVersion = instrumentationVersion != HttpInstrumentationVersion.Unknown ? 
+            this.httpInstrumentationVersion = instrumentationVersion != HttpInstrumentationVersion.Unknown ?
                 instrumentationVersion :
                 GetInstrumentationVersion();
             this.injectRequestIdInW3CMode = injectRequestIdInW3CMode;
@@ -318,7 +318,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             }
 
             if (Activity.DefaultIdFormat == ActivityIdFormat.W3C &&
-                request.Headers.TryGetValues(W3C.W3CConstants.TraceParentHeader, out var parents) && 
+                request.Headers.TryGetValues(W3C.W3CConstants.TraceParentHeader, out var parents) &&
                 parents.FirstOrDefault() != currentActivity.Id)
             {
                 DependencyCollectorEventSource.Log.HttpRequestAlreadyInstrumented();
@@ -619,7 +619,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
                         }
 
                         // Add the parent ID
-                        string parentId = currentActivity.IdFormat == ActivityIdFormat.W3C ? 
+                        string parentId = currentActivity.IdFormat == ActivityIdFormat.W3C ?
                             currentActivity.SpanId.ToHexString() :
                             currentActivity.Id;
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -24,7 +24,7 @@
 
         protected override IDiagnosticEventHandler GetEventHandler(string diagnosticListenerName)
         {
-            return new AzureSdkDiagnosticsEventHandler(this.Configuration);
+            return new AzureSdkDiagnosticsEventHandler(this.Client);
         }
     }
 }

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -25,7 +25,7 @@
         // fetcher is created per AzureSdkDiagnosticsEventHandler and AzureSdkDiagnosticsEventHandler is created per DiagnosticSource
         private readonly PropertyFetcher linksPropertyFetcher = new PropertyFetcher("Links");
 
-        public AzureSdkDiagnosticsEventHandler(TelemetryConfiguration configuration) : base(configuration)
+        public AzureSdkDiagnosticsEventHandler(TelemetryClient client) : base(client)
         {
         }
 
@@ -159,7 +159,7 @@
                     // instrumentation does not consistently report enqueued time, ignoring whole span
                     return false;
                 }
-                
+
                 long startEpochTime = 0;
 #if NET452
                 startEpochTime = (long)(requestStartTime - EpochStart).TotalMilliseconds;
@@ -318,7 +318,7 @@
                 return;
             }
 
-            // Target uniquely identifies the resource, we use both: queueName and endpoint 
+            // Target uniquely identifies the resource, we use both: queueName and endpoint
             // with schema used for SQL-dependencies
             string separator = "/";
             if (endpoint.EndsWith(separator, StringComparison.Ordinal))

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs
@@ -9,7 +9,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
-    /// Base implementation of DiagnosticSource listener. 
+    /// Base implementation of DiagnosticSource listener.
     /// Takes care of managing subscriptions to multiple sources and their events.
     /// </summary>
     /// <typeparamref name="TContext">The type of processing context for given diagnostic source.</typeparamref>
@@ -17,7 +17,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
     {
         protected static readonly ConcurrentDictionary<DiagnosticListener, ActiveSubsciptionManager> SubscriptionManagers =
             new ConcurrentDictionary<DiagnosticListener, ActiveSubsciptionManager>();
-    
+
         protected readonly TelemetryClient Client;
         protected readonly TelemetryConfiguration Configuration;
 
@@ -80,9 +80,9 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
             var manager = SubscriptionManagers.GetOrAdd(value, k => new ActiveSubsciptionManager());
 
             var individualListener = new IndividualDiagnosticSourceListener(
-                value, 
-                eventHandler, 
-                this, 
+                value,
+                eventHandler,
+                this,
                 this.GetListenerContext(value),
                 manager);
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
@@ -31,6 +31,11 @@
             this.TelemetryClient = new TelemetryClient(configuration);
         }
 
+        protected DiagnosticsEventHandlerBase(TelemetryClient client)
+        {
+            this.TelemetryClient = client;
+        }
+
         public virtual bool IsEventEnabled(string evnt, object arg1, object arg2)
         {
             return !evnt.EndsWith(TelemetryDiagnosticSourceListener.ActivityStartNameSuffix, StringComparison.Ordinal);


### PR DESCRIPTION
AzureSdkDiagnosticListener component within DependencyTrackingTelemetryModule currently instantiates a new TelemetryClient, whenever a new Listener is created. (any statement like new DiagnosticListener("Azure.somename") will trigger this. All Azure sdks does this inside them)

In the event that the telemetryconfig used to initialize the module is disposed, but the DependencyTrackingTelemetryModule itself is not disposed, any attempt to create new AzureSdkListener() will result in an unhandled exception from the SDK, as AzureSdkDiagnosticListener will try to instantiate a new TelemetryClient using a disposed config. 

This violates the SDK's error handling policy of never crashing customer application after a successful initialization.

This PR modifies AzureSdk listener to create a single TelemetryClient during initialization, and re-use it for every subsequent AzureSdkListeners. If config is disposed, telemetry is not tracked (must be obvious!), but this PR also prevents the unhandled exception.

Issues like https://github.com/microsoft/ApplicationInsights-dotnet/issues/2195 will be fixed with this PR. However, the user code which is disposing telemetry config, without disposing the DependencyTrackingTelemetryModule must be fixed - but this is not a SDK bug, but user code issue and must handled by end users.