### PR TITLE
Fix AzureSdkDiagnosticListener from crashing user app

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - Reduce technical debt: Use pattern matching
 - [Improve Self Diagnostics and support setting configuration in file](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2238)
+- [Fix AzureSdkDiagnosticListener from crashing user app.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2294)
 
 
 ## Version 2.18.0-beta1

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -24,7 +24,7 @@
 
         protected override IDiagnosticEventHandler GetEventHandler(string diagnosticListenerName)
         {
-            return new AzureSdkDiagnosticsEventHandler(this.Configuration);
+            return new AzureSdkDiagnosticsEventHandler(this.Client);
         }
     }
 }

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -25,7 +25,7 @@
         // fetcher is created per AzureSdkDiagnosticsEventHandler and AzureSdkDiagnosticsEventHandler is created per DiagnosticSource
         private readonly PropertyFetcher linksPropertyFetcher = new PropertyFetcher("Links");
 
-        public AzureSdkDiagnosticsEventHandler(TelemetryConfiguration configuration) : base(configuration)
+        public AzureSdkDiagnosticsEventHandler(TelemetryClient client) : base(client)
         {
         }
 
@@ -159,7 +159,7 @@
                     // instrumentation does not consistently report enqueued time, ignoring whole span
                     return false;
                 }
-                
+
                 long startEpochTime = 0;
 #if NET452
                 startEpochTime = (long)(requestStartTime - EpochStart).TotalMilliseconds;
@@ -318,7 +318,7 @@
                 return;
             }
 
-            // Target uniquely identifies the resource, we use both: queueName and endpoint 
+            // Target uniquely identifies the resource, we use both: queueName and endpoint
             // with schema used for SQL-dependencies
             string separator = "/";
             if (endpoint.EndsWith(separator, StringComparison.Ordinal))

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/EventHandlers/DiagnosticsEventHandlerBase.cs
@@ -31,6 +31,11 @@
             this.TelemetryClient = new TelemetryClient(configuration);
         }
 
+        protected DiagnosticsEventHandlerBase(TelemetryClient client)
+        {
+            this.TelemetryClient = client;
+        }
+
         public virtual bool IsEventEnabled(string evnt, object arg1, object arg2)
         {
             return !evnt.EndsWith(TelemetryDiagnosticSourceListener.ActivityStartNameSuffix, StringComparison.Ordinal);


### PR DESCRIPTION
AzureSdkDiagnosticListener component within DependencyTrackingTelemetryModule currently instantiates a new TelemetryClient, whenever a new Listener is created. (any statement like new DiagnosticListener("Azure.somename") will trigger this. All Azure sdks does this inside them)

In the event that the telemetryconfig used to initialize the module is disposed, but the DependencyTrackingTelemetryModule itself is not disposed, any attempt to create new AzureSdkListener() will result in an unhandled exception from the SDK, as AzureSdkDiagnosticListener will try to instantiate a new TelemetryClient using a disposed config.

This violates the SDK's error handling policy of never crashing customer application after a successful initialization.

This PR modifies AzureSdk listener to create a single TelemetryClient during initialization, and re-use it for every subsequent AzureSdkListeners. If config is disposed, telemetry is not tracked (must be obvious!), but this PR also prevents the unhandled exception.

Issues like #2195 will be fixed with this PR. However, the user code which is disposing telemetry config, without disposing the DependencyTrackingTelemetryModule must be fixed - but this is not a SDK bug, but user code issue and must handled by end users.