### PR TITLE
Adds .NET 5.0 tests for telemetrychannel. Move to use framework ref

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(PropsRoot)\Test.props" />
-  
+
   <PropertyGroup>
     <TargetFrameworks>net452;net46;net461;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -27,10 +27,10 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net452' ">
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
-  
+
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'  Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' ">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.30" />
-    
+
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />
     <Reference Include="System.Management" />
@@ -49,6 +49,6 @@
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
-  
+
   <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="TestFramework.Shared" />
 </Project>

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/LocalInProcHttpServer.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/LocalInProcHttpServer.cs
@@ -1,4 +1,4 @@
-﻿#if NETCOREAPP2_1
+﻿#if NETCOREAPP3_1_OR_GREATER
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using System;

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
 
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.Tests</AssemblyName>
   </PropertyGroup>

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net452;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net452;netcoreapp2.1;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
 
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.Tests</AssemblyName>
@@ -21,12 +21,8 @@
     <PackageReference Include="CompareNETObjects" Version="4.59.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.2.0" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net5.0'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">


### PR DESCRIPTION
This should help with SDL issues about using 2.x packages of aspnetcore