### PR TITLE
Enable the self diagnostics and fix a NullReferenceException bug

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsEventListenerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsEventListenerTest.cs
@@ -85,6 +85,15 @@
         }
 
         [TestMethod]
+        public void SelfDiagnosticsEventListener_EncodeInBuffer_Null()
+        {
+            byte[] buffer = new byte[20];
+            int startPos = 0;
+            int endPos = SelfDiagnosticsEventListener.EncodeInBuffer(null, false, buffer, startPos);
+            Assert.AreEqual(startPos, endPos);
+        }
+
+        [TestMethod]
         public void SelfDiagnosticsEventListener_EncodeInBuffer_Empty()
         {
             byte[] buffer = new byte[20];

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsEventListenerTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsEventListenerTest.cs
@@ -1,11 +1,9 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.SelfDiagnostics
 {
     using System;
-    using System.Collections.Generic;
     using System.Diagnostics.Tracing;
-    using System.Linq;
+    using System.Globalization;
     using System.Text;
-    using System.Threading.Tasks;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Moq;
 
@@ -55,9 +53,9 @@
             // Check DateTimeKind of Utc, Local, and Unspecified
             DateTime[] datetimes = new DateTime[]
             {
-                DateTime.SpecifyKind(DateTime.Parse("1996-12-01T14:02:31.1234567-08:00"), DateTimeKind.Utc),
-                DateTime.SpecifyKind(DateTime.Parse("1996-12-01T14:02:31.1234567-08:00"), DateTimeKind.Local),
-                DateTime.SpecifyKind(DateTime.Parse("1996-12-01T14:02:31.1234567-08:00"), DateTimeKind.Unspecified),
+                DateTime.SpecifyKind(DateTime.Parse("1996-12-01T14:02:31.1234567-08:00", CultureInfo.InvariantCulture), DateTimeKind.Utc),
+                DateTime.SpecifyKind(DateTime.Parse("1996-12-01T14:02:31.1234567-08:00", CultureInfo.InvariantCulture), DateTimeKind.Local),
+                DateTime.SpecifyKind(DateTime.Parse("1996-12-01T14:02:31.1234567-08:00", CultureInfo.InvariantCulture), DateTimeKind.Unspecified),
                 DateTime.UtcNow,
                 DateTime.Now,
             };
@@ -76,7 +74,7 @@
             string[] results = new string[datetimes.Length];
             for (int i = 0; i < datetimes.Length; i++)
             {
-                int len = listener.DateTimeGetBytes(datetimes[i], buffer, pos);
+                int len = SelfDiagnosticsEventListener.DateTimeGetBytes(datetimes[i], buffer, pos);
                 results[i] = Encoding.Default.GetString(buffer, pos, len);
                 pos += len;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresher.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresher.cs
@@ -105,6 +105,10 @@
                     // Or it might have created another MemoryMappedFile in that thread
                     // after the Dispose() below is called.
                     this.memoryMappedFileHandler.Dispose();
+                    if (this.eventListener != null)
+                    {
+                        this.eventListener.Dispose();
+                    }
                 }
 
                 this.disposedValue = true;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsEventListener.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsEventListener.cs
@@ -71,6 +71,11 @@
         /// <returns>The position of the buffer after the last byte of the resulting sequence.</returns>
         internal static int EncodeInBuffer(string str, bool isParameter, byte[] buffer, int position)
         {
+            if (str == null)
+            {
+                return position;
+            }
+
             int charCount = str.Length;
             int ellipses = isParameter ? "{...}\n".Length : "...\n".Length;
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsInitializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsInitializer.cs
@@ -15,7 +15,7 @@
 
         // Long-living object that holds a refresher which checks whether the configuration file was updated
         // every 10 seconds.
-        // private readonly SelfDiagnosticsConfigRefresher configRefresher;
+        private readonly SelfDiagnosticsConfigRefresher configRefresher;
 
         static SelfDiagnosticsInitializer()
         {
@@ -27,7 +27,7 @@
 
         private SelfDiagnosticsInitializer()
         {
-            // this.configRefresher = new SelfDiagnosticsConfigRefresher();
+            this.configRefresher = new SelfDiagnosticsConfigRefresher();
         }
 
         /// <summary>
@@ -54,7 +54,7 @@
         {
             if (disposing)
             {
-                // this.configRefresher.Dispose();
+                this.configRefresher.Dispose();
             }
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-
+- [Enable the self diagnostics and fix a NullReferenceException bug](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2302)
 
 ## Version 2.18.0-beta2
 - Reduce technical debt: Use pattern matching


### PR DESCRIPTION
Fix Issue of error messages not showing. The entry point was commented out.

Tested manually by placing the configuration file in `examples\WebApp.AspNetCore\` folder and running `examples\WebApp.AspNetCore\WebApp.AspNetCore.csproj` with Visual Studio debug.

## Changes
See code diff.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
