### PR TITLE
enable self-diagnostics in example app

### DIFF
--- a/examples/WebApp.AspNetCore/ApplicationInsightsDiagnostics.json
+++ b/examples/WebApp.AspNetCore/ApplicationInsightsDiagnostics.json
@@ -1,5 +1,5 @@
 ﻿{
   "LogDirectory": ".",
   "FileSize": 1024,
-  "LogLevel": "Verbose"
+  "LogLevel": "Warning"
 }

--- a/examples/WebApp.AspNetCore/ApplicationInsightsDiagnostics.json
+++ b/examples/WebApp.AspNetCore/ApplicationInsightsDiagnostics.json
@@ -1,0 +1,5 @@
+﻿{
+  "LogDirectory": ".",
+  "FileSize": 1024,
+  "LogLevel": "Verbose"
+}

--- a/examples/WebApp.AspNetCore/WebApp.AspNetCore.csproj
+++ b/examples/WebApp.AspNetCore/WebApp.AspNetCore.csproj
@@ -9,7 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <!--This file enables self-diagnostics-->
+    <!--This file enables self-diagnostics (https://github.com/microsoft/ApplicationInsights-dotnet/tree/develop/troubleshooting/ETW#self-diagnostics)-->
     <Content Update="ApplicationInsightsDiagnostics.json">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </Content>

--- a/examples/WebApp.AspNetCore/WebApp.AspNetCore.csproj
+++ b/examples/WebApp.AspNetCore/WebApp.AspNetCore.csproj
@@ -8,4 +8,11 @@
     <ProjectReference Include="..\..\NETCORE\src\Microsoft.ApplicationInsights.AspNetCore\Microsoft.ApplicationInsights.AspNetCore.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!--This file enables self-diagnostics-->
+    <Content Update="ApplicationInsightsDiagnostics.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
The self-diagnostics feature has been invaluable while testing.
I would like to enable this in our example app.

I confirmed that the *.log files are excluded from git.