### PR TITLE
AAD: change to CredentialEnvelope to expose Expiration 

### DIFF
--- a/.publicApi/Microsoft.ApplicationInsights.dll/net452/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net452/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken>
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.AuthToken() -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.AuthToken(string token, System.DateTimeOffset expiresOn) -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.ExpiresOn.get -> System.DateTimeOffset
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.ExpiresOn.set -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Token.get -> string
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Token.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope
 Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.CredentialEnvelope() -> void
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CredentialEnvelope.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope
@@ -8,3 +15,7 @@ Microsoft.ApplicationInsights.Channel.IAsyncFlushable
 Microsoft.ApplicationInsights.Channel.IAsyncFlushable.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
 Microsoft.ApplicationInsights.Channel.InMemoryChannel.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
 Microsoft.ApplicationInsights.TelemetryClient.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
+override Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Equals(object obj) -> bool
+override Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.GetHashCode() -> int
+static Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.operator !=(Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken left, Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken right) -> bool
+static Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.operator ==(Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken left, Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken right) -> bool

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net46/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken>
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.AuthToken() -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.AuthToken(string token, System.DateTimeOffset expiresOn) -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.ExpiresOn.get -> System.DateTimeOffset
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.ExpiresOn.set -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Token.get -> string
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Token.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope
 Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.CredentialEnvelope() -> void
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CredentialEnvelope.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope
@@ -8,3 +15,7 @@ Microsoft.ApplicationInsights.Channel.IAsyncFlushable
 Microsoft.ApplicationInsights.Channel.IAsyncFlushable.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
 Microsoft.ApplicationInsights.Channel.InMemoryChannel.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
 Microsoft.ApplicationInsights.TelemetryClient.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
+override Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Equals(object obj) -> bool
+override Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.GetHashCode() -> int
+static Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.operator !=(Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken left, Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken right) -> bool
+static Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.operator ==(Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken left, Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken right) -> bool

--- a/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,5 +1,12 @@
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> string
-abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<string>
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetToken(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken
+abstract Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.GetTokenAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken>
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.AuthToken() -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.AuthToken(string token, System.DateTimeOffset expiresOn) -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.ExpiresOn.get -> System.DateTimeOffset
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.ExpiresOn.set -> void
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Token.get -> string
+Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Token.set -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope
 Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope.CredentialEnvelope() -> void
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CredentialEnvelope.get -> Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.CredentialEnvelope
@@ -8,3 +15,7 @@ Microsoft.ApplicationInsights.Channel.IAsyncFlushable
 Microsoft.ApplicationInsights.Channel.IAsyncFlushable.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
 Microsoft.ApplicationInsights.Channel.InMemoryChannel.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
 Microsoft.ApplicationInsights.TelemetryClient.FlushAsync(System.Threading.CancellationToken cancellationToken) -> System.Threading.Tasks.Task<bool>
+override Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.Equals(object obj) -> bool
+override Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.GetHashCode() -> int
+static Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.operator !=(Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken left, Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken right) -> bool
+static Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken.operator ==(Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken left, Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication.AuthToken right) -> bool

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
@@ -2,6 +2,8 @@
 namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Authentication
 {
     using System;
+    using System.Linq.Expressions;
+    using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
 
@@ -67,10 +69,12 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         {
             var mockCredential = new MockCredential();
             var requestContext = new TokenRequestContext(new string[] { "test/scope" });
+            var tokenFromCredential = mockCredential.GetToken(requestContext, CancellationToken.None);
 
-            var testResult = ReflectionCredentialEnvelope.AzureCore.InvokeGetToken(mockCredential, requestContext, CancellationToken.None);
-
-            Assert.AreEqual("TEST TOKEN test/scope", testResult);
+            var tokenFromReflection = ReflectionCredentialEnvelope.AzureCore.InvokeGetToken(mockCredential, requestContext, CancellationToken.None);
+            
+            Assert.AreEqual(tokenFromCredential.Token, tokenFromReflection.Token);
+            Assert.AreEqual(tokenFromCredential.ExpiresOn, tokenFromReflection.ExpiresOn);
         }
 
         [TestMethod]
@@ -78,10 +82,12 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         {
             var mockCredential = new MockCredential();
             var requestContext = new TokenRequestContext(new string[] { "test/scope" });
+            var tokenFromCredential = mockCredential.GetToken(requestContext, CancellationToken.None);
 
-            var testResult = await ReflectionCredentialEnvelope.AzureCore.InvokeGetTokenAsync(mockCredential, requestContext, CancellationToken.None);
+            var tokenFromReflection = await ReflectionCredentialEnvelope.AzureCore.InvokeGetTokenAsync(mockCredential, requestContext, CancellationToken.None);
 
-            Assert.AreEqual("TEST TOKEN test/scope", testResult);
+            Assert.AreEqual(tokenFromCredential.Token, tokenFromReflection.Token);
+            Assert.AreEqual(tokenFromCredential.ExpiresOn, tokenFromReflection.ExpiresOn);
         }
 
         /// <summary>
@@ -90,12 +96,15 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         [TestMethod]
         public void VerifyGetToken_UsingDynamicTypes()
         {
-            var mockCredential = (object)new MockCredential();
-            var requestContext = ReflectionCredentialEnvelope.AzureCore.MakeTokenRequestContext(new[] { "test/scope" });
+            var mockCredential = new MockCredential();
+            var requestContext = new TokenRequestContext(new string[] { "test/scope" });
+            var tokenFromCredential = mockCredential.GetToken(requestContext, CancellationToken.None);
 
-            var testResult = ReflectionCredentialEnvelope.AzureCore.InvokeGetToken(mockCredential, requestContext, CancellationToken.None);
-
-            Assert.AreEqual("TEST TOKEN test/scope", testResult);
+            var requestContextFromReflection = ReflectionCredentialEnvelope.AzureCore.MakeTokenRequestContext(new[] { "test/scope" });
+            var tokenFromReflection = ReflectionCredentialEnvelope.AzureCore.InvokeGetToken((object)mockCredential, requestContextFromReflection, CancellationToken.None);
+            
+            Assert.AreEqual(tokenFromCredential.Token, tokenFromReflection.Token);
+            Assert.AreEqual(tokenFromCredential.ExpiresOn, tokenFromReflection.ExpiresOn);
         }
 
         /// <summary>
@@ -104,12 +113,15 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         [TestMethod]
         public async Task VerifyGetTokenAsync_UsingDynamicTypes()
         {
-            var mockCredential = (object)new MockCredential();
-            var requestContext = ReflectionCredentialEnvelope.AzureCore.MakeTokenRequestContext(new[] { "test/scope" });
+            var mockCredential = new MockCredential();
+            var requestContext = new TokenRequestContext(new string[] { "test/scope" });
+            var tokenFromCredential = mockCredential.GetToken(requestContext, CancellationToken.None);
 
-            var testResult = await ReflectionCredentialEnvelope.AzureCore.InvokeGetTokenAsync(mockCredential, requestContext, CancellationToken.None);
+            var requestContextFromReflection = ReflectionCredentialEnvelope.AzureCore.MakeTokenRequestContext(new[] { "test/scope" });
+            var tokenFromReflection = await ReflectionCredentialEnvelope.AzureCore.InvokeGetTokenAsync((object)mockCredential, requestContextFromReflection, CancellationToken.None);
 
-            Assert.AreEqual("TEST TOKEN test/scope", testResult);
+            Assert.AreEqual(tokenFromCredential.Token, tokenFromReflection.Token);
+            Assert.AreEqual(tokenFromCredential.ExpiresOn, tokenFromReflection.ExpiresOn);
         }
 
         /// <summary>
@@ -120,12 +132,13 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         {
             var requestContext = new TokenRequestContext(scopes: AuthConstants.GetScopes());
             var mockCredential = new MockCredential();
-            var tokenUsingTypes = mockCredential.GetToken(requestContext, CancellationToken.None);
+            var tokenFromCredential = mockCredential.GetToken(requestContext, CancellationToken.None);
 
             var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
-            var tokenUsingReflection = reflectionCredentialEnvelope.GetToken();
+            var tokenFromReflection = reflectionCredentialEnvelope.GetToken();
 
-            Assert.AreEqual(tokenUsingTypes.Token, tokenUsingReflection);
+            Assert.AreEqual(tokenFromCredential.Token, tokenFromReflection.Token);
+            Assert.AreEqual(tokenFromCredential.ExpiresOn, tokenFromReflection.ExpiresOn);
         }
 
         /// <summary>
@@ -136,12 +149,13 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         {
             var requestContext = new TokenRequestContext(scopes: AuthConstants.GetScopes());
             var mockCredential = new MockCredential();
-            var tokenUsingTypes = await mockCredential.GetTokenAsync(requestContext, CancellationToken.None);
+            var tokenFromCredential = await mockCredential.GetTokenAsync(requestContext, CancellationToken.None);
 
             var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
-            var tokenUsingReflection = await reflectionCredentialEnvelope.GetTokenAsync();
+            var tokenFromReflection = await reflectionCredentialEnvelope.GetTokenAsync();
 
-            Assert.AreEqual(tokenUsingTypes.Token, tokenUsingReflection);
+            Assert.AreEqual(tokenFromCredential.Token, tokenFromReflection.Token);
+            Assert.AreEqual(tokenFromCredential.ExpiresOn, tokenFromReflection.ExpiresOn);
         }
 
         [TestMethod]
@@ -153,7 +167,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
 
             var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
             var token = reflectionCredentialEnvelope.GetToken();
-            Assert.IsNull(token);
+            Assert.AreEqual(default(AuthToken), token);
         }
         
         [TestMethod]
@@ -165,11 +179,131 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
 
             var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
             var token = await reflectionCredentialEnvelope.GetTokenAsync();
-            Assert.IsNull(token);
+            Assert.AreEqual(default(AuthToken), token);
         }
 
-#region TestClasses
-        
+        [TestMethod]
+        public void TestReflection()
+        {
+            Type typeTokenCredential = Type.GetType("Azure.Core.TokenCredential, Azure.Core");
+            Type typeTokenRequestContext = Type.GetType("Azure.Core.TokenRequestContext, Azure.Core");
+            Type typeCancellationToken = typeof(CancellationToken);
+
+            var parameterExpression_tokenCredential = Expression.Parameter(type: typeTokenCredential, name: "parameterExpression_TokenCredential");
+            var parameterExpression_requestContext = Expression.Parameter(type: typeTokenRequestContext, name: "parameterExpression_RequestContext");
+            var parameterExpression_cancellationToken = Expression.Parameter(type: typeCancellationToken, name: "parameterExpression_CancellationToken");
+
+            var exprGetToken = Expression.Call(
+                instance: parameterExpression_tokenCredential,
+                method: typeTokenCredential.GetMethod(name: "GetToken", types: new Type[] { typeTokenRequestContext, typeCancellationToken }),
+                arg0: parameterExpression_requestContext,
+                arg1: parameterExpression_cancellationToken);
+
+            var exprTokenProperty = Expression.Property(
+                expression: exprGetToken,
+                propertyName: "Token");
+
+            var exprExpiresOnProperty = Expression.Property(
+                expression: exprGetToken,
+                propertyName: "ExpiresOn");
+
+            Type typeAuthToken = typeof(AuthToken);
+            ConstructorInfo authTokenCtor = typeAuthToken.GetConstructor(new Type[] { typeof(string), typeof(DateTimeOffset) });
+
+            var exprAuthTokenCtor = Expression.New(authTokenCtor, exprTokenProperty, exprExpiresOnProperty);
+                //Expression.init
+
+
+            var compiledExpression = Expression.Lambda(
+                    //body: exprTokenProperty,
+                    body: exprAuthTokenCtor,
+                    parameters: new ParameterExpression[]
+                    {
+                        parameterExpression_tokenCredential,
+                        parameterExpression_requestContext,
+                        parameterExpression_cancellationToken,
+                    }).Compile();
+
+            //----------------------------------
+
+            var mockCredential = new MockCredential();
+            var requestContext = new TokenRequestContext(new string[] { "test/scope" });
+            CancellationToken ct = default;
+
+            var test = (AuthToken)compiledExpression.DynamicInvoke(mockCredential, requestContext, ct);
+
+        }
+
+
+        [TestMethod]
+        public void TestReflection2()
+        {
+            Type typeTokenCredential = Type.GetType("Azure.Core.TokenCredential, Azure.Core");
+            Type typeTokenRequestContext = Type.GetType("Azure.Core.TokenRequestContext, Azure.Core");
+            Type typeCancellationToken = typeof(CancellationToken);
+
+            var parameterExpression_tokenCredential = Expression.Parameter(type: typeTokenCredential, name: "parameterExpression_TokenCredential");
+            var parameterExpression_requestContext = Expression.Parameter(type: typeTokenRequestContext, name: "parameterExpression_RequestContext");
+            var parameterExpression_cancellationToken = Expression.Parameter(type: typeCancellationToken, name: "parameterExpression_CancellationToken");
+
+            var exprGetToken = Expression.Call(
+                instance: parameterExpression_tokenCredential,
+                method: typeTokenCredential.GetMethod(name: "GetToken", types: new Type[] { typeTokenRequestContext, typeCancellationToken }),
+                arg0: parameterExpression_requestContext,
+                arg1: parameterExpression_cancellationToken);
+
+            var compiledExpression1 = Expression.Lambda(
+                    body: exprGetToken,
+                    parameters: new ParameterExpression[]
+                    {
+                        parameterExpression_tokenCredential,
+                        parameterExpression_requestContext,
+                        parameterExpression_cancellationToken,
+                    }).Compile();
+
+            // ------------------------------
+
+            var mockCredential = new MockCredential();
+            var requestContext = new TokenRequestContext(new string[] { "test/scope" });
+            CancellationToken ct = default;
+
+            var objAccessToken = compiledExpression1.DynamicInvoke(mockCredential, requestContext, ct);
+
+
+            // ----------------------------
+
+            Type typeAccessToken = Type.GetType("Azure.Core.AccessToken, Azure.Core");
+
+            var parameterExpression_AccessToken = Expression.Parameter(typeAccessToken, "parameterExpression_AccessToken");
+
+            var exprTokenProperty = Expression.Property(
+                expression: parameterExpression_AccessToken,
+                propertyName: "Token");
+
+            var exprExpiresOnProperty = Expression.Property(
+                expression: parameterExpression_AccessToken,
+                propertyName: "ExpiresOn");
+
+            Type typeAuthToken = typeof(AuthToken);
+            ConstructorInfo authTokenCtor = typeAuthToken.GetConstructor(new Type[] { typeof(string), typeof(DateTimeOffset) });
+
+            var exprAuthTokenCtor = Expression.New(authTokenCtor, exprTokenProperty, exprExpiresOnProperty);
+            
+            var compiledExpression2 = Expression.Lambda(
+                    //body: exprTokenProperty,
+                    body: exprAuthTokenCtor,
+                    parameters: new ParameterExpression[]
+                    {
+                        parameterExpression_AccessToken,
+                    }).Compile();
+
+            //----------------------------------
+
+            var test = compiledExpression2.DynamicInvoke(objAccessToken);
+
+        }
+        #region TestClasses
+
         /// <summary>
         /// This class inherits <see cref="MockCredential"/> which inherits <see cref="Azure.Core.TokenCredential"/>.
         /// This class is used to verify that the <see cref="ReflectionCredentialEnvelope"/> can correctly identify tests that inherit <see cref="Azure.Core.TokenCredential"/>.

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
@@ -60,7 +60,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         public async Task VerifyTransmissionSendAsync_WithCredential_SetsAuthHeader()
         {
             var credendialEnvelope = new ReflectionCredentialEnvelope(new MockCredential());
-            var token = credendialEnvelope.GetToken();
+            var authToken = credendialEnvelope.GetToken();
 
             var handler = new HandlerForFakeHttpClient
             {
@@ -69,7 +69,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
                 {
                     // VALIDATE
                     Assert.AreEqual(AuthConstants.AuthorizationTokenPrefix.Trim(), req.Headers.Authorization.Scheme);
-                    Assert.AreEqual(token, req.Headers.Authorization.Parameter);
+                    Assert.AreEqual(authToken.Token, req.Headers.Authorization.Parameter);
                     
                     return Task.FromResult<HttpResponseMessage>(new HttpResponseMessage());
                 }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
@@ -59,8 +59,8 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         [TestMethod]
         public async Task VerifyTransmissionSendAsync_WithCredential_SetsAuthHeader()
         {
-            var credendialEnvelope = new ReflectionCredentialEnvelope(new MockCredential());
-            var authToken = credendialEnvelope.GetToken();
+            var credentialEnvelope = new ReflectionCredentialEnvelope(new MockCredential());
+            var authToken = credentialEnvelope.GetToken();
 
             var handler = new HandlerForFakeHttpClient
             {
@@ -83,7 +83,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
 
                 // Instantiate Transmission with the mock HttpClient
                 var transmission = new Transmission(testUri, new byte[] { 1, 2, 3, 4, 5 }, fakeHttpClient, expectedContentType, expectedContentEncoding);
-                transmission.CredentialEnvelope = credendialEnvelope;
+                transmission.CredentialEnvelope = credentialEnvelope;
 
                 var result = await transmission.SendAsync();
             }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
@@ -62,7 +62,6 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
             var credendialEnvelope = new ReflectionCredentialEnvelope(new MockCredential());
             var token = credendialEnvelope.GetToken();
 
-
             var handler = new HandlerForFakeHttpClient
             {
                 InnerHandler = new HttpClientHandler(),

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -424,7 +424,7 @@
                 }
                 else
                 {
-                    request.Headers.TryAddWithoutValidation(AuthConstants.AuthorizationHeaderName, AuthConstants.AuthorizationTokenPrefix + authToken);
+                    request.Headers.TryAddWithoutValidation(AuthConstants.AuthorizationHeaderName, AuthConstants.AuthorizationTokenPrefix + authToken.Token);
                 }
             }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Channel/Transmission.cs
@@ -417,7 +417,7 @@
                 // TODO: NEED TO USE CACHING HERE
                 var authToken = this.CredentialEnvelope.GetToken();
 
-                if (authToken == null)
+                if (authToken == default(AuthToken))
                 {
                     // TODO: DO NOT SEND. RETURN FAILURE AND LET CHANNEL DECIDE WHEN TO RETRY.
                     // This could be either a configuration error or the AAD service is unavailable.

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
@@ -1,0 +1,48 @@
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// This class represents the Azure.Core.AccessToken returned by Azure.Core.TokenCredential.
+    /// (https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/AccessToken.cs).
+    /// </summary>
+    public struct AuthToken
+    {
+        public AuthToken(string token, DateTimeOffset expiresOn)
+        {
+            this.Token = token;
+            this.ExpiresOn = expiresOn;
+        }
+
+        /// <summary>
+        /// Get the access token value.
+        /// </summary>
+        public string Token { get; set; }
+
+        /// <summary>
+        /// Gets the time when the provided token expires.
+        /// </summary>
+        public DateTimeOffset ExpiresOn { get; set; }
+
+        /// <inheritdoc />
+        public override bool Equals(object obj)
+        {
+            if (obj is AuthToken authToken)
+            {
+                return authToken.ExpiresOn == ExpiresOn && authToken.Token == Token;
+            }
+
+            return false;
+        }
+
+        /// <inheritdoc />
+        public static bool operator == (AuthToken left, AuthToken right) => left.Equals(right);
+
+        /// <inheritdoc />
+        public static bool operator != (AuthToken left, AuthToken right) => !left.Equals(right);
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
@@ -40,6 +40,12 @@
         }
 
         /// <inheritdoc />
+        public override int GetHashCode()
+        {
+            return (this.Token.GetHashCode() + "," + this.ExpiresOn.GetHashCode()).GetHashCode();
+        }
+
+        /// <inheritdoc />
         public static bool operator == (AuthToken left, AuthToken right) => left.Equals(right);
 
         /// <inheritdoc />

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
@@ -57,9 +57,6 @@
         }
 
         /// <inheritdoc />
-        public override int GetHashCode()
-        {
-            return (this.Token.GetHashCode() + "," + this.ExpiresOn.GetHashCode()).GetHashCode();
-        }
+        public override int GetHashCode() => this.Token.GetHashCode() ^ this.ExpiresOn.GetHashCode();
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthToken.cs
@@ -1,17 +1,18 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication
 {
     using System;
-    using System.Collections.Generic;
-    using System.Linq;
-    using System.Text;
-    using System.Threading.Tasks;
 
     /// <summary>
-    /// This class represents the Azure.Core.AccessToken returned by Azure.Core.TokenCredential.
+    /// This represents the Azure.Core.AccessToken returned by Azure.Core.TokenCredential.
     /// (https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/AccessToken.cs).
     /// </summary>
     public struct AuthToken
     {
+        /// <summary>
+        /// Initializes a new instance of <see cref="AuthToken"/>.
+        /// </summary>
+        /// <param name="token">Access token.</param>
+        /// <param name="expiresOn">DateTimeOffset representing when the access token expires.</param>
         public AuthToken(string token, DateTimeOffset expiresOn)
         {
             this.Token = token;
@@ -19,21 +20,37 @@
         }
 
         /// <summary>
-        /// Get the access token value.
+        /// Gets or sets get the access token value.
         /// </summary>
         public string Token { get; set; }
 
         /// <summary>
-        /// Gets the time when the provided token expires.
+        /// Gets or sets the time when the provided token expires.
         /// </summary>
         public DateTimeOffset ExpiresOn { get; set; }
+
+        /// <summary>
+        /// Determine if two instance of AuthToken are equal.
+        /// </summary>
+        /// <param name="left">An instance of AuthToken on the left side of the operator.</param>
+        /// <param name="right">An instance of AuthToken on the right side of the operator.</param>
+        /// <returns>Returns a boolean indicating if the params are equal.</returns>
+        public static bool operator ==(AuthToken left, AuthToken right) => left.Equals(right);
+
+        /// <summary>
+        /// Determine if two instance of AuthToken are not equal.
+        /// </summary>
+        /// <param name="left">An instance of AuthToken on the left side of the operator.</param>
+        /// <param name="right">An instance of AuthToken on the right side of the operator.</param>
+        /// <returns>Returns a boolean indicating if the params are not equal.</returns>
+        public static bool operator !=(AuthToken left, AuthToken right) => !left.Equals(right);
 
         /// <inheritdoc />
         public override bool Equals(object obj)
         {
             if (obj is AuthToken authToken)
             {
-                return authToken.ExpiresOn == ExpiresOn && authToken.Token == Token;
+                return authToken.ExpiresOn == this.ExpiresOn && authToken.Token == this.Token;
             }
 
             return false;
@@ -44,11 +61,5 @@
         {
             return (this.Token.GetHashCode() + "," + this.ExpiresOn.GetHashCode()).GetHashCode();
         }
-
-        /// <inheritdoc />
-        public static bool operator == (AuthToken left, AuthToken right) => left.Equals(right);
-
-        /// <inheritdoc />
-        public static bool operator != (AuthToken left, AuthToken right) => !left.Equals(right);
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/CredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/CredentialEnvelope.cs
@@ -5,6 +5,7 @@
 
     /// <summary>
     /// This interface defines a class that can interact with Azure.Core.TokenCredential.
+    /// See also: (https://github.com/Azure/azure-sdk-for-net/blob/master/sdk/core/Azure.Core/src/TokenCredential.cs).
     /// </summary>
     public abstract class CredentialEnvelope
     {
@@ -21,7 +22,7 @@
         /// </remarks>
         /// <param name="cancellationToken">The System.Threading.CancellationToken to use.</param>
         /// <returns>A valid Azure.Core.AccessToken.</returns>
-        public abstract string GetToken(CancellationToken cancellationToken = default);
+        public abstract AuthToken GetToken(CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Gets an Azure.Core.AccessToken.
@@ -31,6 +32,6 @@
         /// </remarks>
         /// <param name="cancellationToken">The System.Threading.CancellationToken to use.</param>
         /// <returns>A valid Azure.Core.AccessToken.</returns>
-        public abstract Task<string> GetTokenAsync(CancellationToken cancellationToken = default);
+        public abstract Task<AuthToken> GetTokenAsync(CancellationToken cancellationToken = default);
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -251,7 +251,7 @@
             /// Returns a delegate that is a wrapper around GetTokenAsync which returns a System.Threading.Tasks.ValueTask of Azure.Core.AccessToken.
             /// Then converts that System.Threading.Tasks.ValueTask to <see cref="Task"/> which can be awaited.
             /// NOTE: The Expression Tree library cannot handle async methods.
-            /// NOTE: ValueTask is not recognized by older versions of .NET
+            /// NOTE: ValueTask is not recognized by older versions of .NET Framework.
             /// </returns>
             private static Delegate BuildDelegateGetTokenAsync()
             {

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Implementation/QuickPulse/QuickPulseCollectionStateManager.cs
@@ -7,6 +7,7 @@
     using System.Threading.Tasks;
 
     using Microsoft.ApplicationInsights.Extensibility.Filtering;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.Implementation.QuickPulse.Helpers;
 
@@ -107,11 +108,11 @@
                 this.firstStateUpdate = false;
             }
 
-            string authToken = null;
+            AuthToken authToken = default;
             if (this.telemetryConfiguration.CredentialEnvelope != null)
             {
                 authToken = this.telemetryConfiguration.CredentialEnvelope.GetToken();
-                if (authToken == null)
+                if (authToken == default)
                 {
                     // If a credential has been set on the configuration and we fail to get a token, do net send.
                     QuickPulseEventSource.Log.FailedToGetAuthToken();
@@ -150,7 +151,7 @@
                     instrumentationKey,
                     this.currentConfigurationETag,
                     authApiKey,
-                    authToken,
+                    authToken.Token,
                     out configurationInfo,
                     this.collectionConfigurationErrors.ToArray());
 
@@ -185,7 +186,7 @@
                     this.timeProvider.UtcNow,
                     this.currentConfigurationETag,
                     authApiKey,
-                    authToken,
+                    authToken.Token,
                     out configurationInfo,
                     out TimeSpan? servicePollingIntervalHint);
 


### PR DESCRIPTION
Fix Issue #2190.

## Changes
- Add new struct AuthToken, which represents Azure.Core.AccessToken.
- Change to CredentialEnvelope to return AuthToken.
- Change to ReflectionCredentialEnvelope. This may be difficult to read.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
