### PR TITLE
refactor TransmissionPolicy

### DIFF
--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmissionPolicy.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmissionPolicy.cs
@@ -1,7 +1,9 @@
 ﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Helpers
 {
     using System;
+
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy;
 
     internal class StubTransmissionPolicy : TransmissionPolicy
     {

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmitter.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmitter.cs
@@ -5,6 +5,7 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Channel.Implementation;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy;
 
     internal class StubTransmitter : Transmitter
     {
@@ -16,13 +17,13 @@
 
 
         public StubTransmitter()
-            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), Enumerable.Empty<TransmissionPolicy>(), new BackoffLogicManager(TimeSpan.FromMinutes(30)))
+            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>()), new BackoffLogicManager(TimeSpan.FromMinutes(30)))
         {
             
         }
 
         public StubTransmitter(BackoffLogicManager backoffLogicManager)
-            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), Enumerable.Empty<TransmissionPolicy>(), backoffLogicManager)
+            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>()), backoffLogicManager)
         {
 
         }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmitter.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Helpers/StubTransmitter.cs
@@ -17,13 +17,13 @@
 
 
         public StubTransmitter()
-            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>()), new BackoffLogicManager(TimeSpan.FromMinutes(30)))
+            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), TransmissionPolicyCollection.Default, new BackoffLogicManager(TimeSpan.FromMinutes(30)))
         {
             
         }
 
         public StubTransmitter(BackoffLogicManager backoffLogicManager)
-            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>()), backoffLogicManager)
+            : base(new StubTransmissionSender(), new StubTransmissionBuffer(), new StubTransmissionStorage(), TransmissionPolicyCollection.Default, backoffLogicManager)
         {
 
         }

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/ApplicationLifecycleTransmissionPolicyTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/ApplicationLifecycleTransmissionPolicyTest.cs
@@ -1,18 +1,16 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Threading.Tasks;
-    using Microsoft.ApplicationInsights.TestFramework;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Helpers;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     
     using Channel.Helpers;
 
-    using TaskEx = System.Threading.Tasks.Task;
-
     public class ApplicationLifecycleTransmissionPolicyTest
     {
         [TestClass]
+        [TestCategory("TransmissionPolicy")]
         public class HandleApplicationStoppingEvent : ApplicationLifecycleTransmissionPolicyTest
         {
             [TestMethod]

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/ErrorHandlingTransmissionPolicyTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/ErrorHandlingTransmissionPolicyTest.cs
@@ -1,6 +1,6 @@
 ﻿using System.Net.Http;
 
-namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Diagnostics.Tracing;
@@ -23,6 +23,7 @@ namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implement
     public class ErrorHandlingTransmissionPolicyTest
     {
         [TestClass]
+        [TestCategory("TransmissionPolicy")]
         [TestCategory("WindowsOnly")] // these tests are flaky on linux builds.
         public class HandleTransmissionSentEvent : ErrorHandlingTransmissionPolicyTest
         {

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/NetworkAvailabilityTransmissionPolicyTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/NetworkAvailabilityTransmissionPolicyTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Diagnostics.Tracing;
@@ -13,9 +13,11 @@
     using TaskEx = System.Threading.Tasks.Task;
 
     [TestClass]
+    [TestCategory("TransmissionPolicy")]
     public class NetworkAvailabilityTransmissionPolicyTest
     {
         [TestClass]
+        [TestCategory("TransmissionPolicy")]
         public class Class : NetworkAvailabilityTransmissionPolicyTest
         {
             [TestMethod]
@@ -44,6 +46,7 @@
         }
 
         [TestClass]
+        [TestCategory("TransmissionPolicy")]
         public class Initialize : NetworkAvailabilityTransmissionPolicyTest
         {
             [TestMethod]
@@ -122,6 +125,7 @@
         }
 
         [TestClass]
+        [TestCategory("TransmissionPolicy")]
         public class HandleNetworkStatusChangedEvent : NetworkAvailabilityTransmissionPolicyTest
         {
             [TestMethod]

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/PartialSuccessTransmissionPolicyTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/PartialSuccessTransmissionPolicyTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.Channel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Collections.Generic;
@@ -15,6 +15,7 @@
     using TaskEx = System.Threading.Tasks.Task;
 
     [TestClass]
+    [TestCategory("TransmissionPolicy")]
     public class PartialSuccessTransmissionPolicyTest
     {
         [TestMethod]

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/TransmissionPolicyCollectionTests.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/TransmissionPolicyCollectionTests.cs
@@ -1,0 +1,58 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    [TestCategory("TransmissionPolicy")]
+    public class TransmissionPolicyCollectionTests
+    {
+        [TestMethod]
+        public void VerifyCalcuateMinimums()
+        {
+            // Setup
+            var policies = new TransmissionPolicyCollection(policies: new List<TransmissionPolicy>
+            {
+                new MockValueTransmissionPolicy(maxSenderCapacity: null, maxBufferCapacity: null, maxStorageCapacity: null),
+                new MockValueTransmissionPolicy(maxSenderCapacity: 1, maxBufferCapacity: 2, maxStorageCapacity: 3),
+                new MockValueTransmissionPolicy(maxSenderCapacity: 101, maxBufferCapacity: 102, maxStorageCapacity: 103),
+            });
+
+            // Act & Verify
+            Assert.AreEqual(1, policies.CalculateMinimumMaxSenderCapacity());
+            Assert.AreEqual(2, policies.CalculateMinimumMaxBufferCapacity());
+            Assert.AreEqual(3, policies.CalculateMinimumMaxStorageCapacity());
+        }
+
+
+        [TestMethod]
+        public void VerifyCalcuateMinimums_CanHandleNulls()
+        {
+            // Setup
+            var policies = new TransmissionPolicyCollection(policies: new List<TransmissionPolicy>
+            {
+                new MockValueTransmissionPolicy(maxSenderCapacity: null, maxBufferCapacity: null, maxStorageCapacity: null),
+            });
+
+            // Act & Verify
+            Assert.AreEqual(null, policies.CalculateMinimumMaxSenderCapacity());
+            Assert.AreEqual(null, policies.CalculateMinimumMaxBufferCapacity());
+            Assert.AreEqual(null, policies.CalculateMinimumMaxStorageCapacity());
+        }
+
+        private class MockValueTransmissionPolicy : TransmissionPolicy
+        {
+            public MockValueTransmissionPolicy(int? maxSenderCapacity, int? maxBufferCapacity, int? maxStorageCapacity)
+            {
+                this.MaxSenderCapacity = maxSenderCapacity;
+                this.MaxBufferCapacity = maxBufferCapacity;
+                this.MaxStorageCapacity = maxStorageCapacity;
+            }
+        }
+    }
+}

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/TransmissionPolicyTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmissionPolicy/TransmissionPolicyTest.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Helpers;

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmitterTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmitterTest.cs
@@ -36,7 +36,7 @@
             TransmissionSender sender = null, 
             TransmissionBuffer buffer = null, 
             TransmissionStorage storage = null, 
-            IEnumerable<StubTransmissionPolicy> policies = null)
+            IEnumerable<TransmissionPolicy.TransmissionPolicy> policies = null)
         {
             return new Transmitter(
                 sender ?? new StubTransmissionSender(),

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmitterTest.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/TransmitterTest.cs
@@ -16,6 +16,7 @@
     using TaskEx = System.Threading.Tasks.Task;
     using System.Threading.Tasks;
     using System.Threading;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy;
 
     public class TransmitterTest
     {
@@ -35,13 +36,13 @@
             TransmissionSender sender = null, 
             TransmissionBuffer buffer = null, 
             TransmissionStorage storage = null, 
-            IEnumerable<TransmissionPolicy> policies = null)
+            IEnumerable<StubTransmissionPolicy> policies = null)
         {
             return new Transmitter(
                 sender ?? new StubTransmissionSender(),
                 buffer ?? new StubTransmissionBuffer(),
                 storage ?? new StubTransmissionStorage(),
-                policies);
+                new TransmissionPolicyCollection(policies));
         }
 
         [TestClass]

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/ApplicationLifecycleTransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/ApplicationLifecycleTransmissionPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     internal class ApplicationLifecycleTransmissionPolicy : TransmissionPolicy
     {

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/ErrorHandlingTransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/ErrorHandlingTransmissionPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Globalization;

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/NetworkAvailabilityTransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/NetworkAvailabilityTransmissionPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Net.NetworkInformation;

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/PartialSuccessTransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/PartialSuccessTransmissionPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Threading.Tasks;

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/ThrottlingTransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/ThrottlingTransmissionPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     using System.Threading.Tasks;

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicy.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicy.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
 {
     using System;
     

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
@@ -1,0 +1,89 @@
+﻿namespace Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+
+    internal class TransmissionPolicyCollection : IDisposable
+    {
+        private readonly IEnumerable<TransmissionPolicy> policies;
+        private bool isDisposed;
+
+        public TransmissionPolicyCollection(INetwork network, IApplicationLifecycle applicationLifecycle)
+        {
+            this.policies = new TransmissionPolicy[]
+            { 
+#if NETFRAMEWORK
+                // We don't have implementation for IApplicationLifecycle for .NET Core
+                new ApplicationLifecycleTransmissionPolicy(applicationLifecycle),
+#endif
+                new ThrottlingTransmissionPolicy(),
+                new ErrorHandlingTransmissionPolicy(),
+                new PartialSuccessTransmissionPolicy(),
+                new NetworkAvailabilityTransmissionPolicy(network),
+            };
+        }
+
+        /// <summary>
+        /// Constructor for unit tests only.
+        /// </summary>
+        /// <param name="policies">A collection of <see cref="TransmissionPolicy"/> specific to a test scenario.</param>
+        internal TransmissionPolicyCollection(IEnumerable<TransmissionPolicy> policies)
+        {
+            this.policies = policies ?? Enumerable.Empty<TransmissionPolicy>();
+        }
+
+        public void Initialize(Transmitter transmitter)
+        {
+            foreach (var policy in this.policies)
+            {
+                policy.Initialize(transmitter);
+            }
+        }
+
+        public int? CalculateMinimumMaxSenderCapacity() => this.CalculateMinimumCapacity(p => p.MaxSenderCapacity);
+
+        public int? CalculateMinimumMaxBufferCapacity() => this.CalculateMinimumCapacity(p => p.MaxBufferCapacity);
+
+        public int? CalculateMinimumMaxStorageCapacity() => this.CalculateMinimumCapacity(p => p.MaxStorageCapacity);
+
+        public void Dispose()
+        {
+            this.Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private int? CalculateMinimumCapacity(Func<TransmissionPolicy, int?> getMaxPolicyCapacity)
+        {
+            int? maxComponentCapacity = null;
+            foreach (TransmissionPolicy policy in this.policies)
+            {
+                int? maxPolicyCapacity = getMaxPolicyCapacity(policy);
+                if (maxPolicyCapacity != null)
+                {
+                    maxComponentCapacity = maxComponentCapacity == null
+                        ? maxPolicyCapacity
+                        : Math.Min(maxComponentCapacity.Value, maxPolicyCapacity.Value);
+                }
+            }
+
+            return maxComponentCapacity;
+        }
+
+        private void Dispose(bool disposing)
+        {
+            if (!this.isDisposed)
+            {
+                if (disposing)
+                {
+                    foreach (var policy in this.policies.OfType<IDisposable>())
+                    {
+                        policy.Dispose();
+                    }
+                }
+
+                this.isDisposed = true;
+            }
+        }
+    }
+}

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
@@ -25,7 +25,8 @@
         }
 
         /// <summary>
-        /// Constructor for unit tests only.
+        /// Constructor intended for unit tests only. 
+        /// This is also used by the <see cref="TransmissionPolicyCollection.Default"/> to create an empty collection.
         /// </summary>
         /// <param name="policies">A collection of <see cref="TransmissionPolicy"/> specific to a test scenario.</param>
         internal TransmissionPolicyCollection(IEnumerable<TransmissionPolicy> policies)

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
@@ -24,8 +24,6 @@
             };
         }
 
-        public static TransmissionPolicyCollection Default => new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>());
-
         /// <summary>
         /// Constructor for unit tests only.
         /// </summary>
@@ -34,6 +32,8 @@
         {
             this.policies = policies ?? Enumerable.Empty<TransmissionPolicy>();
         }
+
+        public static TransmissionPolicyCollection Default => new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>());
 
         public void Initialize(Transmitter transmitter)
         {

--- a/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/TransmissionPolicy/TransmissionPolicyCollection.cs
@@ -24,6 +24,8 @@
             };
         }
 
+        public static TransmissionPolicyCollection Default => new TransmissionPolicyCollection(Enumerable.Empty<TransmissionPolicy>());
+
         /// <summary>
         /// Constructor for unit tests only.
         /// </summary>

--- a/BASE/src/ServerTelemetryChannel/Implementation/Transmitter.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/Transmitter.cs
@@ -38,7 +38,7 @@
             TransmissionSender sender = null,
             TransmissionBuffer transmissionBuffer = null,
             TransmissionStorage storage = null,
-            TransmissionPolicyCollection policies = null,
+            TransmissionPolicyCollection policies,
             BackoffLogicManager backoffLogicManager = null)
         {
             this.backoffLogicManager = backoffLogicManager ?? new BackoffLogicManager();
@@ -53,8 +53,8 @@
             this.Storage = storage ?? new TransmissionStorage();
             this.maxStorageCapacity = this.Storage.Capacity;
 
-            this.policies = policies;
-            this.policies?.Initialize(this);
+            this.policies = policies ?? TransmissionPolicyCollection.Default;
+            this.policies.Initialize(this);
         }
 
         public event EventHandler<TransmissionProcessedEventArgs> TransmissionSent;
@@ -416,9 +416,9 @@
 
         private void UpdateComponentCapacitiesFromPolicies()
         {
-            this.Sender.Capacity = this.policies?.CalculateMinimumMaxSenderCapacity() ?? this.maxSenderCapacity;
-            this.Buffer.Capacity = this.policies?.CalculateMinimumMaxBufferCapacity() ?? this.maxBufferCapacity;
-            this.Storage.Capacity = this.policies?.CalculateMinimumMaxStorageCapacity() ?? this.maxStorageCapacity;
+            this.Sender.Capacity = this.policies.CalculateMinimumMaxSenderCapacity() ?? this.maxSenderCapacity;
+            this.Buffer.Capacity = this.policies.CalculateMinimumMaxBufferCapacity() ?? this.maxBufferCapacity;
+            this.Storage.Capacity = this.policies.CalculateMinimumMaxStorageCapacity() ?? this.maxStorageCapacity;
         }
 
         private void Dispose(bool disposing)

--- a/BASE/src/ServerTelemetryChannel/Implementation/Transmitter.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/Transmitter.cs
@@ -10,6 +10,7 @@
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.Channel.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy;
 
     /// <summary>
     /// Implements throttled and persisted transmission of telemetry to Application Insights. 
@@ -19,7 +20,7 @@
         internal readonly TransmissionSender Sender;
         internal readonly TransmissionBuffer Buffer;
         internal readonly TransmissionStorage Storage;
-        private readonly IEnumerable<TransmissionPolicy> policies;
+        private readonly TransmissionPolicyCollection policies;
         private readonly BackoffLogicManager backoffLogicManager;
         private readonly Task<bool> successTask = Task.FromResult(true);
         private readonly Task<bool> failedTask = Task.FromResult(false);
@@ -37,7 +38,7 @@
             TransmissionSender sender = null,
             TransmissionBuffer transmissionBuffer = null,
             TransmissionStorage storage = null,
-            IEnumerable<TransmissionPolicy> policies = null,
+            TransmissionPolicyCollection policies = null,
             BackoffLogicManager backoffLogicManager = null)
         {
             this.backoffLogicManager = backoffLogicManager ?? new BackoffLogicManager();
@@ -52,11 +53,8 @@
             this.Storage = storage ?? new TransmissionStorage();
             this.maxStorageCapacity = this.Storage.Capacity;
 
-            this.policies = policies ?? Enumerable.Empty<TransmissionPolicy>();
-            foreach (TransmissionPolicy policy in this.policies)
-            {
-                policy.Initialize(this);
-            }
+            this.policies = policies;
+            this.policies?.Initialize(this);
         }
 
         public event EventHandler<TransmissionProcessedEventArgs> TransmissionSent;
@@ -390,21 +388,6 @@
             }
         }
 
-        private int? CalculateCapacity(Func<TransmissionPolicy, int?> getMaxPolicyCapacity)
-        {
-            int? maxComponentCapacity = null;
-            foreach (TransmissionPolicy policy in this.policies)
-            {
-                int? maxPolicyCapacity = getMaxPolicyCapacity(policy);
-                if (maxPolicyCapacity != null)
-                {
-                    maxComponentCapacity = maxComponentCapacity == null ? maxPolicyCapacity : Math.Min(maxComponentCapacity.Value, maxPolicyCapacity.Value);
-                }
-            }
-
-            return maxComponentCapacity;
-        }
-
         private void HandleSenderTransmissionSentEvent(object sender, TransmissionProcessedEventArgs e)
         {
             this.OnTransmissionSent(e);
@@ -433,19 +416,16 @@
 
         private void UpdateComponentCapacitiesFromPolicies()
         {
-            this.Sender.Capacity = this.CalculateCapacity(policy => policy.MaxSenderCapacity) ?? this.maxSenderCapacity;
-            this.Buffer.Capacity = this.CalculateCapacity(policy => policy.MaxBufferCapacity) ?? this.maxBufferCapacity;
-            this.Storage.Capacity = this.CalculateCapacity(policy => policy.MaxStorageCapacity) ?? this.maxStorageCapacity;
+            this.Sender.Capacity = this.policies?.CalculateMinimumMaxSenderCapacity() ?? this.maxSenderCapacity;
+            this.Buffer.Capacity = this.policies?.CalculateMinimumMaxBufferCapacity() ?? this.maxBufferCapacity;
+            this.Storage.Capacity = this.policies?.CalculateMinimumMaxStorageCapacity() ?? this.maxStorageCapacity;
         }
 
         private void Dispose(bool disposing)
         {
             if (disposing && this.policies != null)
             {
-                foreach (var policy in this.policies.OfType<IDisposable>())
-                {
-                    policy.Dispose();
-                }
+                this.policies.Dispose();
 
                 if (this.Storage != null)
                 {

--- a/BASE/src/ServerTelemetryChannel/Implementation/Transmitter.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/Transmitter.cs
@@ -38,7 +38,7 @@
             TransmissionSender sender = null,
             TransmissionBuffer transmissionBuffer = null,
             TransmissionStorage storage = null,
-            TransmissionPolicyCollection policies,
+            TransmissionPolicyCollection policies = null,
             BackoffLogicManager backoffLogicManager = null)
         {
             this.backoffLogicManager = backoffLogicManager ?? new BackoffLogicManager();

--- a/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
+++ b/BASE/src/ServerTelemetryChannel/ServerTelemetryChannel.cs
@@ -12,6 +12,7 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication;
     using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation;
+    using Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TransmissionPolicy;
 
     using TelemetryBuffer = Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.Implementation.TelemetryBuffer;
 
@@ -25,6 +26,7 @@
         internal Transmitter Transmitter;
 
         private readonly InterlockedThrottle throttleEmptyIkeyLog = new InterlockedThrottle(interval: TimeSpan.FromSeconds(30));
+        private readonly TransmissionPolicyCollection policies;
 
         private bool? developerMode;
         private int telemetryBufferCapacity;
@@ -46,19 +48,8 @@
 
         internal ServerTelemetryChannel(INetwork network, IApplicationLifecycle applicationLifecycle)
         {
-            var policies = new TransmissionPolicy[]
-            { 
-#if NETFRAMEWORK
-                // We don't have implementation for IApplicationLifecycle for .NET Core
-                new ApplicationLifecycleTransmissionPolicy(applicationLifecycle),
-#endif
-                new ThrottlingTransmissionPolicy(),
-                new ErrorHandlingTransmissionPolicy(),
-                new PartialSuccessTransmissionPolicy(),
-                new NetworkAvailabilityTransmissionPolicy(network),
-            };
-
-            this.Transmitter = new Transmitter(policies: policies);
+            this.policies = new TransmissionPolicyCollection(network, applicationLifecycle);
+            this.Transmitter = new Transmitter(policies: this.policies);
 
             this.TelemetrySerializer = new TelemetrySerializer(this.Transmitter);
             this.TelemetryBuffer = new TelemetryBuffer(this.TelemetrySerializer, applicationLifecycle);


### PR DESCRIPTION
Here I've refactored `TransmissionPolicy` and introduced a new class `TransmissionPolicyCollection`.

Why
I need to introduce a new TransmissionPolicy for AAD scenarios. 
Moving all the existing policies into their own collection let me review how they are used. 

## Changes
- Introduced a new class `TransmissionPolicyCollection` to encapsulate all policy classes and their interactions.
- Moved existing classes to a new namespace.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
