### PR TITLE
Remove OpenCover. CVE-2018-1285

### DIFF
--- a/WEB/Src/Web/Web.Tests/Web.Tests.csproj
+++ b/WEB/Src/Web/Web.Tests/Web.Tests.csproj
@@ -36,7 +36,6 @@
     <PackageReference Include="Microsoft.AspNet.TelemetryCorrelation" Version="1.0.8" />
     <PackageReference Include="Microsoft.AspNet.WebApi" Version="5.2.4" />
     <PackageReference Include="Moq" Version="4.8.2" />
-    <PackageReference Include="OpenCover" Version="4.7.922" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Although this is a test project, this vulnerability is generating internal security warnings.

We currently not using OpenCover so best to remove it for now.