### PR TITLE
Self-Diagnostics: include datetimestamp in filename

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresherTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresherTest.cs
@@ -27,8 +27,10 @@
                     // Emitting event of EventLevel.Warning
                     CoreEventSource.Log.OperationIsNullWarning();
 
+                    var filePath = configRefresher.CurrentFilePath;
+
                     int bufferSize = 512;
-                    byte[] actualBytes = ReadFile(bufferSize);
+                    byte[] actualBytes = ReadFile(filePath, bufferSize);
                     string logText = Encoding.UTF8.GetString(actualBytes);
                     Assert.IsTrue(logText.StartsWith(MessageOnNewFileString));
 
@@ -52,8 +54,10 @@
                     // Emitting event of EventLevel.Error
                     CoreEventSource.Log.InvalidOperationToStopError();
 
+                    var filePath = configRefresher.CurrentFilePath;
+
                     int bufferSize = 512;
-                    byte[] actualBytes = ReadFile(bufferSize);
+                    byte[] actualBytes = ReadFile(filePath, bufferSize);
                     string logText = Encoding.UTF8.GetString(actualBytes);
                     Assert.IsTrue(logText.StartsWith(MessageOnNewFileString));
 
@@ -77,12 +81,11 @@
             return logLine.Substring(timestampPrefixLength);
         }
 
-        private static byte[] ReadFile(int byteCount)
+        private static byte[] ReadFile(string filePath, int byteCount)
         {
-            var outputFileName = Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName) + "."
-                    + Process.GetCurrentProcess().Id + ".log";
-            var outputFilePath = Path.Combine(".", outputFileName);
-            using (var file = File.Open(outputFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
+            //var outputFileName = Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName) + "." + Process.GetCurrentProcess().Id + ".log";
+            //var outputFilePath = Path.Combine(".", outputFileName);
+            using (var file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 byte[] actualBytes = new byte[byteCount];
                 file.Read(actualBytes, 0, byteCount);

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresherTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresherTest.cs
@@ -83,8 +83,6 @@
 
         private static byte[] ReadFile(string filePath, int byteCount)
         {
-            //var outputFileName = Path.GetFileName(Process.GetCurrentProcess().MainModule.FileName) + "." + Process.GetCurrentProcess().Id + ".log";
-            //var outputFilePath = Path.Combine(".", outputFileName);
             using (var file = File.Open(filePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite))
             {
                 byte[] actualBytes = new byte[byteCount];

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresher.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigRefresher.cs
@@ -37,6 +37,8 @@
             this.worker = Task.Run(() => this.Worker(this.cancellationTokenSource.Token), this.cancellationTokenSource.Token);
         }
 
+        public string CurrentFilePath => this.memoryMappedFileHandler.CurrentFilePath;
+
         /// <inheritdoc/>
         public void Dispose()
         {

--- a/troubleshooting/ETW/Readme.md
+++ b/troubleshooting/ETW/Readme.md
@@ -122,7 +122,8 @@ As of version 2.18.0, this SDK ships a "self-diagnostics feature" which captures
 
 The self-diagnostics feature can be enabled/changed/disabled while the process is running.
 The SDK will attempt to read the configuration file every 10 seconds, using a non-exclusive read-only mode.
-The SDK will create or overwrite a file with new logs according to the configuration. 
+Each time this configuration file changes, a new log file will be created according to the configuration. 
+This file will not exceed the configured max size and will be circularly overwritten.
 
 #### Configuration
 

--- a/troubleshooting/ETW/Readme.md
+++ b/troubleshooting/ETW/Readme.md
@@ -122,7 +122,7 @@ As of version 2.18.0, this SDK ships a "self-diagnostics feature" which captures
 
 The self-diagnostics feature can be enabled/changed/disabled while the process is running.
 The SDK will attempt to read the configuration file every 10 seconds, using a non-exclusive read-only mode.
-Each time this configuration file changes, a new log file will be created according to the configuration. 
+The SDK will create or overwrite a file with new logs according to the configuration.
 This file will not exceed the configured max size and will be circularly overwritten.
 
 #### Configuration

--- a/troubleshooting/ETW/Readme.md
+++ b/troubleshooting/ETW/Readme.md
@@ -151,14 +151,14 @@ Example:
 #### Configuration Parameters
 
 A `FileSize`-KiB log file named as `YearMonthDay-HourMinuteSecond.ExecutableName.ProcessId.log` (e.g. `20010101-120000.foobar.exe.12345.log`) will be generated at the specified directory `LogDirectory`.
-The file starts with the `DateTime.UtcNow` timestamp of when the file was created.
+The file name starts with the `DateTime.UtcNow` timestamp of when the file was created.
 
 1. `LogDirectory` is the directory where the output log file will be stored. 
 It can be an absolute path or a relative path to the current directory.
 
 2. `FileSize` is a positive integer, which specifies the log file size in [KiB](https://en.wikipedia.org/wiki/Kibibyte).
 This value must be between 1 MiB and 128 MiB (inclusive), or it will be rounded to the closest upper or lower limit.
-The log file will never exceed this configured size, and will be curcularly rewriten.
+The log file will never exceed this configured size, and will be circularly rewriten.
 
 3. `LogLevel` is the lowest level of the events to be captured. 
 This value must match one of the [fields](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventlevel#fields) of the `EventLevel` enum.

--- a/troubleshooting/ETW/Readme.md
+++ b/troubleshooting/ETW/Readme.md
@@ -150,13 +150,15 @@ Example:
 
 #### Configuration Parameters
 
-A `FileSize`-KiB log file named as `ExecutableName.ProcessId.log` (e.g. `foobar.exe.12345.log`) will be generated at the specified directory `LogDirectory`.
+A `FileSize`-KiB log file named as `YearMonthDay-HourMinuteSecond.ExecutableName.ProcessId.log` (e.g. `20010101-120000.foobar.exe.12345.log`) will be generated at the specified directory `LogDirectory`.
+The file starts with the `DateTime.UtcNow` timestamp of when the file was created.
 
 1. `LogDirectory` is the directory where the output log file will be stored. 
 It can be an absolute path or a relative path to the current directory.
 
 2. `FileSize` is a positive integer, which specifies the log file size in [KiB](https://en.wikipedia.org/wiki/Kibibyte).
 This value must be between 1 MiB and 128 MiB (inclusive), or it will be rounded to the closest upper or lower limit.
+The log file will never exceed this configured size, and will be curcularly rewriten.
 
 3. `LogLevel` is the lowest level of the events to be captured. 
 This value must match one of the [fields](https://docs.microsoft.com/dotnet/api/system.diagnostics.tracing.eventlevel#fields) of the `EventLevel` enum.


### PR DESCRIPTION
Parent Issue #2238


I'm proposing a change to the self-diagnostics to address an issue I'm running into.
When running multiple tests I'm finding it difficult to identify the most recent log file because, I end up with file names like this:
```
// <process file name>.<process id>.log
iisexpress.exe.11111.log
iisexpress.exe.22222.log
iisexpress.exe.33333.log
iisexpress.exe.44444.log
```

I'm proposing to include the datetime in the file name to better identify the most recent log file.

```
// <YearMonthDay>-<HourMinuteSecond>.<process file name>.<process id>.log
20210709-120000.iisexpress.exe.22222.log
20210709-130000.iisexpress.exe.11111.log
20210709-140000.iisexpress.exe.44444.log
20210709-150000.iisexpress.exe.33333.log
```

This will have the added benefit of helping to identify log files when collected for support investigations.


## Changes
- include DateTime.UtcNow in filename
- update unit tests.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
