### PR TITLE
Update .Net 5 version in linux-build.yml

### DIFF
--- a/NETCORE/.vsts/linux-build.yml
+++ b/NETCORE/.vsts/linux-build.yml
@@ -37,8 +37,7 @@ steps:
 - task: UseDotNet@2
   displayName: install dotnet 5
   inputs:
-    version: 5.0.100-rc.2.20479.15
-    includePreviewVersions: true
+    version: 5.0.x
     
 - task: DotNetCoreCLI@2
   displayName:  DotNetCoreCLI - Restore Solution


### PR DESCRIPTION
builds are throwing a new exception today:
```
##[error]Failed while installing version: 5.0.100-rc.2.20479.15. Could not download installation package. Error: Unexpected HTTP response: 404
```

The lastest version is 5.0.7 (https://dotnet.microsoft.com/download/dotnet/5.0).

Updating the yml to take latest.


This is for the NetCore linux build.
The Base linux build was already using the wildcard to get latest:
https://github.com/microsoft/ApplicationInsights-dotnet/blob/dfa51220a53930d087e1be2613e0ae7ba21d3032/BASE/.vsts/linux-build.yml#L26-L29