### PR TITLE
Custom properties in full documents for QuickPulse - up to 10 from 3, consistent selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - [Change Self-Diagnostics to include datetimestamp in filename](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2325)
 - [AAD: Add logging to AuthenticationTransmissionPolicy](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2319)
+- [QuickPulse: Bump the number of custom dimensions included into full documents for QuickPulse from 3 to 10, make the selection consistent]
 
 ## Version 2.18.0-beta3
 - [Enable the self diagnostics and fix a NullReferenceException bug](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2302)

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
@@ -582,7 +582,11 @@
                 Success = false,
                 ResponseCode = "500",
                 Duration = TimeSpan.FromSeconds(1),
-                Properties = { { "Prop1", "Val1" }, { "Prop2", "Val2" }, { "Prop3", "Val3" }, { "Prop4", "Val4" } },
+                Properties =
+                {
+                    {"Prop1", "Val1"}, {"Prop5", "Val5"}, {"Prop10", "Val10"}, {"Prop8", "Val8"}, {"Prop3", "Val3"}, {"Prop7", "Val7"}, {"Prop6", "Val6"}, {"Prop9", "Val9"},
+                    {"Prop4", "Val4"}, {"Prop11", "Val11"}, {"Prop2", "Val2"}
+                },
                 Context = { InstrumentationKey = instrumentationKey }
             };
 
@@ -591,27 +595,44 @@
                 Name = Guid.NewGuid().ToString(),
                 Success = false,
                 Duration = TimeSpan.FromSeconds(1),
-                Properties = { { "Prop1", "Val1" }, { "Prop2", "Val2" }, { "Prop3", "Val3" }, { "Prop4", "Val4" }, { "ErrorMessage", "EMValue" } },
+                Properties =
+                {
+                    {"Prop1", "Val1"}, {"Prop5", "Val5"}, {"Prop10", "Val10"}, {"Prop8", "Val8"}, {"ErrorMessage", "EMValue"}, {"Prop3", "Val3"}, {"Prop7", "Val7"},
+                    {"Prop6", "Val6"}, {"Prop9", "Val9"},
+                    {"Prop4", "Val4"}, {"Prop11", "Val11"}, {"Prop2", "Val2"}
+                },
                 Context = { InstrumentationKey = instrumentationKey }
             };
 
             var exception = new ExceptionTelemetry(new ArgumentNullException())
             {
-                Properties = { { "Prop1", "Val1" }, { "Prop2", "Val2" }, { "Prop3", "Val3" }, { "Prop4", "Val4" } },
+                Properties =
+                {
+                    {"Prop1", "Val1"}, {"Prop5", "Val5"}, {"Prop10", "Val10"}, {"Prop8", "Val8"}, {"Prop3", "Val3"}, {"Prop7", "Val7"}, {"Prop6", "Val6"}, {"Prop9", "Val9"},
+                    {"Prop4", "Val4"}, {"Prop11", "Val11"}, {"Prop2", "Val2"}
+                },
                 Context = { InstrumentationKey = instrumentationKey }
             };
 
             var @event = new EventTelemetry()
             {
                 Name = "Event1",
-                Properties = { { "Prop1", "Val1" }, { "Prop2", "Val2" }, { "Prop3", "Val3" }, { "Prop4", "Val4" } },
+                Properties =
+                {
+                    {"Prop1", "Val1"}, {"Prop5", "Val5"}, {"Prop10", "Val10"}, {"Prop8", "Val8"}, {"Prop3", "Val3"}, {"Prop7", "Val7"}, {"Prop6", "Val6"}, {"Prop9", "Val9"},
+                    {"Prop4", "Val4"}, {"Prop11", "Val11"}, {"Prop2", "Val2"}
+                },
                 Context = { InstrumentationKey = instrumentationKey }
             };
 
             var trace = new TraceTelemetry()
             {
                 Message = "Trace1",
-                Properties = { { "Prop1", "Val1" }, { "Prop2", "Val2" }, { "Prop3", "Val3" }, { "Prop4", "Val4" } },
+                Properties =
+                {
+                    {"Prop1", "Val1"}, {"Prop5", "Val5"}, {"Prop10", "Val10"}, {"Prop8", "Val8"}, {"Prop3", "Val3"}, {"Prop7", "Val7"}, {"Prop6", "Val6"}, {"Prop9", "Val9"},
+                    {"Prop4", "Val4"}, {"Prop11", "Val11"}, {"Prop2", "Val2"}
+                },
                 Context = { InstrumentationKey = instrumentationKey }
             };
 
@@ -624,19 +645,28 @@
             // ASSERT
             var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().Reverse().ToArray();
 
+            var expectedProperties =
+                new Dictionary<string, string>()
+                {
+                    {"Prop1", "Val1"}, {"Prop10", "Val10"}, {"Prop11", "Val11"}, {"Prop2", "Val2"}, {"Prop3", "Val3"}, {"Prop4", "Val4"}, {"Prop5", "Val5"}, {"Prop6", "Val6"},
+                    {"Prop7", "Val7"}, {"Prop8", "Val8"}
+                }.ToArray();
+
             Assert.IsFalse(accumulatorManager.CurrentDataAccumulator.GlobalDocumentQuotaReached);
 
             Assert.AreEqual(5, accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Count);
 
             Assert.AreEqual(TelemetryDocumentType.Request, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[0].DocumentType));
             Assert.AreEqual(request.Name, ((RequestTelemetryDocument)collectedTelemetry[0]).Name);
-            Assert.AreEqual(3, collectedTelemetry[0].Properties.Length);
+            Assert.AreEqual(10, collectedTelemetry[0].Properties.Length);
+            CollectionAssert.AreEqual(expectedProperties, collectedTelemetry[0].Properties);
             Assert.AreEqual("StreamRequestsAndDependenciesAndExceptions", collectedTelemetry[0].DocumentStreamIds.Single());
             Assert.IsTrue(collectedTelemetry[0].Properties.ToList().TrueForAll(pair => pair.Key.Contains("Prop") && pair.Value.Contains("Val")));
 
             Assert.AreEqual(TelemetryDocumentType.RemoteDependency, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[1].DocumentType));
             Assert.AreEqual(dependency.Name, ((DependencyTelemetryDocument)collectedTelemetry[1]).Name);
-            Assert.AreEqual(3 + 1, collectedTelemetry[1].Properties.Length);
+            Assert.AreEqual(10 + 1, collectedTelemetry[1].Properties.Length);
+            CollectionAssert.AreEqual(expectedProperties.Concat(new[] {new KeyValuePair<string, string>("ErrorMessage", "EMValue")}).ToArray(), collectedTelemetry[1].Properties);
             Assert.AreEqual("StreamRequestsAndDependenciesAndExceptions", collectedTelemetry[1].DocumentStreamIds.Single());
             Assert.IsTrue(
                 collectedTelemetry[1].Properties.ToList()
@@ -645,7 +675,8 @@
 
             Assert.AreEqual(TelemetryDocumentType.Exception, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[2].DocumentType));
             Assert.AreEqual(exception.Exception.ToString(), ((ExceptionTelemetryDocument)collectedTelemetry[2]).Exception);
-            Assert.AreEqual(3, collectedTelemetry[2].Properties.Length);
+            Assert.AreEqual(10, collectedTelemetry[2].Properties.Length);
+            CollectionAssert.AreEqual(expectedProperties, collectedTelemetry[2].Properties);
             Assert.AreEqual(2, collectedTelemetry[2].DocumentStreamIds.Length);
             Assert.AreEqual("StreamRequestsAndDependenciesAndExceptions", collectedTelemetry[2].DocumentStreamIds.First());
             Assert.AreEqual("StreamExceptionsEventsTraces", collectedTelemetry[2].DocumentStreamIds.Last());
@@ -653,13 +684,15 @@
 
             Assert.AreEqual(TelemetryDocumentType.Event, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[3].DocumentType));
             Assert.AreEqual(@event.Name, ((EventTelemetryDocument)collectedTelemetry[3]).Name);
-            Assert.AreEqual(3, collectedTelemetry[3].Properties.Length);
+            Assert.AreEqual(10, collectedTelemetry[3].Properties.Length);
+            CollectionAssert.AreEqual(expectedProperties, collectedTelemetry[3].Properties);
             Assert.AreEqual("StreamExceptionsEventsTraces", collectedTelemetry[3].DocumentStreamIds.Single());
             Assert.IsTrue(collectedTelemetry[3].Properties.ToList().TrueForAll(pair => (pair.Key.Contains("Prop") && pair.Value.Contains("Val"))));
 
             Assert.AreEqual(TelemetryDocumentType.Trace, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[4].DocumentType));
             Assert.AreEqual(trace.Message, ((TraceTelemetryDocument)collectedTelemetry[4]).Message);
-            Assert.AreEqual(3, collectedTelemetry[4].Properties.Length);
+            Assert.AreEqual(10, collectedTelemetry[4].Properties.Length);
+            CollectionAssert.AreEqual(expectedProperties, collectedTelemetry[4].Properties);
             Assert.AreEqual("StreamExceptionsEventsTraces", collectedTelemetry[4].DocumentStreamIds.Single());
             Assert.IsTrue(collectedTelemetry[4].Properties.ToList().TrueForAll(pair => (pair.Key.Contains("Prop") && pair.Value.Contains("Val"))));
         }

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryProcessor.cs
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/QuickPulseTelemetryProcessor.cs
@@ -34,7 +34,7 @@
 
         private const int MaxFieldLength = 32768;
 
-        private const int MaxPropertyCount = 3;
+        private const int MaxPropertyCount = 10;
 
         private const string SpecialDependencyPropertyName = "ErrorMessage";
 
@@ -376,7 +376,7 @@
                 properties = new Dictionary<string, string>(MaxPropertyCount + 1);
 
                 foreach (var prop in
-                    telemetry.Properties.Where(p => !string.Equals(p.Key, specialPropertyName, StringComparison.Ordinal)).Take(MaxPropertyCount))
+                    telemetry.Properties.Where(p => !string.Equals(p.Key, specialPropertyName, StringComparison.Ordinal)).OrderBy(p => p.Key, StringComparer.Ordinal).Take(MaxPropertyCount))
                 {
                     string truncatedKey = TruncateValue(prop.Key);
 


### PR DESCRIPTION
Custom property in live full documents - up to 10 from 3, consistent selection

## Changes
Custom properties in full documents for QuickPulse - bump the limit from 3 up to 10, and make the selection of properties to include consistent across documents.

### Checklist
- [x ] I ran Unit Tests locally.
- [x ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
