### PR TITLE
remove netcore2.1 from linux builds

### DIFF
--- a/BASE/.vsts/linux-build.yml
+++ b/BASE/.vsts/linux-build.yml
@@ -3,8 +3,6 @@ pool:
 
 strategy:
     matrix:
-        #netcoreapp2_1:
-        #    framework: netcoreapp2.1
         netcoreapp3_1:
             framework: netcoreapp3.1
         net5_0:
@@ -12,11 +10,6 @@ strategy:
     maxParallel: 2
 
 steps:
-
-- task: UseDotNet@2
-  displayName: install dotnet core 2.1
-  inputs:
-    version: 2.1.x
     
 - task: UseDotNet@2
   displayName: install dotnet core 3.1

--- a/NETCORE/.vsts/linux-build.yml
+++ b/NETCORE/.vsts/linux-build.yml
@@ -1,17 +1,11 @@
 strategy:
   matrix:
-    linux_netcore2_1:
-      imageName: 'ubuntu-latest'
-      framework: netcoreapp2.1
     linux_netcore3_1:
       imageName: 'ubuntu-latest'
       framework: netcoreapp3.1
     linux_net5:
       imageName: 'ubuntu-latest'
       framework: net5.0
-    windows_netcore2_1:
-      imageName: 'windows-latest'
-      framework: netcoreapp2.1
     windows_netcore3_1:
       imageName: 'windows-latest'
       framework: netcoreapp3.1
@@ -23,11 +17,6 @@ pool:
   vmImage: $(imageName)
 
 steps:
-
-- task: UseDotNet@2
-  displayName: install dotnet core 2.1
-  inputs:
-    version: 2.1.x
     
 - task: UseDotNet@2
   displayName: install dotnet core 3.1


### PR DESCRIPTION
#2251

linux tests are failing to install netcore 2.1.

> ##[error]Failed while installing version: 2.1.816 at path: C:\hostedtoolcache\windows/dotnet with error: Could not download installation package from this URL: https://download.visualstudio.microsoft.com/download/pr/01afc7b8-49e9-4455-b525-b01f0f531a5f/d3f240d79b78f1cdb5fc115bc0dc9eec/dotnet-sdk-2.1.816-win-x64.zip Error: Error: Unexpected HTTP response: 404

These tests still run on our windows builds so I think it's safe to remove now.