### PR TITLE
[PoC] Support for Redfield

### DIFF
--- a/.props/_GlobalStaticVersion.props
+++ b/.props/_GlobalStaticVersion.props
@@ -14,6 +14,7 @@
     <SemanticVersionMinor>18</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
     <SemanticVersionPatch>0</SemanticVersionPatch>
     <PreReleaseMilestone></PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
+    <PreReleaseMilestone Condition="'$(Redfield)' == 'True'">redfield</PreReleaseMilestone>
     <PreReleaseMilestone Condition="'$(NightlyBuild)' == 'True'">nightly</PreReleaseMilestone> <!-- Overwrite this property for nightly builds from the DEVELOP branch. -->
     <!-- 
       Date when Semantic Version was changed. 

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/CoreEventSourceTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/CoreEventSourceTest.cs
@@ -4,6 +4,7 @@
     using Microsoft.ApplicationInsights.TestFramework;
     using System.Diagnostics.Tracing;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
+    using System.Linq;
 
     [TestClass]
     public class CoreEventSourceTest
@@ -25,5 +26,26 @@
             MethodInfo method = typeof(CoreEventSource).GetMethod(methodName);
             return method.GetCustomAttribute<EventAttribute>();
         }
+
+#if Redfield
+        /// <summary>
+        /// This is a sanitiy check.
+        /// The 'Redfield' compilation flag should switch the name of EventSource class.
+        /// Devs can review the test log and confirm that this test runs and passes.
+        /// This will serve as a verification that the Redfield compilation flag worked as expected.
+        /// </summary>
+        [TestMethod]
+        public void VerifyRedfieldEventSourceName()
+        {
+            var expectedName = "Redfield-Microsoft-ApplicationInsights-Core";
+
+            var eventSourceAttribute = typeof(CoreEventSource)
+                .GetCustomAttributes(typeof(EventSourceAttribute))
+                .Single() as EventSourceAttribute;
+
+            Assert.IsNotNull(eventSourceAttribute);
+            Assert.AreEqual(expectedName, eventSourceAttribute.Name);
+        }
+#endif
     }
 }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/CoreEventSourceTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Tracing/CoreEventSourceTest.cs
@@ -27,12 +27,16 @@
             return method.GetCustomAttribute<EventAttribute>();
         }
 
-#if Redfield
+#if REDFIELD
         /// <summary>
         /// This is a sanitiy check.
         /// The 'Redfield' compilation flag should switch the name of EventSource class.
         /// Devs can review the test log and confirm that this test runs and passes.
         /// This will serve as a verification that the Redfield compilation flag worked as expected.
+        /// 
+        /// To run this test:
+        /// dotnet build /p:Redfield=True ".\dotnet\BASE\Microsoft.ApplicationInsights.sln"
+        /// dotnet test ".\bin\Debug\test\Microsoft.ApplicationInsights.Tests\net5.0\Microsoft.ApplicationInsights.Tests.dll" --filter Name~VerifyRedfieldEventSourceName
         /// </summary>
         [TestMethod]
         public void VerifyRedfieldEventSourceName()

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -4,7 +4,11 @@
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
 
+#if REDFIELD
+    [EventSource(Name = "Redfield-Microsoft-ApplicationInsights-Core")]
+#else
     [EventSource(Name = "Microsoft-ApplicationInsights-Core")]
+#endif
     [SuppressMessage("Microsoft.Usage", "CA1801:ReviewUnusedParameters", Justification = "appDomainName is required")]
     internal sealed class CoreEventSource : EventSource
     {
@@ -608,7 +612,7 @@
         [Event(60, Message = "MetricManager created {0} Tasks.", Level = EventLevel.Verbose)]
         public void MetricManagerCreatedTasks(int taskCount, string appDomainName = "Incorrect") => this.WriteEvent(60, taskCount, this.nameProvider.Name);
 
-        #region FileDiagnosticsTelemetryModule
+#region FileDiagnosticsTelemetryModule
 
         [Event(61, Message = "Logs file name: {0}.", Level = EventLevel.Verbose)]
         public void LogsFileName(string fileName, string appDomainName = "Incorrect") => this.WriteEvent(61, fileName ?? string.Empty, this.nameProvider.Name);
@@ -630,7 +634,7 @@
         [Event(66, Message = "Call to WindowsIdentity.Current failed with the exception: {0}.", Level = EventLevel.Warning)]
         public void LogWindowsIdentityAccessSecurityException(string error, string appDomainName = "Incorrect") => this.WriteEvent(66, error ?? string.Empty, this.nameProvider.Name);
 
-        #endregion
+#endregion
 
         [Event(67, Message = "Backend has responded with {0} status code in {1}ms.", Level = EventLevel.Informational)]
         public void IngestionResponseTime(int responseCode, float responseDurationInMs, string appDomainName = "Incorrect") => this.WriteEvent(67, responseCode, responseDurationInMs, this.nameProvider.Name);

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -612,7 +612,7 @@
         [Event(60, Message = "MetricManager created {0} Tasks.", Level = EventLevel.Verbose)]
         public void MetricManagerCreatedTasks(int taskCount, string appDomainName = "Incorrect") => this.WriteEvent(60, taskCount, this.nameProvider.Name);
 
-#region FileDiagnosticsTelemetryModule
+        #region FileDiagnosticsTelemetryModule
 
         [Event(61, Message = "Logs file name: {0}.", Level = EventLevel.Verbose)]
         public void LogsFileName(string fileName, string appDomainName = "Incorrect") => this.WriteEvent(61, fileName ?? string.Empty, this.nameProvider.Name);
@@ -634,7 +634,7 @@
         [Event(66, Message = "Call to WindowsIdentity.Current failed with the exception: {0}.", Level = EventLevel.Warning)]
         public void LogWindowsIdentityAccessSecurityException(string error, string appDomainName = "Incorrect") => this.WriteEvent(66, error ?? string.Empty, this.nameProvider.Name);
 
-#endregion
+        #endregion
 
         [Event(67, Message = "Backend has responded with {0} status code in {1}ms.", Level = EventLevel.Informational)]
         public void IngestionResponseTime(int responseCode, float responseDurationInMs, string appDomainName = "Incorrect") => this.WriteEvent(67, responseCode, responseDurationInMs, this.nameProvider.Name);

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -154,6 +154,21 @@
             set { this.instrumentationKey = value ?? throw new ArgumentNullException(nameof(this.InstrumentationKey)); }
         }
 
+
+
+        /// <summary>
+        /// Gets a boolean indicating if this is a Redfield build.
+        /// </summary>
+        public bool Redfield
+        {
+#if REDFIELD
+            get => true;
+#else
+            get => false;
+#endif
+        }
+
+
         /// <summary>
         /// Gets or sets a value indicating whether sending of telemetry to Application Insights is disabled.
         /// </summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -154,21 +154,6 @@
             set { this.instrumentationKey = value ?? throw new ArgumentNullException(nameof(this.InstrumentationKey)); }
         }
 
-
-
-        /// <summary>
-        /// Gets a boolean indicating if this is a Redfield build.
-        /// </summary>
-        public bool Redfield
-        {
-#if REDFIELD
-            get => true;
-#else
-            get => false;
-#endif
-        }
-
-
         /// <summary>
         /// Gets or sets a value indicating whether sending of telemetry to Application Insights is disabled.
         /// </summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -23,9 +23,21 @@
     <PackageReference Include="Microsoft.Diagnostics.Tracing.EventRegister" Version="1.1.28" Condition="$(OS) == 'Windows_NT'">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
   </ItemGroup>
 
+  <Choose>
+    <When Condition="'$(Redfield)' == 'True'">
+      <ItemGroup>
+        <PackageReference Include="System.Diagnostics.DiagnosticSource"  Version="4.7.0" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  
   <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>

--- a/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -28,7 +28,7 @@
   <Choose>
     <When Condition="'$(Redfield)' == 'True'">
       <ItemGroup>
-        <PackageReference Include="System.Diagnostics.DiagnosticSource"  Version="4.7.0" />
+        <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.7.0" />
       </ItemGroup>
     </When>
     <Otherwise>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,11 +3,12 @@
 
   <PropertyGroup>
     <!-- USE THESE VARIABLES TO CONTROL THE BUILD TASKS.-->
-    <Internal_Logging>true</Internal_Logging>
+    <Internal_Logging>false</Internal_Logging>
 
     <!-- This is used to disable some build properties. -->
     <IsExamplesSolution Condition="'$(SolutionName)' == 'Examples' ">true</IsExamplesSolution>
 
+    <!-- This is used to change EventSource names. -->
     <DefineConstants Condition="'$(Redfield)' == 'True'">$(DefineConstants);REDFIELD</DefineConstants>
   </PropertyGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -3,14 +3,28 @@
 
   <PropertyGroup>
     <!-- USE THESE VARIABLES TO CONTROL THE BUILD TASKS.-->
-    <Internal_Logging>false</Internal_Logging>
+    <Internal_Logging>true</Internal_Logging>
 
     <!-- This is used to disable some build properties. -->
     <IsExamplesSolution Condition="'$(SolutionName)' == 'Examples' ">true</IsExamplesSolution>
+
+    <DefineConstants Condition="'$(Redfield)' == 'True'">$(DefineConstants);REDFIELD</DefineConstants>
   </PropertyGroup>
 
-  <Target Name="Info_InternalSettings"  BeforeTargets="Build">
-    <Message Text="Directory.Build.props: Internal_Logging is set to $(Internal_Logging)." Importance="high"/>
+  <Target Name="Info_Redfield"  BeforeTargets="Build" Condition="'$(Redfield)' == 'True'">
+    <!-- 
+    This flag is reserved for Codeless Attach products.
+    Redfield has some unique code changes to avoid conflicting with the real AI SDK.
+    To use: dotnet build /p:Redfield=True
+    -->
+    <Message Text="Directory.Build.props: Redfield build detected." Importance="high"/>
+  </Target>
+
+  <Target Name="Info_DirectoryBuildProps"  BeforeTargets="Build" Condition=" $(Internal_Logging) == 'true' ">
+    <Message Text="Info: SolutionName: $(SolutionName)." Importance="high"/>
+    <Message Text="Info: ProjectName: $(MSBuildProjectName)." Importance="high"/>
+    <Message Text="Info: TargetFramework: $(TargetFramework)." Importance="high"/>
+    <Message Text="Info: Directory.Build.props imported by $(MSBuildProjectName)." Importance="high"/>
   </Target>
 
   <Target Name="Info_DirectoryBuildProps"  BeforeTargets="Build" Condition=" $(Internal_Logging) == 'true' ">

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,13 +28,6 @@
     <Message Text="Info: Directory.Build.props imported by $(MSBuildProjectName)." Importance="high"/>
   </Target>
 
-  <Target Name="Info_DirectoryBuildProps"  BeforeTargets="Build" Condition=" $(Internal_Logging) == 'true' ">
-    <Message Text="Info: SolutionName: $(SolutionName)." Importance="high"/>
-    <Message Text="Info: ProjectName: $(MSBuildProjectName)." Importance="high"/>
-    <Message Text="Info: TargetFramework: $(TargetFramework)." Importance="high"/>
-    <Message Text="Info: Directory.Build.props imported by $(MSBuildProjectName)." Importance="high"/>
-  </Target>
-
   <PropertyGroup>
     <!-- EnlistmentRoot identifies the root directory of the repo and is used to dermine all other relative paths. -->
     <EnlistmentRoot>$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'EnlistmentRoot.marker'))</EnlistmentRoot>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,6 +21,10 @@
     <Message Text="Directory.Build.props: Redfield build detected." Importance="high"/>
   </Target>
 
+  <Target Name="Info_InternalSettings"  BeforeTargets="Build">
+    <Message Text="Directory.Build.props: Internal_Logging is set to $(Internal_Logging)." Importance="high"/>
+  </Target>
+
   <Target Name="Info_DirectoryBuildProps"  BeforeTargets="Build" Condition=" $(Internal_Logging) == 'true' ">
     <Message Text="Info: SolutionName: $(SolutionName)." Importance="high"/>
     <Message Text="Info: ProjectName: $(MSBuildProjectName)." Importance="high"/>


### PR DESCRIPTION
## Changes

- Introduce build flag `Redfield=True`
- When detected, change version of dependency: `System.Diagnostics.DiagnosticSource`
- When detected set a Constant to be used in preprocessor. This is used to change the name of `EventSource`.



## To use:

```
dotnet build /p:Redfield=True
```

## To verify:

I introduced a new unit test to verify that these changes took effect.
```
dotnet build /p:Redfield=True ".\dotnet\BASE\Microsoft.ApplicationInsights.sln"
dotnet test ".\bin\Debug\test\Microsoft.ApplicationInsights.Tests\net5.0\Microsoft.ApplicationInsights.Tests.dll" --filter Name~VerifyRedfieldEventSourceName
```


## Open Questions
- Do we need to run full tests against Redfield build?