### PR TITLE
Remove braces while serializing {OriginalFormat}

### DIFF
--- a/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
+++ b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
@@ -199,7 +199,14 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
                             {
                                 foreach (KeyValuePair<string, object> item in activeScopeDictionary)
                                 {
-                                    dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                                    if (item.Key == "{OriginalFormat}")
+                                    {
+                                        dict["OriginalFormat"] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                                    }
+                                    else
+                                    {
+                                        dict[item.Key] = Convert.ToString(item.Value, CultureInfo.InvariantCulture);
+                                    }
                                 }
                             }
                             else


### PR DESCRIPTION
The following code would cause a key-value pair in the property bag with the key equals to `{OriginalFormat}`.

![image](https://user-images.githubusercontent.com/17327289/129261285-ac827934-c352-4dd1-8337-f395d2013b15.png)

                Application Insights Telemetry: 
                {
                  "name":"AppTraces",
                  "time":"2021-04-22T22:41:50.4529345Z",
                  "iKey":"--YourAIKeyHere--",
                  "tags":{
                    "ai.application.ver":"1.0.0.0",
                    "ai.cloud.roleInstance":"-------------",
                    "ai.internal.sdkVersion":"il:2.17.0-146",
                    "ai.internal.nodeName":"----------"
                  },
                  "data":{
                    "baseType":"MessageData",
                    "baseData":{
                      "ver":2,
                      "message":"Test application is starting",
                      "severityLevel":"Information",
                      "properties":{
                        "AspNetCoreEnvironment":"Development",
                        "DeveloperMode":"true",
                        "CategoryName":"AppInsightsScopeTest.TestApplication",
                                                "{OriginalFormat}":"TestScope {ScopeColumn1} and {ScopeColumn2}",    <----- !!! THIS IS WHAT PROBABLY BREAKS KUSTO !!!
                        "OriginalFormat":"Test application is starting",
                        "ScopeColumn2":"5678",
                        "ScopeColumn1":"1234"
                      }
                    }
                  }
                }
