### PR TITLE
cleanup test projects

### DIFF
--- a/.props/Test.props
+++ b/.props/Test.props
@@ -9,6 +9,22 @@
   <Import Project=".\_AnalyzerSettings.props" />
 
   <PropertyGroup>
+    <!-- Our test matrix includes every currently supported version of .NET
+          - net4.5.2 (EoL April 2022)
+          - net4.6.0 (EoL April 2022)
+          - net4.6.1 (EoL April 2022)
+          - net4.6.2
+          - net4.7.2
+          - net4.8.0
+          - netcoreapp3.1 (EoL Dec 2022)
+          - net5.0 (EoL Feb 2022)
+          - net6.0 (GA Nov 2021)
+    -->
+    <TargetFrameworks>net462;net472;net480;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
+  </PropertyGroup>
+
+  <PropertyGroup>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
   
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net452;net46;net461;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -46,9 +47,5 @@
     <PackageReference Include="Azure.Core" Version="1.14.0" /> <!-- Supports: net461, netstandard2.0, and net5.0 -->
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-  
   <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="TestFramework.Shared" />
 </Project>

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Standalone/Microsoft.ApplicationInsights.Isolated.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Standalone/Microsoft.ApplicationInsights.Isolated.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <ProjectGuid>{2759BC71-7F47-44DA-8579-AE2D8C8C684D}</ProjectGuid>
     <TargetFrameworks>net46;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
@@ -50,9 +51,4 @@
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.Xml.Linq" />  
   </ItemGroup>
-  
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>
-

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Nuget.Tests/TelemetryChannel.Nuget.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Nuget.Tests/TelemetryChannel.Nuget.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <ProjectGuid>{21CB9A8A-F25B-4DEB-92CB-ACB6920EB8BC}</ProjectGuid>
     <TargetFrameworks>net452</TargetFrameworks>
     <AssemblyName>TelemetryChannel.Nuget.Tests</AssemblyName>
@@ -32,9 +33,5 @@
     <EmbeddedResource Include="..\..\..\src\ServerTelemetryChannel\ApplicationInsights.config.uninstall.xdt">
       <Link>Resources\ApplicationInsights.config.uninstall.xdt</Link>
     </EmbeddedResource>
-  </ItemGroup>
-  
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 </Project>

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1</TargetFrameworks>
 
@@ -26,10 +27,6 @@
     <Reference Include="System.Web" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Web.Extensions" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'">

--- a/LOGGING/test/DiagnosticSourceListener.Tests/DiagnosticSourceListener.Tests.csproj
+++ b/LOGGING/test/DiagnosticSourceListener.Tests/DiagnosticSourceListener.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.DiagnosticSourceListener.Tests</AssemblyName>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -15,13 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\DiagnosticSourceListener\DiagnosticSourceListener.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <Import Project="$(PropsRoot)\Test.props" />
 
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="..\CommonTestShared\CommonTestShared.projitems" Label="Shared" Condition="Exists('..\CommonTestShared\CommonTestShared.projitems')" />

--- a/LOGGING/test/EtwCollector.Tests/EtwCollector.Tests.csproj
+++ b/LOGGING/test/EtwCollector.Tests/EtwCollector.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.EtwCollector.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.EtwCollector.Tests</AssemblyName>
     <TargetFrameworks>net46</TargetFrameworks>
@@ -18,14 +20,7 @@
   <ItemGroup>
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-  
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <Import Project="$(PropsRoot)\Test.props" />
-
+ 
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="..\CommonTestShared\CommonTestShared.projitems" Label="Shared" Condition="Exists('..\CommonTestShared\CommonTestShared.projitems')" />
 </Project>

--- a/LOGGING/test/EventSourceListener.Tests/EventSourceListener.Tests.csproj
+++ b/LOGGING/test/EventSourceListener.Tests/EventSourceListener.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.EventSourceListener.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.EventSourceListener.Tests</AssemblyName>
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
@@ -15,14 +17,6 @@
   <ItemGroup>
     <ProjectReference Include="..\..\src\EventSourceListener\EventSourceListener.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
-  <Import Project="$(PropsRoot)\Test.props" />
-
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="..\CommonTestShared\CommonTestShared.projitems" Label="Shared" Condition="Exists('..\CommonTestShared\CommonTestShared.projitems')" />
 </Project>

--- a/LOGGING/test/ILogger.Tests/ILogger.Tests.csproj
+++ b/LOGGING/test/ILogger.Tests/ILogger.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/LOGGING/test/Log4NetAppender.Tests/Log4NetAppender.Tests.csproj
+++ b/LOGGING/test/Log4NetAppender.Tests/Log4NetAppender.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.Log4NetAppender.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.Log4NetAppender.Tests</AssemblyName>
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
@@ -19,12 +20,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
-
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="..\CommonTestShared\CommonTestShared.projitems" Label="Shared" Condition="Exists('..\CommonTestShared\CommonTestShared.projitems')" />

--- a/LOGGING/test/NLogTarget.Tests/NLogTarget.Tests.csproj
+++ b/LOGGING/test/NLogTarget.Tests/NLogTarget.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.NLogTarget.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.NLogTarget.Tests</AssemblyName>
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
@@ -18,11 +19,6 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />

--- a/LOGGING/test/TraceListener.Tests/TraceListener.Tests.csproj
+++ b/LOGGING/test/TraceListener.Tests/TraceListener.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.TraceListener.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.TraceListener.Tests</AssemblyName>
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
@@ -20,11 +21,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
   <Import Project="..\Shared\Adapters.Shared.Tests.projitems" Label="Shared" Condition="Exists('..\Shared\Adapters.Shared.Tests.projitems')" />
   <Import Project="..\CommonTestShared\CommonTestShared.projitems" Label="Shared" Condition="Exists('..\CommonTestShared\CommonTestShared.projitems')" />
 </Project>

--- a/LOGGING/test/Xdt.Tests/Xdt.Tests.csproj
+++ b/LOGGING/test/Xdt.Tests/Xdt.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Xdt.Tests</RootNamespace>
     <AssemblyName>Xdt.Tests</AssemblyName>
     <TargetFrameworks>net452</TargetFrameworks>
@@ -14,11 +15,6 @@
     <PackageReference Include="Microsoft.Web.Xdt" Version="3.0.0" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <ItemGroup>
@@ -77,6 +73,7 @@
       <Link>Resources\EtwCollector\ApplicationInsights.config.uninstall.xdt</Link>
     </EmbeddedResource>
   </ItemGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="Resources\Log4Net\TestDataSet.xml" />
     <EmbeddedResource Include="Resources\NLog\TestDataSet.xml" />
@@ -84,9 +81,11 @@
     <EmbeddedResource Include="Resources\DiagnosticSourceListener\TestDataSet.xml" />
     <EmbeddedResource Include="Resources\EventSourceListener\TestDataSet.xml" />
   </ItemGroup>
+  
   <ItemGroup>
     <EmbeddedResource Include="Resources\EtwCollector\TestDataSet.xml" />
   </ItemGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\..\BASE\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
   </ItemGroup>

--- a/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
@@ -60,8 +60,4 @@
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -43,8 +43,4 @@
     <DotNetCliToolReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Tools" Version="2.0.0" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
-
 </Project>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -5,6 +5,9 @@
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
+
+    <!-- Side effect of adding the Test.props, some analyzers are now running in this project. I'll fix these in a follow up PR. -->
+    <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -1,16 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="$(PropsRoot)\_Signing.props" />
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
-    <VersionPrefix>2.0.0</VersionPrefix>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
-    <DelaySign Condition=" '$(OS)' == 'Windows_NT' ">true</DelaySign>
-    <PreserveCompilationContext>true</PreserveCompilationContext>
-    <AssemblyName>Microsoft.ApplicationInsights.AspNetCore.Tests</AssemblyName>
-    <PackageId>Microsoft.ApplicationInsights.AspNetCore.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,7 +18,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
@@ -51,10 +44,6 @@
     <None Update="content\**">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-
-  <Import Project="$(PropsRoot)\_Signing.props" />
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
@@ -17,7 +17,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
-    <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
@@ -2,11 +2,11 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.ApplicationInsights.DependencyCollector.Tests</AssemblyName>
     <PackageId>Microsoft.AI.DependencyCollector.Tests</PackageId>
 
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <NoWarn>1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
@@ -48,9 +48,6 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
   <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="Shared" />
 
 </Project>

--- a/WEB/Src/EventCounterCollector/EventCounterCollector.Tests/EventCounterCollector.Tests.csproj
+++ b/WEB/Src/EventCounterCollector/EventCounterCollector.Tests/EventCounterCollector.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
   
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.AI.EventCounterCollector.Tests</AssemblyName>
   </PropertyGroup>

--- a/WEB/Src/HostingStartup/HostingStartup.Tests/HostingStartup.Tests.csproj
+++ b/WEB/Src/HostingStartup/HostingStartup.Tests/HostingStartup.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
   
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Microsoft.ApplicationInsights.HostingStartup.Tests</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights.HostingStartup.Tests</AssemblyName>
     <TargetFrameworks>net452</TargetFrameworks>
@@ -19,11 +20,6 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <Reference Include="System" />
     <Reference Include="System.Net.Http" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
@@ -5,8 +5,6 @@
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.AI.PerformanceCollector.Tests</AssemblyName>
-    <!--<PackageId>Microsoft.AI.DependencyCollector.Tests</PackageId>-->
-    <!--<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
   </PropertyGroup>
 

--- a/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
@@ -2,10 +2,11 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
     <AssemblyName>Microsoft.AI.PerformanceCollector.Tests</AssemblyName>
-    <PackageId>Microsoft.AI.DependencyCollector.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+    <!--<PackageId>Microsoft.AI.DependencyCollector.Tests</PackageId>-->
+    <!--<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
   </PropertyGroup>
 
@@ -36,10 +37,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\PerformanceCollector\Perf.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Xdt.Tests</RootNamespace>
     <AssemblyName>Xdt.Tests</AssemblyName>
     <TargetFrameworks>net45;net452</TargetFrameworks>
@@ -34,8 +35,4 @@
     </EmbeddedResource>
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Identifies the project as test project -->
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>

--- a/WEB/Src/Web/Web.Tests/Web.Tests.csproj
+++ b/WEB/Src/Web/Web.Tests/Web.Tests.csproj
@@ -2,6 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
   
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <AssemblyName>Microsoft.ApplicationInsights.Web.Tests</AssemblyName>
     <TargetFrameworks>net452</TargetFrameworks>
   </PropertyGroup>
@@ -42,5 +43,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  
   <Import Project="..\..\TestFramework\Shared\TestFramework.Shared.projitems" Label="Shared" />
+  
 </Project>

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -4,10 +4,6 @@
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <AssemblyName>Microsoft.AI.WindowsServer.Tests</AssemblyName>
-    <!--<PackageId>Microsoft.AI.WindowsServer.Tests</PackageId>-->
-    <!--<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
-    <!--<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>-->
-    <!--<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>-->
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -2,11 +2,12 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <AssemblyName>Microsoft.AI.WindowsServer.Tests</AssemblyName>
-    <PackageId>Microsoft.AI.WindowsServer.Tests</PackageId>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
+    <!--<PackageId>Microsoft.AI.WindowsServer.Tests</PackageId>-->
+    <!--<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>-->
+    <!--<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>-->
+    <!--<GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>-->
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
     <TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION
As a part of #2251, I'm reviewing all test projects and trying to get them on the same target frameworks.
This PR is pulling some of my changes out of #2361.

I'm cleaning up test projects by removing unused properties:
- `<Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />` was a bug fix for VS2017 and no longer necessary. ([link](https://github.com/microsoft/vstest/issues/472))
- Some of the extra properties in the AspNetCore projects were preventing VS and some CLI from running those tests (FIXED!!)

- Preparing to move the `<TargetFrameworks>` to the Test.props file. We few exceptions, we should have uniform `TargetFrameworks` across all our projects. 
  I'll convert individual test projects to use the centralized TargetFrameworks in follow up PRs because this is requiring some other changes in those individual projects (preprocessors and conditional PackageReferences)