### PR TITLE
Suppress long running SignalR connections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - [The `{OriginalFormat}` field in ILogger Scope will be emitted as `OriginalFormat` with the braces removed](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2362)
 - [Enable SDK to create package for auto-instrumentation](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2365)
+- [Suppress long running SignalR connections](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2372)
 
 ## Version 2.18.0
 - [Change Self-Diagnostics to include datetimestamp in filename](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2325)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/DiagnosticListeners/Implementation/HostingDiagnosticListener.cs
@@ -754,6 +754,17 @@
                     return;
                 }
 
+                var activity = Activity.Current;
+                
+                // Suppress long running SignalR requests
+                // Ref: https://github.com/dotnet/aspnetcore/pull/32084
+                var httpLongRunningRequest = activity?.Tags.FirstOrDefault(tag => tag.Key == "http.long_running").Value;
+
+                if (httpLongRunningRequest == "true")
+                {
+                    return;
+                }
+
                 telemetry.Stop(timestamp);
                 telemetry.ResponseCode = httpContext.Response.StatusCode.ToString(CultureInfo.InvariantCulture);
 
@@ -781,7 +792,6 @@
                 this.client.TrackRequest(telemetry);
 
                 // Stop what we started.
-                var activity = Activity.Current;
                 if (activity != null && activity.OperationName == ActivityCreatedByHostingDiagnosticListener)
                 {
                     activity.Stop();


### PR DESCRIPTION
- SignalR team has added a new Activity Tag `http.long_running: true` to the Activity to indicate that the request is long running. Ref: https://github.com/dotnet/aspnetcore/pull/32084

## Changes
If `http.long_running` is set to `true` in Activity.Tag, avoid creating a `Request` telemetry.

### Checklist
- [X] I ran Unit Tests locally.
- [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.
