### PR TITLE
test coverage: AspNetCore and WorkerService

### DIFF
--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/AddApplicationInsightsTelemetryTests.cs
@@ -978,7 +978,8 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             //ACT
             services.ConfigureTelemetryModule<TestTelemetryModule>
-                (module => module.CustomProperty = "mycustomproperty");
+                ((module, o) => module.CustomProperty = "mycustomproperty");
+
             services.AddApplicationInsightsTelemetry();
             IServiceProvider serviceProvider = services.BuildServiceProvider();
 
@@ -1045,7 +1046,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
                 {
                     o.RequestCollectionOptions.InjectResponseHeaders = isEnable;
                     o.RequestCollectionOptions.TrackExceptions = isEnable;
-                    o.RequestCollectionOptions.EnableW3CDistributedTracing = isEnable;
+                    // o.RequestCollectionOptions.EnableW3CDistributedTracing = isEnable; // Obsolete
                 };
                 filePath = null;
             }
@@ -1062,7 +1063,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             Assert.Equal(isEnable, requestTrackingModule.CollectionOptions.InjectResponseHeaders);
             Assert.Equal(isEnable, requestTrackingModule.CollectionOptions.TrackExceptions);
-            Assert.Equal(isEnable, requestTrackingModule.CollectionOptions.EnableW3CDistributedTracing);
+            // Assert.Equal(isEnable, requestTrackingModule.CollectionOptions.EnableW3CDistributedTracing); // Obsolete
         }
 
         [Fact]
@@ -1074,7 +1075,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             //ACT and VALIDATE
             Assert.Throws<ArgumentNullException>(() => services.ConfigureTelemetryModule<TestTelemetryModule>((Action<TestTelemetryModule, ApplicationInsightsServiceOptions>)null));
+
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.Throws<ArgumentNullException>(() => services.ConfigureTelemetryModule<TestTelemetryModule>((Action<TestTelemetryModule>)null));
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         [Fact]
@@ -1455,7 +1459,9 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             IServiceProvider serviceProvider = services.BuildServiceProvider();
             var telemetryConfiguration = serviceProvider.GetTelemetryConfiguration();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             Assert.DoesNotContain(telemetryConfiguration.TelemetryInitializers, t => t is W3COperationCorrelationTelemetryInitializer);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             var modules = serviceProvider.GetServices<ITelemetryModule>().ToList();
 
@@ -1490,8 +1496,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
             bool firstLoggerCallback = false;
             bool secondLoggerCallback = false;
 
+#pragma warning disable CS0618 // Type or member is obsolete
             loggerProvider.AddApplicationInsights(serviceProvider, (s, level) => true, () => firstLoggerCallback = true);
             loggerProvider.AddApplicationInsights(serviceProvider, (s, level) => true, () => secondLoggerCallback = true);
+#pragma warning restore CS0618 // Type or member is obsolete
 
             Assert.True(firstLoggerCallback);
             Assert.False(secondLoggerCallback);
@@ -1506,8 +1514,10 @@ namespace Microsoft.Extensions.DependencyInjection.Test
 
             var loggerProvider = new MockLoggingFactory();
 
+#pragma warning disable CS0618 // Type or member is obsolete
             loggerProvider.AddApplicationInsights(serviceProvider, (s, level) => true, null);
             loggerProvider.AddApplicationInsights(serviceProvider, (s, level) => true, null);
+#pragma warning restore CS0618 // Type or member is obsolete
         }
 
         /// <summary>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -3,11 +3,6 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
-
-    <!-- Side effect of adding the Test.props, some analyzers are now running in this project. I'll fix these in a follow up PR. -->
-    <NoWarn>CS0618</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -23,11 +18,11 @@
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.8" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'  Or  '$(TargetFramework)' == 'net462'  Or   '$(TargetFramework)' == 'net472'   Or  '$(TargetFramework)' == 'net480' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.8" /><!--TODO: CAN THIS BE UPGRADED TO 2.2.5 ?-->
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'Or '$(TargetFramework)' == 'net5.0' ">
     <!-- TODO: Can't switch to FrameworkReference yet; 
          'IHostingEnvironment' is obsolete: 'This type is obsolete and will be removed in a future version. 
          The recommended alternative is Microsoft.AspNetCore.Hosting.IWebHostEnvironment.' -->

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
@@ -19,10 +19,11 @@
         {
             var initializer = new AspNetCoreEnvironmentTelemetryInitializer(new HostingEnvironment() { EnvironmentName = "Production"});
             var telemetry = new RequestTelemetry();
-            telemetry.Context.Properties.Add("AspNetCoreEnvironment", "Development");
+            telemetry.Context.GlobalProperties.Add("AspNetCoreEnvironment", "Development");
             initializer.Initialize(telemetry);
 
-            Assert.Equal("Development", telemetry.Context.Properties["AspNetCoreEnvironment"]);
+            Assert.Equal("Development", telemetry.Context.GlobalProperties["AspNetCoreEnvironment"]);
+            Assert.Equal("Development", telemetry.Properties["AspNetCoreEnvironment"]);
         }
 
         [Fact]
@@ -32,7 +33,7 @@
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry);
 
-            Assert.Equal("Production", telemetry.Context.Properties["AspNetCoreEnvironment"]);
+            Assert.Equal("Development", telemetry.Properties["AspNetCoreEnvironment"]);
         }
     }
 }

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/Microsoft.ApplicationInsights.WorkerService.Tests.csproj
@@ -3,7 +3,6 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,6 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.0" />


### PR DESCRIPTION
Fix Issue #2379.

## Changes
- Expanding test coverage for AspNetCore.
    - Before: net461;netcoreapp3.1
    - After: net462,net472,net480,netcoreapp3.1,net5.0
- expanding test coverage for WorkerService
    - Before: netcoreapp3.1
    - After: net462,net472,net480,netcoreapp3.1,net5.0

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
