### PR TITLE
Simplify TargetFrameworks

### DIFF
--- a/.props/Test.props
+++ b/.props/Test.props
@@ -20,7 +20,7 @@
           - net5.0 (EoL Feb 2022)
           - net6.0 (GA Nov 2021)
     -->
-    <TargetFrameworks>net462;net472;net480;netcoreapp3.1;net5.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net480;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/.props/Test.props
+++ b/.props/Test.props
@@ -20,7 +20,7 @@
           - net5.0 (EoL Feb 2022)
           - net6.0 (GA Nov 2021)
     -->
-    <TargetFrameworks>net462;net472;net480;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net472;net480;netcoreapp3.1;net5.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net5.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -3,8 +3,7 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <!--<TargetFrameworks Condition="$(OS) == 'Windows_NT'">net452;net46;net461;$(TargetFrameworks)</TargetFrameworks>-->
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">net452;net46;net461;$(TargetFrameworks)</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -28,7 +28,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.71" />
 
     <Reference Include="Microsoft.CSharp" />
@@ -41,7 +41,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetStandard20)' == 'True'">
+  <ItemGroup Condition="'$(IsNetStandard20)' == 'True'">
     <PackageReference Include="Azure.Identity" Version="1.3.0" /> <!-- Supports: netstandard2.0 -->
     <PackageReference Include="Azure.Core" Version="1.14.0" /> <!-- Supports: net461, netstandard2.0, and net5.0 -->
   </ItemGroup>

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">net452;net46;net461;$(TargetFrameworks)</TargetFrameworks>
+    <!--<TargetFrameworks Condition="$(OS) == 'Windows_NT'">net452;net46;net461;$(TargetFrameworks)</TargetFrameworks>-->
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
@@ -28,7 +29,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452'  Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461'  Or '$(TargetFramework)' == 'net462'  Or '$(TargetFramework)' == 'net472'   Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.71" />
 
     <Reference Include="Microsoft.CSharp" />
@@ -41,7 +42,7 @@
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462'  Or '$(TargetFramework)' == 'net472'  Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">
+  <ItemGroup Condition="'$(TargetFrameworks_NetStandard20)' == 'True'">
     <PackageReference Include="Azure.Identity" Version="1.3.0" /> <!-- Supports: netstandard2.0 -->
     <PackageReference Include="Azure.Core" Version="1.14.0" /> <!-- Supports: net461, netstandard2.0, and net5.0 -->
   </ItemGroup>

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.71" />
 
     <Reference Include="System.Web" />
@@ -32,11 +32,11 @@
     <Reference Include="System.Web.Extensions" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetStandard20)' == 'True'">
+  <ItemGroup Condition="'$(IsNetStandard20)' == 'True'">
     <PackageReference Include="Azure.Core" Version="1.14.0" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
+  <ItemGroup Condition="'$(IsNetCore)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -24,7 +24,7 @@
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <PackageReference Include="Microsoft.Diagnostics.Tracing.TraceEvent" Version="2.0.71" />
 
     <Reference Include="System.Web" />
@@ -32,11 +32,11 @@
     <Reference Include="System.Web.Extensions" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' != 'net452' And '$(TargetFramework)' != 'net46' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetStandard20)' == 'True'">
     <PackageReference Include="Azure.Core" Version="1.14.0" />
   </ItemGroup>
   
-  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp3.1'  Or '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -79,7 +79,7 @@
 
   <PropertyGroup>
     <!-- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
-    <LangVersion>preview</LangVersion>
+    <LangVersion>latest</LangVersion>
 
     <TargetFrameworks_NetFramework Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">True</TargetFrameworks_NetFramework>
     <TargetFrameworks_NetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'  Or '$(TargetFramework)' == 'net6.0'">True</TargetFrameworks_NetCore>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -78,12 +78,12 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <!-- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
+    <!-- https://docs.microsoft.com/dotnet/csharp/language-reference/configure-language-version -->
     <LangVersion>latest</LangVersion>
 
-    <TargetFrameworks_NetFramework Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">True</TargetFrameworks_NetFramework>
-    <TargetFrameworks_NetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">True</TargetFrameworks_NetCore>
-    <TargetFrameworks_NetStandard20 Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">True</TargetFrameworks_NetStandard20>
+    <IsNetFramework Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">True</IsNetFramework>
+    <IsNetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">True</IsNetCore>
+    <IsNetStandard20 Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">True</IsNetStandard20>
     
   </PropertyGroup>
   

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -78,9 +78,16 @@
   </PropertyGroup>
 
   <PropertyGroup>
+    <!-- https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version -->
+    <LangVersion>preview</LangVersion>
 
-    <LangVersion>7.3</LangVersion>
-
+    <TargetFrameworks_NetFramework Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">True</TargetFrameworks_NetFramework>
+    <TargetFrameworks_NetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'  Or '$(TargetFramework)' == 'net6.0'">True</TargetFrameworks_NetCore>
+    <TargetFrameworks_NetStandard20 Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">True</TargetFrameworks_NetStandard20>
+    
+  </PropertyGroup>
+  
+  <PropertyGroup>
     <!-- Enable NuGet package restore during build -->
     <RestorePackages>true</RestorePackages>
     <RequireRestoreConsent>false</RequireRestoreConsent>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -82,8 +82,8 @@
     <LangVersion>latest</LangVersion>
 
     <TargetFrameworks_NetFramework Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">True</TargetFrameworks_NetFramework>
-    <TargetFrameworks_NetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'  Or '$(TargetFramework)' == 'net6.0'">True</TargetFrameworks_NetCore>
-    <TargetFrameworks_NetStandard20 Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">True</TargetFrameworks_NetStandard20>
+    <TargetFrameworks_NetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">True</TargetFrameworks_NetCore>
+    <TargetFrameworks_NetStandard20 Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'">True</TargetFrameworks_NetStandard20>
     
   </PropertyGroup>
   

--- a/LOGGING/test/ILogger.Tests/ILogger.Tests.csproj
+++ b/LOGGING/test/ILogger.Tests/ILogger.Tests.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\ILogger\ILogger.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/LOGGING/test/ILogger.Tests/ILogger.Tests.csproj
+++ b/LOGGING/test/ILogger.Tests/ILogger.Tests.csproj
@@ -16,7 +16,7 @@
     <ProjectReference Include="..\..\src\ILogger\ILogger.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.8" /><!--TODO: CAN THIS BE UPGRADED TO 2.2.5 ?-->
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
+  <ItemGroup Condition="'$(IsNetCore)' == 'True'">
     <!-- TODO: Can't switch to FrameworkReference yet; 
          'IHostingEnvironment' is obsolete: 'This type is obsolete and will be removed in a future version. 
          The recommended alternative is Microsoft.AspNetCore.Hosting.IWebHostEnvironment.' -->

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -18,11 +18,11 @@
     <PackageReference Include="xunit" Version="2.4.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net461'  Or  '$(TargetFramework)' == 'net462'  Or   '$(TargetFramework)' == 'net472'   Or  '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="1.1.8" /><!--TODO: CAN THIS BE UPGRADED TO 2.2.5 ?-->
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1'Or '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
     <!-- TODO: Can't switch to FrameworkReference yet; 
          'IHostingEnvironment' is obsolete: 'This type is obsolete and will be removed in a future version. 
          The recommended alternative is Microsoft.AspNetCore.Hosting.IWebHostEnvironment.' -->

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
@@ -24,14 +24,14 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
@@ -24,14 +24,14 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
+  <ItemGroup Condition="'$(IsNetCore)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <PackageReference Include="System.Buffers" Version="4.5.1" />
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="System" />

--- a/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
@@ -23,7 +23,7 @@
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <Reference Include="System" />
     <Reference Include="System.Net" />
     <Reference Include="System.Net.Http" />

--- a/WEB/Src/Web/Web.Tests/Web.Tests.csproj
+++ b/WEB/Src/Web/Web.Tests/Web.Tests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462'  Or '$(TargetFramework)' == 'net472'   Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />

--- a/WEB/Src/Web/Web.Tests/Web.Tests.csproj
+++ b/WEB/Src/Web/Web.Tests/Web.Tests.csproj
@@ -29,7 +29,7 @@
   </ItemGroup>
 
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <Reference Include="System" />
     <Reference Include="System.Configuration" />
     <Reference Include="System.Drawing" />

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
     <Reference Include="System" />
     <Reference Include="System.EnterpriseServices">
       <Private>True</Private>
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0'  ">
+  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     
     <PackageReference Include="NETStandard.HttpListener" Version="1.0.3.5" />

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -20,7 +20,7 @@
     </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetFramework)' == 'True'">
+  <ItemGroup Condition="'$(IsNetFramework)' == 'True'">
     <Reference Include="System" />
     <Reference Include="System.EnterpriseServices">
       <Private>True</Private>
@@ -37,7 +37,7 @@
     <PackageReference Include="System.Buffers" Version="4.5.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFrameworks_NetCore)' == 'True'">
+  <ItemGroup Condition="'$(IsNetCore)' == 'True'">
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     
     <PackageReference Include="NETStandard.HttpListener" Version="1.0.3.5" />


### PR DESCRIPTION
Instead of having long Conditional statements in project files, move the conditionals to the Directory.Build.props


## Changes
- Introduce new properties for Conditional frameworks.
- 

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
