### PR TITLE
cleanup Integration Tests

### DIFF
--- a/NETCORE/test/IntegrationTests.Tests/RequestCollectionTest.cs
+++ b/NETCORE/test/IntegrationTests.Tests/RequestCollectionTest.cs
@@ -12,34 +12,13 @@ using Xunit.Abstractions;
 
 namespace IntegrationTests.Tests
 {
-    public partial class RequestCollectionTest :
-#if NET5_0
-        IClassFixture<CustomWebApplicationFactory<Startup_net_5_0>>
-#elif NETCOREAPP3_1
-        IClassFixture<CustomWebApplicationFactory<Startup_netcoreapp_3_1>>
-#else
-        IClassFixture<CustomWebApplicationFactory<Startup_netcoreapp_2_1>>
-#endif
+    public partial class RequestCollectionTest : IClassFixture<CustomWebApplicationFactory<Startup>>
     {
-#if NET5_0
-        private readonly CustomWebApplicationFactory<Startup_net_5_0> _factory;
-#elif NETCOREAPP3_1
-        private readonly CustomWebApplicationFactory<Startup_netcoreapp_3_1> _factory;
-#else
-        private readonly CustomWebApplicationFactory<Startup_netcoreapp_2_1> _factory;
-#endif
+        private readonly CustomWebApplicationFactory<Startup> _factory;
 
         protected readonly ITestOutputHelper output;
 
-        public RequestCollectionTest(CustomWebApplicationFactory<
- #if NET5_0
-        Startup_net_5_0
-#elif NETCOREAPP3_1
-        Startup_netcoreapp_3_1
-#else
-        Startup_netcoreapp_2_1 
-#endif            
-            > factory, ITestOutputHelper output)
+        public RequestCollectionTest(CustomWebApplicationFactory<Startup> factory, ITestOutputHelper output)
         {
             this.output = output;
             _factory = factory;

--- a/NETCORE/test/IntegrationTests.Tests/RequestCorrelationHeaderTest.cs
+++ b/NETCORE/test/IntegrationTests.Tests/RequestCorrelationHeaderTest.cs
@@ -13,14 +13,7 @@ using IntegrationTests.WebApp;
 
 namespace IntegrationTests.Tests
 {
-    public partial class RequestCollectionTest :
-#if NET5_0
-        IClassFixture<CustomWebApplicationFactory<Startup_net_5_0>>
-#elif NETCOREAPP3_1
-        IClassFixture<CustomWebApplicationFactory<Startup_netcoreapp_3_1>>
-#else
-        IClassFixture<CustomWebApplicationFactory<Startup_netcoreapp_2_1>>
-#endif
+    public partial class RequestCollectionTest : IClassFixture<CustomWebApplicationFactory<Startup>>
     {
         [Fact]
         public async Task RequestSuccessWithTraceParent()

--- a/NETCORE/test/IntegrationTests.Tests/RequestILoggerTest.cs
+++ b/NETCORE/test/IntegrationTests.Tests/RequestILoggerTest.cs
@@ -17,14 +17,7 @@ using IntegrationTests.WebApp;
 
 namespace IntegrationTests.Tests
 {
-    public partial class RequestCollectionTest : 
-#if NET5_0
-        IClassFixture<CustomWebApplicationFactory<Startup_net_5_0>>
-#elif NETCOREAPP3_1
-        IClassFixture<CustomWebApplicationFactory<Startup_netcoreapp_3_1>>
-#else
-        IClassFixture<CustomWebApplicationFactory<Startup_netcoreapp_2_1>>
-#endif
+    public partial class RequestCollectionTest : IClassFixture<CustomWebApplicationFactory<Startup>>
     {
         [Fact]
         public async Task RequestILoggerUserConfigOverRidesDefaultLevel()

--- a/NETCORE/test/IntegrationTests.WebApp/Program.cs
+++ b/NETCORE/test/IntegrationTests.WebApp/Program.cs
@@ -13,7 +13,6 @@ namespace IntegrationTests.WebApp
 {
     public class Program
     {
-#if NET5_0
         public static void Main(string[] args)
         {
             CreateHostBuilder(args).Build().Run();
@@ -23,20 +22,7 @@ namespace IntegrationTests.WebApp
             Host.CreateDefaultBuilder(args)
                 .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseStartup<Startup_net_5_0>();
+                    webBuilder.UseStartup<Startup>();
                 });
-#else
-        public static void Main(string[] args)
-        {
-            CreateHostBuilder(args).Build().Run();
-        }
-
-        public static IHostBuilder CreateHostBuilder(string[] args) =>
-            Host.CreateDefaultBuilder(args)
-                .ConfigureWebHostDefaults(webBuilder =>
-                {
-                    webBuilder.UseStartup<Startup_netcoreapp_3_1>();
-                });
-#endif
-                }
+    }
 }

--- a/NETCORE/test/IntegrationTests.WebApp/Startup.net5.0.cs
+++ b/NETCORE/test/IntegrationTests.WebApp/Startup.net5.0.cs
@@ -11,9 +11,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace IntegrationTests.WebApp
 {
-    public class Startup_net_5_0
+    public partial class Startup
     {
-        public Startup_net_5_0(IConfiguration configuration)
+        public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
         }

--- a/NETCORE/test/IntegrationTests.WebApp/Startup.netcoreapp3.1.cs
+++ b/NETCORE/test/IntegrationTests.WebApp/Startup.netcoreapp3.1.cs
@@ -11,9 +11,9 @@ using Microsoft.Extensions.Hosting;
 
 namespace IntegrationTests.WebApp
 {
-    public class Startup_netcoreapp_3_1
+    public partial class Startup
     {
-        public Startup_netcoreapp_3_1(IConfiguration configuration)
+        public Startup(IConfiguration configuration)
         {
             Configuration = configuration;
         }


### PR DESCRIPTION
I'm going to add more tests to the Integration projects.
I'm cleaning these up.


## Changes
- Remove extra Startup classes in Web project. Use framework specific `partial` classes instead.
- Remove unnecessary pre-processors from Test project.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
