### PR TITLE
Auto-Instrumentation - Enable AI SDK to honor repacked Azure.Identity assembly name

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET452 && !NET46
+﻿#if !NET452 && !NET46 && !REDFIELD
 namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Authentication
 {
     using System;
@@ -302,7 +302,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
             var test = compiledExpression2.DynamicInvoke(objAccessToken);
 
         }
-        #region TestClasses
+#region TestClasses
 
         /// <summary>
         /// This class inherits <see cref="MockCredential"/> which inherits <see cref="Azure.Core.TokenCredential"/>.

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TelemetryConfigurationCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TelemetryConfigurationCredentialEnvelopeTests.cs
@@ -1,4 +1,4 @@
-#if !NET452 && !NET46
+#if !NET452 && !NET46 && !REDFIELD
 namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Authentication
 {
     using System;

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TransmissionCredentialEnvelopeTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET452 && !NET46
+﻿#if !NET452 && !NET46 && !REDFIELD
 namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation.Authentication
 {
     using System;

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ServerTelemetryChannelCredentialEnvelopeTests.cs
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/Implementation/ServerTelemetryChannelCredentialEnvelopeTests.cs
@@ -1,4 +1,4 @@
-﻿#if !NET452 && !NET46
+﻿#if !NET452 && !NET46 && !REDFIELD
 namespace Microsoft.ApplicationInsights.TestFramework.Implementation
 {
     using Microsoft.ApplicationInsights.Channel;

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -20,9 +20,9 @@
     internal class ReflectionCredentialEnvelope : CredentialEnvelope
     {
 #if REDFIELD
-        private static readonly string AzureCoreAssemblyName = "Azure.Identity.ILRepack";
+        private static volatile string AzureCoreAssemblyName = "Azure.Identity.ILRepack";
 #else
-        private static readonly string AzureCoreAssemblyName = "Azure.Core";
+        private static volatile string AzureCoreAssemblyName = "Azure.Core";
 #endif
 
         private readonly object tokenCredential;
@@ -109,7 +109,6 @@
         private static Type GetTokenCredentialType()
         {
             var typeName = $"Azure.Core.TokenCredential, {AzureCoreAssemblyName}";
-            var assemblyName = AzureCoreAssemblyName;
 
             Type typeTokenCredential = null;
 
@@ -124,7 +123,7 @@
 
             if (typeTokenCredential == null)
             {
-                if (AppDomain.CurrentDomain.GetAssemblies().Any(x => x.FullName.StartsWith(assemblyName)))
+                if (AppDomain.CurrentDomain.GetAssemblies().Any(x => x.FullName.StartsWith(AzureCoreAssemblyName)))
                 {
                     throw new Exception("An unknown error has occurred. Failed to get type Azure.Core.TokenCredential. Detected that Azure.Core is loaded in AppDomain.CurrentDomain.");
                 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -20,9 +20,9 @@
     internal class ReflectionCredentialEnvelope : CredentialEnvelope
     {
 #if REDFIELD
-        private static volatile string AzureCoreAssemblyName = "Azure.Identity.ILRepack";
+        private static volatile string azureCoreAssemblyName = "Azure.Identity.ILRepack";
 #else
-        private static volatile string AzureCoreAssemblyName = "Azure.Core";
+        private static volatile string azureCoreAssemblyName = "Azure.Core";
 #endif
 
         private readonly object tokenCredential;
@@ -108,7 +108,7 @@
         /// </returns>
         private static Type GetTokenCredentialType()
         {
-            var typeName = $"Azure.Core.TokenCredential, {AzureCoreAssemblyName}";
+            var typeName = $"Azure.Core.TokenCredential, {azureCoreAssemblyName}";
 
             Type typeTokenCredential = null;
 
@@ -123,7 +123,7 @@
 
             if (typeTokenCredential == null)
             {
-                if (AppDomain.CurrentDomain.GetAssemblies().Any(x => x.FullName.StartsWith(AzureCoreAssemblyName)))
+                if (AppDomain.CurrentDomain.GetAssemblies().Any(x => x.FullName.StartsWith(azureCoreAssemblyName)))
                 {
                     throw new Exception("An unknown error has occurred. Failed to get type Azure.Core.TokenCredential. Detected that Azure.Core is loaded in AppDomain.CurrentDomain.");
                 }
@@ -174,7 +174,7 @@
             internal static object MakeTokenRequestContext(string[] scopes)
             {
                 return Activator.CreateInstance(
-                    type: Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}"),
+                    type: Type.GetType($"Azure.Core.TokenRequestContext, {azureCoreAssemblyName}"),
                     args: new object[] { scopes, null, });
             }
 
@@ -188,7 +188,7 @@
             /// </returns>
             private static Delegate BuildDelegateAccessTokenToAuthToken()
             {
-                Type typeAccessToken = Type.GetType($"Azure.Core.AccessToken, {AzureCoreAssemblyName}");
+                Type typeAccessToken = Type.GetType($"Azure.Core.AccessToken, {azureCoreAssemblyName}");
 
                 var parameterExpression_AccessToken = Expression.Parameter(typeAccessToken, "parameterExpression_AccessToken");
 
@@ -223,8 +223,8 @@
             /// </returns>
             private static Delegate BuildDelegateGetToken()
             {
-                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {AzureCoreAssemblyName}");
-                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}");
+                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {azureCoreAssemblyName}");
+                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {azureCoreAssemblyName}");
                 Type typeCancellationToken = typeof(CancellationToken);
 
                 var parameterExpression_tokenCredential = Expression.Parameter(type: typeTokenCredential, name: "parameterExpression_TokenCredential");
@@ -260,8 +260,8 @@
             /// </returns>
             private static Delegate BuildDelegateGetTokenAsync()
             {
-                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {AzureCoreAssemblyName}");
-                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}");
+                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {azureCoreAssemblyName}");
+                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {azureCoreAssemblyName}");
                 Type typeCancellationToken = typeof(CancellationToken);
 
                 var parameterExpression_TokenCredential = Expression.Parameter(type: typeTokenCredential, name: "parameterExpression_TokenCredential");
@@ -302,8 +302,8 @@
             /// </returns>
             private static Delegate BuildGetTaskResult()
             {
-                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {AzureCoreAssemblyName}");
-                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}");
+                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {azureCoreAssemblyName}");
+                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {azureCoreAssemblyName}");
                 Type typeCancellationToken = typeof(CancellationToken);
                 var methodInfo_GetTokenAsync = typeTokenCredential.GetMethod(name: "GetTokenAsync", types: new Type[] { typeTokenRequestContext, typeCancellationToken });
                 var methodInfo_AsTask = methodInfo_GetTokenAsync.ReturnType.GetMethod("AsTask");

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -20,7 +20,7 @@
     internal class ReflectionCredentialEnvelope : CredentialEnvelope
     {
 #if REDFIELD
-        private static readonly string AzureCoreAssemblyName = "Azure.Core.ILRepack";
+        private static readonly string AzureCoreAssemblyName = "Azure.Identity.ILRepack";
 #else
         private static readonly string AzureCoreAssemblyName = "Azure.Core";
 #endif

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -19,6 +19,12 @@
     /// </remarks>
     internal class ReflectionCredentialEnvelope : CredentialEnvelope
     {
+#if REDFIELD
+        private static readonly string AzureCoreAssemblyName = "Azure.Core.ILRepack";
+#else
+        private static readonly string AzureCoreAssemblyName = "Azure.Core";
+#endif
+
         private readonly object tokenCredential;
         private readonly object tokenRequestContext;
 
@@ -102,8 +108,8 @@
         /// </returns>
         private static Type GetTokenCredentialType()
         {
-            var typeName = "Azure.Core.TokenCredential, Azure.Core";
-            var assemblyName = "Azure.Core";
+            var typeName = $"Azure.Core.TokenCredential, {AzureCoreAssemblyName}";
+            var assemblyName = AzureCoreAssemblyName;
 
             Type typeTokenCredential = null;
 
@@ -169,7 +175,7 @@
             internal static object MakeTokenRequestContext(string[] scopes)
             {
                 return Activator.CreateInstance(
-                    type: Type.GetType("Azure.Core.TokenRequestContext, Azure.Core"),
+                    type: Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}"),
                     args: new object[] { scopes, null, });
             }
 
@@ -183,7 +189,7 @@
             /// </returns>
             private static Delegate BuildDelegateAccessTokenToAuthToken()
             {
-                Type typeAccessToken = Type.GetType("Azure.Core.AccessToken, Azure.Core");
+                Type typeAccessToken = Type.GetType($"Azure.Core.AccessToken, {AzureCoreAssemblyName}");
 
                 var parameterExpression_AccessToken = Expression.Parameter(typeAccessToken, "parameterExpression_AccessToken");
 
@@ -218,8 +224,8 @@
             /// </returns>
             private static Delegate BuildDelegateGetToken()
             {
-                Type typeTokenCredential = Type.GetType("Azure.Core.TokenCredential, Azure.Core");
-                Type typeTokenRequestContext = Type.GetType("Azure.Core.TokenRequestContext, Azure.Core");
+                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {AzureCoreAssemblyName}");
+                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}");
                 Type typeCancellationToken = typeof(CancellationToken);
 
                 var parameterExpression_tokenCredential = Expression.Parameter(type: typeTokenCredential, name: "parameterExpression_TokenCredential");
@@ -255,8 +261,8 @@
             /// </returns>
             private static Delegate BuildDelegateGetTokenAsync()
             {
-                Type typeTokenCredential = Type.GetType("Azure.Core.TokenCredential, Azure.Core");
-                Type typeTokenRequestContext = Type.GetType("Azure.Core.TokenRequestContext, Azure.Core");
+                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {AzureCoreAssemblyName}");
+                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}");
                 Type typeCancellationToken = typeof(CancellationToken);
 
                 var parameterExpression_TokenCredential = Expression.Parameter(type: typeTokenCredential, name: "parameterExpression_TokenCredential");
@@ -297,8 +303,8 @@
             /// </returns>
             private static Delegate BuildGetTaskResult()
             {
-                Type typeTokenCredential = Type.GetType("Azure.Core.TokenCredential, Azure.Core");
-                Type typeTokenRequestContext = Type.GetType("Azure.Core.TokenRequestContext, Azure.Core");
+                Type typeTokenCredential = Type.GetType($"Azure.Core.TokenCredential, {AzureCoreAssemblyName}");
+                Type typeTokenRequestContext = Type.GetType($"Azure.Core.TokenRequestContext, {AzureCoreAssemblyName}");
                 Type typeCancellationToken = typeof(CancellationToken);
                 var methodInfo_GetTokenAsync = typeTokenCredential.GetMethod(name: "GetTokenAsync", types: new Type[] { typeTokenRequestContext, typeCancellationToken });
                 var methodInfo_AsTask = methodInfo_GetTokenAsync.ReturnType.GetMethod("AsTask");


### PR DESCRIPTION
Fix Issue # .

- `Azure.Core` assembly name is hard-coded in `ReflectionCredentialEnvelope` class
- This changes will enable auto-instrumentation to use loaded IL Repacked Azure.Identity library
- This approach will avoid conflict with customer libraries

## Changes
(Please provide a brief description of the changes here.)
Introduce a local to decide between redfelid and normal 

### Checklist
- [X] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

