### PR TITLE
stale

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,27 @@
+# Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
+# Github Actions Stale: https://github.com/actions/stale
+# Description: The purpose of this build is to compile and test with redfield flag.
+
+name: Stale Issues and PRs
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *' # End of every day
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4.0.0
+        id: stale
+        with:
+          stale-issue-message: 'This issue is stale because it has been open 300 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          stale-pr-message: 'This PR is stale because it has been open 300 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          operations-per-run: 200
+          days-before-stale: 300
+          days-before-close: 7
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          exempt-all-milestones: true
+      - name: Print outputs
+        run: echo ${{ join(steps.stale.outputs.*, ',') }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,6 +1,6 @@
 # Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 # Github Actions Stale: https://github.com/actions/stale
-# Description: The purpose of this build is to compile and test with redfield flag.
+# Description: The purpose of this action is to close stale issues and PRs.
 
 name: Stale Issues and PRs
 on:


### PR DESCRIPTION
This repo has hundreds of issues that are not being commented or worked on.
I'm introducing Github's Stale Action (https://github.com/actions/stale) to automatically close any issues that are inactive.


Beginning with these params: `days-before-stale: 300` `days-before-close: 7`.
This is to quickly remove the oldest issues in this repo.

Later, I'm proposing that these params be changed to `100` and `14` to keep open issues relevant to our latest versions.