### PR TITLE
remove AspNetCore net461 (prep FrameworkReference)

### DIFF
--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -7,9 +7,7 @@
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.Extensibility;
-#if NETSTANDARD2_0
     using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
-#endif
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.AspNetCore.Builder;
     using Microsoft.AspNetCore.Hosting;

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
 
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WEB;</DefineConstants>

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -18,9 +18,7 @@
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
 
-#if NETSTANDARD2_0
     using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
-#endif
 
     using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
@@ -343,9 +341,7 @@
             services.AddSingleton<ITelemetryModule, QuickPulseTelemetryModule>();
 
             AddAndConfigureDependencyTracking(services);
-#if NETSTANDARD2_0
             services.AddSingleton<ITelemetryModule, EventCounterCollectionModule>();
-#endif
         }
 
         private static void AddTelemetryChannel(IServiceCollection services)

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
@@ -44,13 +44,11 @@
         /// </summary>
         public bool EnableDependencyTrackingTelemetryModule { get; set; } = true;
 
-#if NETSTANDARD2_0
         /// <summary>
         /// Gets or sets a value indicating whether EventCounterCollectionModule should be enabled.
         /// Defaults to <value>true</value>.
         /// </summary>
         public bool EnableEventCounterCollectionModule { get; set; } = true;
-#endif
 
         /// <summary>
         /// Gets or sets a value indicating whether telemetry processor that controls sampling is added to the service.
@@ -184,10 +182,8 @@
             target.EnableAppServicesHeartbeatTelemetryModule = this.EnableAppServicesHeartbeatTelemetryModule;
             target.EnableAzureInstanceMetadataTelemetryModule = this.EnableAzureInstanceMetadataTelemetryModule;
             target.EnableDiagnosticsTelemetryModule = this.EnableDiagnosticsTelemetryModule;
-            
-#if NETSTANDARD2_0
             target.EnableEventCounterCollectionModule = this.EnableEventCounterCollectionModule;
-#endif
+
 #if AI_ASPNETCORE_WEB
             target.EnableAuthenticationTrackingJavaScript = this.EnableAuthenticationTrackingJavaScript;
             target.EnableRequestTrackingTelemetryModule = this.EnableRequestTrackingTelemetryModule;

--- a/NETCORE/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
+++ b/NETCORE/src/Shared/Implementation/TelemetryConfigurationOptionsSetup.cs
@@ -17,9 +17,7 @@ namespace Microsoft.Extensions.DependencyInjection
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.DependencyCollector;
     using Microsoft.ApplicationInsights.Extensibility;
-#if NETSTANDARD2_0
     using Microsoft.ApplicationInsights.Extensibility.EventCounterCollector;
-#endif
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
@@ -187,7 +185,6 @@ namespace Microsoft.Extensions.DependencyInjection
                     }
 #endif
 
-#if NETSTANDARD2_0
                     // EventCounterCollectionModule
                     if (module is EventCounterCollectionModule)
                     {
@@ -197,7 +194,6 @@ namespace Microsoft.Extensions.DependencyInjection
                             continue;
                         }
                     }
-#endif
 
                     // PerformanceCollectorModule
                     if (module is PerformanceCollectorModule)

--- a/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
+++ b/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTests.Utils</AssemblyName>


### PR DESCRIPTION
Fix Issue #2251.

We're aligning the AspNetCore project with NetCoreApp3.1, Net5.0, and Net6.0.
Formerly, NetCoreApp2.1 was compatible with targeting Net Framework. This is no longer available in the newer framework versions and we're removing it from this project.


## Changes
- Removing Net461 from AspNetCore project. 
- Removing preprocesosrs.



### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
