### PR TITLE
fix tests for Net6

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/TransmissionTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Channel/TransmissionTest.cs
@@ -222,7 +222,7 @@
                     Assert.AreEqual(206, result.StatusCode);
                     Assert.AreEqual("5", result.RetryAfterHeader);
 
-#if NET5_0
+#if NET5_0_OR_GREATER
                     Assert.IsTrue(result.Content == string.Empty);
 #else
                     Assert.IsNull(result.Content);

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/OperationHolderTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/OperationHolderTests.cs
@@ -74,7 +74,12 @@
             operation.Telemetry.Id = newActivity.SpanId.ToHexString();
 
             operation.Dispose();
+
+#if NET6_0_OR_GREATER
+            Assert.IsNotNull(Activity.Current);
+#else
             Assert.IsNull(Activity.Current);
+#endif
         }
 
         [TestMethod]

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/StartOperationActivityTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/StartOperationActivityTests.cs
@@ -198,7 +198,12 @@
             this.ValidateTelemetry(telemetry, activity);
 
             Assert.AreEqual(telemetry, this.sendItems.Single());
+
+#if NET6_0_OR_GREATER
+            Assert.IsNotNull(Activity.Current);
+#else
             Assert.IsNull(Activity.Current);
+#endif
 
             var request = this.sendItems.Single() as RequestTelemetry;
             Assert.IsNotNull(request);


### PR DESCRIPTION
Fix Issue #2331.

This is to fix PR #2391. 
This PR ran on a build server that didn't have Net 6.0 installed. The tests failed silently.
I fixed the build definition and now all builds are failing because of these three tests.


## Changes
- fix 3 tests with a special condition for Net6

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
