### PR TITLE
fix for Net6 implicit global usings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -84,7 +84,12 @@
     <IsNetFramework Condition="'$(TargetFramework)' == 'net452' Or '$(TargetFramework)' == 'net46' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' ">True</IsNetFramework>
     <IsNetCore Condition="'$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">True</IsNetCore>
     <IsNetStandard20 Condition="'$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net462' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net480' Or '$(TargetFramework)' == 'netcoreapp3.1' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">True</IsNetStandard20>
-    
+
+    <!-- .NET 6 introduces implicit global usings.
+    This causes build errors in our multi-target projects.
+    Dotnet team has commented that they will fix this error when .NET 6 is GA (Nov2021).
+    https://docs.microsoft.com/dotnet/core/compatibility/sdk/6.0/implicit-namespaces#recommended-action -->
+    <DisableImplicitNamespaceImports>True</DisableImplicitNamespaceImports>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
Fix Issue #2331 

.NET 6 introduces global usings. 
This produces auto-gen assembly files which then conflict with the usings in the class files.

```
Warning	CS0105	The using directive for 'System' appeared previously in this namespace
```

Dotnet team commented on github that they would change this behavior when .NET 6 GAs.
For now, we need to disable this in our projects.

## Changes
- disable implicit global usings

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
