### PR TITLE
Change AspNetCore to use FrameworkReference (without fixing IHostingEnvironment)

### DIFF
--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/DefaultApplicationInsightsServiceConfigureOptions.cs
@@ -14,7 +14,9 @@
     /// </summary>
     internal class DefaultApplicationInsightsServiceConfigureOptions : IConfigureOptions<ApplicationInsightsServiceOptions>
     {
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly IHostingEnvironment hostingEnvironment;
+#pragma warning restore CS0618 // Type or member is obsolete
         private readonly IConfiguration userConfiguration;
 
         /// <summary>
@@ -22,7 +24,9 @@
         /// </summary>
         /// <param name="hostingEnvironment"><see cref="IHostingEnvironment"/> to use for retreiving ContentRootPath.</param>
         /// <param name="configuration"><see cref="IConfiguration"/>  from an application.</param>
+#pragma warning disable CS0618 // Type or member is obsolete
         public DefaultApplicationInsightsServiceConfigureOptions(IHostingEnvironment hostingEnvironment, IConfiguration configuration = null)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             this.hostingEnvironment = hostingEnvironment;
             this.userConfiguration = configuration;

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -32,11 +32,13 @@
     <ProjectReference Include="..\..\..\WEB\Src\WindowsServer\WindowsServer\WindowsServer.csproj" />
     <ProjectReference Include="..\..\..\WEB\Src\EventCounterCollector\EventCounterCollector\EventCounterCollector.csproj" />
     <ProjectReference Include="..\..\..\LOGGING\src\ILogger\ILogger.csproj" />
-    
+  </ItemGroup>
+  
+  <ItemGroup Condition="'$(IsNetCore)' == 'True'">
+    <FrameworkReference Include="Microsoft.AspNetCore.App"/>
   </ItemGroup>
 
-  <ItemGroup>
-    <!-- Will change to conditionally use FrameworkReference in follow up PR. -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
     

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializer.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializer.cs
@@ -12,13 +12,17 @@
     public class AspNetCoreEnvironmentTelemetryInitializer : ITelemetryInitializer
     {
         private const string AspNetCoreEnvironmentPropertyName = "AspNetCoreEnvironment";
+#pragma warning disable CS0618 // Type or member is obsolete
         private readonly IHostingEnvironment environment;
+#pragma warning restore CS0618 // Type or member is obsolete
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AspNetCoreEnvironmentTelemetryInitializer"/> class.
         /// </summary>
         /// <param name="environment">HostingEnvironment to provide EnvironmentName to be added to telemetry properties.</param>
+#pragma warning disable CS0618 // Type or member is obsolete
         public AspNetCoreEnvironmentTelemetryInitializer(IHostingEnvironment environment)
+#pragma warning restore CS0618 // Type or member is obsolete
         {
             this.environment = environment;
         }


### PR DESCRIPTION
Fix Issue #2251.

## Changes
- AspNetCore to use FrameworkReference.
- disable Obsolete warning for IHostingEnvironment (will address this in a follow up PR)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
