### PR TITLE
abstract IHostingEnvironment in unit tests

### DIFF
--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/EnvironmentHelper.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/EnvironmentHelper.cs
@@ -1,0 +1,31 @@
+﻿namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+{
+    using System.IO;
+
+    using Moq;
+
+    using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
+
+    /// <summary>
+    /// The type <see cref="IHostingEnvironment"/> was marked Obsolete starting in NetCore3.
+    /// Here I'm abstracting it's use into a helper method to simplify some of the tests.
+    /// </summary>
+    public static class EnvironmentHelper
+    {
+#pragma warning disable CS0618 // Type or member is obsolete
+        /// <summary>
+        /// Get an instance of <see cref="IHostingEnvironment"/>.
+        /// <see cref="IHostingEnvironment.EnvironmentName"/> is set to "UnitTest".
+        /// <see cref="IHostingEnvironment.ContentRootPath"/> is set to <see cref="Directory.GetCurrentDirectory"/>.
+        /// </summary>
+        /// <returns></returns>
+        public static IHostingEnvironment GetIHostingEnvironment()
+        {
+            var mockEnvironment = new Mock<IHostingEnvironment>();
+            mockEnvironment.Setup(x => x.EnvironmentName).Returns("UnitTest");
+            mockEnvironment.Setup(x => x.ContentRootPath).Returns(Directory.GetCurrentDirectory());
+            return mockEnvironment.Object;
+        }
+#pragma warning restore CS0618 // Type or member is obsolete
+    }
+}

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/BaseTestClass.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/BaseTestClass.cs
@@ -9,6 +9,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using System.IO;
 
     using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+    using Microsoft.ApplicationInsights.AspNetCore.Tests;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.AspNetCore.Hosting;
     using Microsoft.AspNetCore.Hosting.Internal;
@@ -80,7 +81,7 @@ namespace Microsoft.Extensions.DependencyInjection.Test
         public static ServiceCollection GetServiceCollectionWithContextAccessor()
         {
             var services = new ServiceCollection();
-            services.AddSingleton<IHostingEnvironment>(new HostingEnvironment() { ContentRootPath = Directory.GetCurrentDirectory() });
+            services.AddSingleton<IHostingEnvironment>(EnvironmentHelper.GetIHostingEnvironment());
             services.AddSingleton<DiagnosticListener>(new DiagnosticListener("TestListener"));
             return services;
         }

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsServiceOptionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsServiceOptionsTests.cs
@@ -76,7 +76,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.Extensions
         {
             IConfigurationRoot config;
             var services = new ServiceCollection()
-                .AddSingleton<IHostingEnvironment>(new HostingEnvironment() { ContentRootPath = Directory.GetCurrentDirectory() })
+                .AddSingleton<IHostingEnvironment>(EnvironmentHelper.GetIHostingEnvironment())
                 .AddSingleton<DiagnosticListener>(new DiagnosticListener("TestListener"));
 
             if (jsonPath != null)

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -16,6 +16,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsNetFramework)' == 'True'">

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
@@ -10,30 +10,30 @@
         [Fact]
         public void InitializeDoesNotThrowIfHostingEnvironmentIsNull()
         {
-            var initializer = new AspNetCoreEnvironmentTelemetryInitializer(null);
+            var initializer = new AspNetCoreEnvironmentTelemetryInitializer(environment: null);
             initializer.Initialize(new RequestTelemetry());
         }
 
         [Fact]
         public void InitializeDoesNotOverrideExistingProperty()
         {
-            var initializer = new AspNetCoreEnvironmentTelemetryInitializer(new HostingEnvironment() { EnvironmentName = "Production"});
+            var initializer = new AspNetCoreEnvironmentTelemetryInitializer(environment: EnvironmentHelper.GetIHostingEnvironment());
             var telemetry = new RequestTelemetry();
             telemetry.Context.GlobalProperties.Add("AspNetCoreEnvironment", "Development");
             initializer.Initialize(telemetry);
 
             Assert.Equal("Development", telemetry.Context.GlobalProperties["AspNetCoreEnvironment"]);
-            Assert.Equal("Production", telemetry.Properties["AspNetCoreEnvironment"]);
+            Assert.Equal("UnitTest", telemetry.Properties["AspNetCoreEnvironment"]);
         }
 
         [Fact]
         public void InitializeSetsCurrentEnvironmentNameToProperty()
         {
-            var initializer = new AspNetCoreEnvironmentTelemetryInitializer(new HostingEnvironment() { EnvironmentName = "Production"});
+            var initializer = new AspNetCoreEnvironmentTelemetryInitializer(environment: EnvironmentHelper.GetIHostingEnvironment());
             var telemetry = new RequestTelemetry();
             initializer.Initialize(telemetry);
 
-            Assert.Equal("Production", telemetry.Properties["AspNetCoreEnvironment"]);
+            Assert.Equal("UnitTest", telemetry.Properties["AspNetCoreEnvironment"]);
         }
     }
 }


### PR DESCRIPTION
Fix Issue #2251 .

Finding several compatibility issues with `IHostingEnvironment`. I've cleaned up some tests and moved it to a static helper class.

## Changes
- New static class `EnvironmentHelper` which creates Moq instances of obsolete `IHostingEnvironment`.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
