### PR TITLE
remove dependency system.runtime.serialization.json (CVE-2019-0820)

### DIFF
--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -42,6 +42,7 @@
     
     <PackageReference Include="NETStandard.HttpListener" Version="1.0.3.5" />
     <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
+    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/WindowsServer/WindowsServer/WindowsServer.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer/WindowsServer.csproj
@@ -27,12 +27,6 @@
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="$(SystemDiagnosticsDiagnosticSourcePkgVer)" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <!-- NetCore Dependencies -->
-    <PackageReference Include="System.Runtime.Serialization.Json" Version="4.3.0" />
-    <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <!--Nuget Transforms (install.xdt, uninstall.xdt, config.transform): "nupkg\content\<framework>\*.*-->
     <Content Include="ApplicationInsights.config.transform" />


### PR DESCRIPTION
Fix Issue #2401.

CVE-2019-0820: System.Text.RegularExpressions/4.3.0

- Microsoft.AI.WindowsServer
    - Microsoft.ApplicationInsights.AspNetCore/2.18.0 
        - Microsoft.ApplicationInsights.WindowsServer/2.18.0 
            - System.Runtime.Serialization.Json/4.3.0
                - System.Private.DataContractSerialization/4.3.0 
                    - System.Xml.XmlSerializer/4.3.0
                        - System.Text.RegularExpressions/4.3.0


## Changes
- remove dependency System.Runtime.Serialization.Json from WindowsServer.csproj
- add dependency System.Runtime.Serialization.Json to WindowsServer.Tests.csproj

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
