### PR TITLE
move output directories

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -47,13 +47,13 @@
     <TargetsRoot>$(EnlistmentRoot)\.targets</TargetsRoot>
     <PublicApiRoot>$(EnlistmentRoot)\.publicApi</PublicApiRoot>
 
-    <BinRoot>$(EnlistmentRoot)\..\bin</BinRoot>
+    <BinRoot>$(EnlistmentRoot)\bin</BinRoot>
     <BinRoot>$([System.IO.Path]::GetFullPath( $(BinRoot) ))</BinRoot>
 
-    <ObjRoot>$(EnlistmentRoot)\..\obj</ObjRoot>
+    <ObjRoot>$(EnlistmentRoot)\obj</ObjRoot>
     <ObjRoot>$([System.IO.Path]::GetFullPath( $(ObjRoot) ))</ObjRoot>
 
-    <PackagesDir>$(EnlistmentRoot)\..\packages</PackagesDir>
+    <PackagesDir>$(EnlistmentRoot)\packages</PackagesDir>
     <PackagesDir>$([System.IO.Path]::GetFullPath( $(PackagesDir) ))</PackagesDir>
 
     <RelativeOutputPathBase>$(MSBuildProjectDirectory.Substring($(EnlistmentRoot.Length)))</RelativeOutputPathBase>


### PR DESCRIPTION
#2466

Currently, the AI SDK uses a directory above where the repo was checked out for all build output.
example:
`c:\Repos\ai-sdk\Everything.sln`
`c:\Repos\bin`

This change will move all outputs to be within the repo directory.


### TODO:
- [ ] Need to review all build definitions and confirm they use the newer output