### PR TITLE
cleanup net6

### DIFF
--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -39,7 +39,6 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-        include-prerelease: true
 
     - name: Restore
       run: dotnet restore ./BASE/Microsoft.ApplicationInsights.sln

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -38,7 +38,6 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-        include-prerelease: true
 
     - name: Restore
       run: dotnet restore ./NETCORE/ApplicationInsights.AspNetCore.sln

--- a/.github/workflows/examples-sanity.yml
+++ b/.github/workflows/examples-sanity.yml
@@ -18,10 +18,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Setup .NET
-      uses: actions/setup-dotnet@v1
+    - uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 5.0.x
+        dotnet-version: 6.0.x
 
     - name: Install dependencies
       run: dotnet restore ./examples/Examples.sln

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -37,7 +37,6 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-        include-prerelease: true
 
     - uses: nuget/setup-nuget@v1
       with:

--- a/.github/workflows/redfield-sanity-check.yml
+++ b/.github/workflows/redfield-sanity-check.yml
@@ -39,7 +39,6 @@ jobs:
     - uses: actions/setup-dotnet@v1
       with:
         dotnet-version: '6.0.x'
-        include-prerelease: true
 
     - name: Restore
       run: dotnet restore ./BASE/Microsoft.ApplicationInsights.sln

--- a/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
+++ b/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
@@ -32,7 +32,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net6.0'">
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0-rc.2.21480.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="6.0.0" />
   </ItemGroup>
   
   <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">

--- a/examples/AspNetCoreWebApp/AspNetCoreWebApp.csproj
+++ b/examples/AspNetCoreWebApp/AspNetCoreWebApp.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/BackgroundTasksWithHostedService/BackgroundTasksWithHostedService.csproj
+++ b/examples/BackgroundTasksWithHostedService/BackgroundTasksWithHostedService.csproj
@@ -1,14 +1,14 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\..\NETCORE\src\Microsoft.ApplicationInsights.WorkerService\Microsoft.ApplicationInsights.WorkerService.csproj" />
   </ItemGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="5.0.0" />
@@ -20,5 +20,4 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="5.0.0" />
   </ItemGroup>
-
 </Project>

--- a/examples/ConsoleApp/ConsoleApp.csproj
+++ b/examples/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/examples/WorkerService/WorkerService.csproj
+++ b/examples/WorkerService/WorkerService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <UserSecretsId>dotnet-WorkerServiceSampleWithApplicationInsights-E563FF63-73E2-4449-909F-BD093B43F6EF</UserSecretsId>
   </PropertyGroup>
 
@@ -10,6 +10,6 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Fix Issue #2331.

## Changes
- remove "preview" versions from build definitions and projects
- upgrade examples projects and build to net6

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
