### PR TITLE
Full test coverage using Github Workflows

### DIFF
--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -24,9 +24,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         framework: [net462, net472, net480, netcoreapp3.1,net5.0,net6.0]
-        exclude:
-          - os: ubuntu-latest
-            framework: [net462, net472, net480]
         include: 
           - os: ubuntu-latest
             args: "--filter TestCategory!=WindowsOnly"

--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -23,10 +23,13 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        framework: [netcoreapp3.1,net5.0,net6.0]
+        framework: [net462, net472, net480, netcoreapp3.1,net5.0,net6.0]
+        exclude:
+          - os: ubuntu-latest
+          framework: [net462, net472, net480]
         include: 
-            - os: ubuntu-latest
-              args: "--filter TestCategory!=WindowsOnly"
+          - os: ubuntu-latest
+          args: "--filter TestCategory!=WindowsOnly"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -26,10 +26,10 @@ jobs:
         framework: [net462, net472, net480, netcoreapp3.1,net5.0,net6.0]
         exclude:
           - os: ubuntu-latest
-          framework: [net462, net472, net480]
+            framework: [net462, net472, net480]
         include: 
           - os: ubuntu-latest
-          args: "--filter TestCategory!=WindowsOnly"
+            args: "--filter TestCategory!=WindowsOnly"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -1,6 +1,6 @@
 # Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
-# Description: The purpose of this build is to build and test on both Windows and Linux.
+# Description: The purpose of this workflow is to compile and run unit tests.
 
 name: Build And Test, BASE
 

--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        framework: [net462, net472, net480, netcoreapp3.1,net5.0,net6.0]
+        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
         include: 
           - os: ubuntu-latest
             args: "--filter TestCategory!=WindowsOnly"

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -2,7 +2,7 @@
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
 # Description: The purpose of this build is to build and test on both Windows and Linux.
 
-name: Build And Test, WEB
+name: Build And Test, LOGGING
 
 on:
   workflow_dispatch:

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -2,7 +2,7 @@
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
 # Description: The purpose of this build is to build and test on both Windows and Linux.
 
-name: Build And Test, BASE
+name: Build And Test, WEB
 
 on:
   workflow_dispatch:
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      SOLUTION: ./BASE/Microsoft.ApplicationInsights.sln
+      SOLUTION: ./LOGGING/Logging.sln"
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
         framework: [netcoreapp3.1,net5.0,net6.0]
         include: 
             - os: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         dotnet-version: '6.0.x'
 
     - name: Restore
-      run: dotnet restore ${{ env.SOLUTION }}
+      run: dotnet restore ${{ env.SOLUTION }} 
 
     - name: Build
       run: dotnet build ${{ env.SOLUTION }} --configuration Release --no-restore

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        framework: [netcoreapp3.1,net5.0,net6.0]
+        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      SOLUTION: ./LOGGING/Logging.sln"
+      SOLUTION: ./LOGGING/Logging.sln
 
     strategy:
       fail-fast: false

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -1,6 +1,6 @@
 # Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
-# Description: The purpose of this build is to build and test on both Windows and Linux.
+# Description: The purpose of this workflow is to compile and run unit tests.
 
 name: Build And Test, LOGGING
 

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -12,7 +12,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-test-BASE:
+  build-test-LOGGING:
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -24,9 +24,6 @@ jobs:
       matrix:
         os: [windows-latest]
         framework: [netcoreapp3.1,net5.0,net6.0]
-        include: 
-            - os: ubuntu-latest
-              args: "--filter TestCategory!=WindowsOnly"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -1,6 +1,6 @@
 # Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
-# Description: The purpose of this build is to build and test on both Windows and Linux.
+# Description: The purpose of this workflow is to compile and run unit tests.
 
 name: Build And Test, NETCORE
 

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -15,6 +15,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      SOLUTION: ./NETCORE/ApplicationInsights.AspNetCore.sln
+
     strategy:
       fail-fast: false
       matrix:
@@ -40,15 +43,15 @@ jobs:
         dotnet-version: '6.0.x'
 
     - name: Restore
-      run: dotnet restore ./NETCORE/ApplicationInsights.AspNetCore.sln
+      run: dotnet restore ${{ env.SOLUTION }}
 
     - name: Build
-      run: dotnet build ./NETCORE/ApplicationInsights.AspNetCore.sln --configuration Release --no-restore
+      run: dotnet build ${{ env.SOLUTION }} --configuration Release --no-restore
 
     - name: Test
       id: test1
       continue-on-error: true
-      run: dotnet test ./NETCORE/ApplicationInsights.AspNetCore.sln --framework ${{ matrix.framework }} --configuration Release --no-build --logger:"console;verbosity=detailed" --logger:"trx;logfilename=${{ github.workspace }}/testResults.trx" ${{ matrix.args }}
+      run: dotnet test ${{ env.SOLUTION }} --framework ${{ matrix.framework }} --configuration Release --no-build --logger:"console;verbosity=detailed" --logger:"trx;logfilename=${{ github.workspace }}/testResults.trx" ${{ matrix.args }}
 
     - name: Retry tests
       if: steps.test1.outcome=='failure'

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -5,6 +5,7 @@
 name: Build And Test, NETCORE
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
   pull_request:
@@ -24,8 +25,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
         framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
         include: 
-            - os: ubuntu-latest
-              args: "--filter TestCategory!=WindowsOnly"
+          - os: ubuntu-latest
+            args: "--filter TestCategory!=WindowsOnly"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        framework: [netcoreapp3.1,net5.0,net6.0]
+        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
         include: 
             - os: ubuntu-latest
               args: "--filter TestCategory!=WindowsOnly"

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -12,7 +12,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-test-web:
+  build-test-WEB:
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -1,6 +1,6 @@
 # Syntax: https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
-# Description: The purpose of this build is to build and test on both Windows and Linux.
+# Description: The purpose of this workflow is to compile and run unit tests.
 
 name: Build And Test, WEB
 

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        framework: [netcoreapp3.1,net5.0,net6.0]
+        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -24,9 +24,6 @@ jobs:
       matrix:
         os: [windows-latest]
         framework: [netcoreapp3.1,net5.0,net6.0]
-        include: 
-            - os: ubuntu-latest
-              args: "--filter TestCategory!=WindowsOnly"
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -2,7 +2,7 @@
 # .NET CLI: https://docs.microsoft.com/dotnet/core/tools/
 # Description: The purpose of this build is to build and test on both Windows and Linux.
 
-name: Build And Test, BASE
+name: Build And Test, WEB
 
 on:
   workflow_dispatch:
@@ -17,12 +17,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     env:
-      SOLUTION: ./BASE/Microsoft.ApplicationInsights.sln
+      SOLUTION: ./WEB/Src/Microsoft.ApplicationInsights.Web.sln
 
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [windows-latest]
         framework: [netcoreapp3.1,net5.0,net6.0]
         include: 
             - os: ubuntu-latest
@@ -44,7 +44,7 @@ jobs:
         dotnet-version: '6.0.x'
 
     - name: Restore
-      run: dotnet restore ${{ env.SOLUTION }}
+      run: dotnet restore ${{ env.SOLUTION }} 
 
     - name: Build
       run: dotnet build ${{ env.SOLUTION }} --configuration Release --no-restore

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -12,7 +12,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build-test-BASE:
+  build-test-web:
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
#2379
#2466


This finished migrating all of our unit-tests from Azure DevOps to Github Workflows.

- BASE
  - Windows & Linux
- WEB
  - Windows
- NETCORE
  - Windows & Linux
- LOGGING
  - Windows

All combinations use the same list of frameworks:
- net452
- net462
- net472
- net480
- netcoreapp3.1
- net5.0
- net6.0


NOTE that the "REQUIRED" setting is defined in the repo, not the workflow.
For Linux builds, the unsupported frameworks are no-op and I've omitted the REQUIRED.