### PR TITLE
fix analyzers

### DIFF
--- a/.props/Product.props
+++ b/.props/Product.props
@@ -13,9 +13,6 @@
 
   <ItemGroup Condition=" $(OS) == 'Windows_NT'">
     <!--Analyzers-->
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="5.0.3">
-      <PrivateAssets>All</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
@@ -52,7 +49,6 @@
     <!--<EnableNETAnalyzers>true</EnableNETAnalyzers>--> 
     
     
-
     <!--Removing the SRC folder from the output directory-->
     <CorePath>$(RelativeOutputPathBase)</CorePath>
     <OutputPath>$(BinRoot)\$(Configuration)\$(CorePath)</OutputPath>

--- a/.props/Test.props
+++ b/.props/Test.props
@@ -6,7 +6,6 @@
   </Target>
 
   <Import Project=".\_Common.props" />
-  <Import Project=".\_AnalyzerSettings.props" />
 
   <PropertyGroup>
     <!-- Our test matrix includes every currently supported version of .NET
@@ -26,6 +25,14 @@
 
   <PropertyGroup>
     <IsPackable>false</IsPackable>
+
+    <!-- 
+      We have a significant backlog of analyzer issues in the Test projects. Turning these off for now. 
+      https://docs.microsoft.com/en-us/visualstudio/code-quality/disable-code-analysis?view=vs-2022#net-framework-projects
+      https://docs.microsoft.com/en-us/dotnet/core/project-sdk/msbuild-props#analysismode
+    -->
+    <AnalysisMode>None</AnalysisMode>
+    <RunAnalyzers>false</RunAnalyzers>
   </PropertyGroup>
 
 </Project>

--- a/NETCORE/test/FunctionalTests.MVC.Tests/Controllers/HomeController.cs
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/Controllers/HomeController.cs
@@ -45,7 +45,13 @@ namespace FunctionalTests.MVC.Tests.Controllers
 
         public IActionResult Dependency()
         {
-            this.telemetryClient.TrackDependency("MyDependency", "MyCommand", DateTimeOffset.Now, TimeSpan.FromMilliseconds(1), success: true);
+            this.telemetryClient.TrackDependency(
+                dependencyTypeName: "test",
+                dependencyName: "MyDependency", 
+                data: "MyCommand", 
+                startTime: DateTimeOffset.Now, 
+                duration: TimeSpan.FromMilliseconds(1), 
+                success: true);
             return View();
         }
 

--- a/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
     <VersionPrefix>2.0.0</VersionPrefix>

--- a/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
+++ b/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/MultipleWebHostsTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/MultipleWebHostsTests.cs
@@ -136,12 +136,16 @@ namespace FunctionalTests.WebApi.Tests.FunctionalTest
             // Active config could be used multiple times in the same process before this test
             // let's reassign it
 
+#pragma warning disable CS0618 // Type or member is obsolete
             TelemetryConfiguration.Active.Dispose();
+#pragma warning restore CS0618 // Type or member is obsolete
             MethodInfo setActive =
                 typeof(TelemetryConfiguration).GetMethod("set_Active", BindingFlags.Static | BindingFlags.NonPublic);
             setActive.Invoke(null, new object[] { TelemetryConfiguration.CreateDefault() });
 
+#pragma warning disable CS0618 // Type or member is obsolete
             var activeConfig = TelemetryConfiguration.Active;
+#pragma warning restore CS0618 // Type or member is obsolete
             using (var server = new InProcessServer(assemblyName, this.output, (aiOptions) => aiOptions.EnableActiveTelemetryConfigurationSetup = true))
             {
                 this.ExecuteRequest(server.BaseHost + requestPath);

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -1,4 +1,5 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
+  <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>

--- a/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
+++ b/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
@@ -1,5 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
+  <Import Project="$(PropsRoot)\Test.props" />
+  
   <!-- 
   Integration tests evaluate an app's components on a broader level than unit tests. 
   Unit tests are used to test isolated software components, such as individual class methods. 

--- a/NETCORE/test/IntegrationTests.WebApp/IntegrationTests.WebApp.csproj
+++ b/NETCORE/test/IntegrationTests.WebApp/IntegrationTests.WebApp.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-
+  <Import Project="$(PropsRoot)\Test.props" />
+  
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
   </PropertyGroup>


### PR DESCRIPTION


Fix for the following issues:

- `warning : The .NET SDK has newer analyzers with version '6.0.0' than what version '5.0.3' of 'Microsoft.CodeAnalysis.NetAnalyzers' package provides. Update or remove this package reference.`
  This package is included by default for net5.0 and net6.0. We do not need to manually include it. Removed.

- Turned off Analyzers for Test projects.
  Analyzers are on by default for net5.0 and net6.0. When I onboarded the test projects to these frameworks, it flooded our build output with warnings. These warnings were showing up in the "Files Changed" for all PRs.



