### PR TITLE
Validate exception stack trace line numbers to comply with endpoint r…

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
@@ -149,6 +149,22 @@
             Assert.IsTrue(parsedStackLength <= ExceptionConverter.MaxParsedStackLength);
         }
 
+        [TestMethod]
+        public void SanitizesLineNumberOnParsedStackFrame()
+        {
+            var stackFrame = ExceptionConverter.GetStackFrame(new System.Diagnostics.StackFrame("test", 1000001), 0);
+            
+            Assert.AreEqual(0, stackFrame.line);
+
+            stackFrame = ExceptionConverter.GetStackFrame(new System.Diagnostics.StackFrame("test", -1000001), 0);
+
+            Assert.AreEqual(0, stackFrame.line);
+
+            stackFrame = ExceptionConverter.GetStackFrame(new System.Diagnostics.StackFrame("test", 10), 0);
+
+            Assert.AreEqual(10, stackFrame.line);
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private Exception CreateException(int numberOfStackpoints)
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
@@ -68,7 +68,8 @@
 
             // 0 means it is unavailable
             int line = stackFrame.GetFileLineNumber();
-            if (line != 0)
+            //the endpoint cannot ingest line number below -1000000 or above 1000000
+            if (line != 0 && line > -1000000 && line < 1000000)
             {
                 convertedStackFrame.line = line;
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VNext
+- [Validate exception stack trace line numbers to comply with endpoint restrictions.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2482)
 
 ## Version 2.20.0-beta1
 - [Allow Control of Documents sampling for QuickPulse telemetry](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2425)


### PR DESCRIPTION
Fix Issue # 2482.

## Changes
Validate exception stack trace line numbers to comply with endpoint restrictions. 

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
