### PR TITLE
Retry Test Script: wait between retries

### DIFF
--- a/.scripts/build_RetryTests.ps1
+++ b/.scripts/build_RetryTests.ps1
@@ -33,6 +33,8 @@ if ($testRunXml.TestRun.ResultSummary.outcome -eq "Failed")
     [bool]$scriptResult = $true;
     $ScriptSummary = @();
 
+    [int]$secondsBetweenRetries = 5;
+
     # FOREACH TEST RUN RESULTS
     foreach ($result in $results)
     {
@@ -51,6 +53,9 @@ if ($testRunXml.TestRun.ResultSummary.outcome -eq "Failed")
             [bool]$retryResult = $false;
             for($i=0; $i -lt $maxRetries -and $retryResult -eq $false ; $i++)
             {
+                # This will breifly wait before consecutive retries.
+                Start-Sleep -Seconds ([int]$secondsBetweenRetries * $i)
+
                 $logPath = "$logDirectoryRetries/$($definition.TestMethod.className).$($definition.TestMethod.name)_$i.trx";
                 dotnet test $($definition.TestMethod.codeBase) --logger "trx;LogFileName=$logPath" --filter "ClassName=$($definition.TestMethod.className)&Name=$($definition.TestMethod.name)" | Out-Null
 

--- a/.scripts/build_RetryTests.ps1
+++ b/.scripts/build_RetryTests.ps1
@@ -11,6 +11,7 @@ Write-Host "-WorkingDirectory: $WorkingDirectory"
 Write-Host ""
 
 [int]$maxRetries = 5;
+[int]$secondsBetweenRetries = 5;
 
 # INSPECT TEST RUN RESULTS
 [xml]$testRunXml = Get-Content -Path $TestResultFile -ErrorAction Stop
@@ -32,8 +33,6 @@ if ($testRunXml.TestRun.ResultSummary.outcome -eq "Failed")
 
     [bool]$scriptResult = $true;
     $ScriptSummary = @();
-
-    [int]$secondsBetweenRetries = 5;
 
     # FOREACH TEST RUN RESULTS
     foreach ($result in $results)


### PR DESCRIPTION
This script is working as intended. 
Any failed test is retried up to 5 times before failing the run.
This appears to work for most tests but `ChannelSendsTransmissionAndMovesBufferToStorageOnFlushAsync ` consistently fails all 5 times.

Instead of letting tests retry consecutively, I'm introducing a minor wait. `5 seconds * i` where `i' is the retry #.
- Most tests pass on the first retry. These tests would be unaffected.
- For tests that repeatedly fail, the wait grows slightly (0 seconds, 5, 10, 15, 20). 