### PR TITLE
Validate exception message length to comply with endpoint restrictions

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
@@ -165,6 +165,26 @@
             Assert.AreEqual(10, stackFrame.line);
         }
 
+        [TestMethod]
+        public void TrimsExceptionMessagesGreaterThanMaxLength()
+        {
+            var exp = new Exception(new string('x', ExceptionConverter.MaxExceptionMessageLength + 5));
+
+            ExceptionDetails expDetails = ExceptionConverter.ConvertToExceptionDetails(exp, null);
+
+            Assert.AreEqual(ExceptionConverter.MaxExceptionMessageLength, expDetails.message.Length);
+        }
+
+        [TestMethod]
+        public void DoesNotTrimShortExceptionMessages()
+        {
+            var exp = new Exception(new string('x', 5));
+
+            ExceptionDetails expDetails = ExceptionConverter.ConvertToExceptionDetails(exp, null);
+
+            Assert.AreEqual(5, expDetails.message.Length);
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private Exception CreateException(int numberOfStackpoints)
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
@@ -21,7 +21,9 @@
                                                                                                                 parentExceptionDetails);
             // The endpoint cannot ingest message lengths longer than a certain length
             if (exceptionDetails.message != null && exceptionDetails.message.Length > MaxExceptionMessageLength)
+            {
                 exceptionDetails.message = exceptionDetails.message.Substring(0, MaxExceptionMessageLength);
+            }
 
             var stack = new StackTrace(exception, true);
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/ExceptionConverter.cs
@@ -7,6 +7,7 @@
     internal static class ExceptionConverter
     {
         public const int MaxParsedStackLength = 32768;
+        public const int MaxExceptionMessageLength = 32768;
 
         /// <summary>
         /// Converts a System.Exception to a Microsoft.ApplicationInsights.Extensibility.Implementation.TelemetryTypes.ExceptionDetails.
@@ -18,6 +19,10 @@
             External.ExceptionDetails exceptionDetails = External.ExceptionDetails.CreateWithoutStackInfo(
                                                                                                                 exception,
                                                                                                                 parentExceptionDetails);
+            // The endpoint cannot ingest message lengths longer than a certain length
+            if (exceptionDetails.message != null && exceptionDetails.message.Length > MaxExceptionMessageLength)
+                exceptionDetails.message = exceptionDetails.message.Substring(0, MaxExceptionMessageLength);
+
             var stack = new StackTrace(exception, true);
 
             var frames = stack.GetFrames();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - [Validate exception stack trace line numbers to comply with endpoint restrictions.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2482)
 - [Removed redundant memory allocations and processing in PartialSuccessTransmissionPolicy for ingestion sampling cases](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2445)
+- [Validate exception message length to comply with endpoint restrictions.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2284)
 
 ## Version 2.20
 - [Allow Control of Documents sampling for QuickPulse telemetry](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2425)


### PR DESCRIPTION
Fix Issue #2284.

## Changes
Added validation to ExceptionConverter to trim messages greater than a certain length.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
