### PR TITLE
update Xdt.Tests.csproj targetframework

### DIFF
--- a/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
@@ -5,7 +5,7 @@
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <RootNamespace>Xdt.Tests</RootNamespace>
     <AssemblyName>Xdt.Tests</AssemblyName>
-    <TargetFrameworks>net45;net452</TargetFrameworks>
+    <TargetFrameworks>net462</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   


### PR DESCRIPTION
I'm working with external contributors to investigate why some people cannot compile our repo.
Found one test project with unsupported `net45` Target Frameworks.

The Xdt.Tests project verifies xml transforms for the applicationinsights.config file. This does not need to be on any specific version.

## Changes
- upgrade TargetFrameworks to the [soon to be] minimum supported version `net462`

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
