### PR TITLE
remove net452, net460, and net461 from workflows and props

### DIFF
--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
+        framework: [net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
         include: 
           - os: ubuntu-latest
             args: "--filter TestCategory!=WindowsOnly"

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
+        framework: [net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
+        framework: [net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
         include: 
           - os: ubuntu-latest
             args: "--filter TestCategory!=WindowsOnly"

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -24,7 +24,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest]
-        framework: [net452, net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
+        framework: [net462, net472, net480, netcoreapp3.1, net5.0, net6.0]
 
     steps:
     - uses: actions/checkout@v2

--- a/.props/Test.props
+++ b/.props/Test.props
@@ -9,14 +9,11 @@
 
   <PropertyGroup>
     <!-- Our test matrix includes every currently supported version of .NET
-          - net4.5.2 (EoL April 2022)
-          - net4.6.0 (EoL April 2022)
-          - net4.6.1 (EoL April 2022)
           - net4.6.2
           - net4.7.2
           - net4.8.0
           - netcoreapp3.1 (EoL Dec 2022)
-          - net5.0 (EoL Feb 2022)
+          - net5.0 (EoL May 2022)
           - net6.0 (GA Nov 2021)
     -->
     <TargetFrameworks>net462;net472;net480;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>


### PR DESCRIPTION
#2273

The purpose of this PR is to remove retiring versions of NET Framework from our test infra.
This is preparing for future work to remove these frameworks from all projects.

## Changes
- remove net452, net460, net461 
  - from github workflows
  - from Test.props

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
