### PR TITLE
Document excludeTypes and includedTypes parameters for UseAdaptiveSampling

### DIFF
--- a/BASE/src/ServerTelemetryChannel/TelemetryProcessorChainBuilderExtensions.cs
+++ b/BASE/src/ServerTelemetryChannel/TelemetryProcessorChainBuilderExtensions.cs
@@ -18,8 +18,8 @@
         /// </summary>
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/>.</param>
         /// <param name="samplingPercentage">Sampling Percentage to configure.</param>     
-        /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>   
-        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
+        /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled. Allowed type names: Dependency, Event, Exception, PageView, Request, Trace.</param>   
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty. Allowed type names: Dependency, Event, Exception, PageView, Request, Trace.</param> 
         /// <return>Same instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
         public static TelemetryProcessorChainBuilder UseSampling(this TelemetryProcessorChainBuilder builder, double samplingPercentage, string excludedTypes = null, string includedTypes = null)
         {
@@ -41,8 +41,8 @@
         /// Adds <see cref="AdaptiveSamplingTelemetryProcessor"/> to the <see cref="TelemetryProcessorChainBuilder" />.
         /// </summary>
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/>.</param>
-        /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>
-        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
+        /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled. Allowed type names: Dependency, Event, Exception, PageView, Request, Trace. </param>
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty. Allowed type names: Dependency, Event, Exception, PageView, Request, Trace. </param> 
         /// <return>Same instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
         public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, string excludedTypes = null, string includedTypes = null)
         {
@@ -63,8 +63,8 @@
         /// </summary>
         /// <param name="builder">Instance of <see cref="TelemetryProcessorChainBuilder"/>.</param>
         /// <param name="maxTelemetryItemsPerSecond">Maximum number of telemetry items to be generated on this application instance.</param>
-        /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled.</param>
-        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty.</param> 
+        /// <param name="excludedTypes">Semicolon separated list of types that should not be sampled. Allowed type names: Dependency, Event, Exception, PageView, Request, Trace. </param>
+        /// <param name="includedTypes">Semicolon separated list of types that should be sampled. All types are sampled when left empty. Allowed type names: Dependency, Event, Exception, PageView, Request, Trace. </param> 
         /// <return>Same instance of <see cref="TelemetryProcessorChainBuilder"/>.</return>
         public static TelemetryProcessorChainBuilder UseAdaptiveSampling(this TelemetryProcessorChainBuilder builder, double maxTelemetryItemsPerSecond, string excludedTypes = null, string includedTypes = null)
         {


### PR DESCRIPTION
## Changes
The `excludeTypes` and `includedTypes` parameters are `string`s with no information what a "type" can be. This PR extends the xmldoc for the parameters with info on the possible values: Dependency, Event, Exception, PageView, Request, Trace

This list is documented on the `SamplingTelemetryProcessor` class. The actual list of values exists in the internal class `SamplingIncludesUtility`.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
