### PR TITLE
cleanup ApplicationInsightsTypes.csproj

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -1,31 +1,28 @@
 ﻿<Project ToolsVersion="15.0" Sdk="Microsoft.NET.Sdk">
-  <!--temp while we dont merge application insights types -->
-  <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), 'Product.props'))\Product.props" />
   <Import Project="$(PropsRoot)\Test.props" />
   <PropertyGroup>
-    <Company>Microsoft</Company>
-    <Copyright>Copyright © Microsoft. All Rights Reserved.</Copyright>
-
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
+  </PropertyGroup>
 
-    <ProjectGuid>{4B0BC3B7-C7FC-4333-9E28-5790D9153F07}</ProjectGuid>
-    <RootNamespace>ApplicationInsightsTypes</RootNamespace>
-    <AssemblyName>ApplicationInsightsTypes</AssemblyName>
+  <PropertyGroup>
     <BondOptions>--collection-interfaces --using="DateTimeOffset=System.DateTimeOffset" --using="TimeSpan=System.TimeSpan" --using="Guid=System.Guid"</BondOptions>
     <BondOutputDirectory>$(MSBuildThisFileDirectory)\Generated</BondOutputDirectory>
     <EnableDefaultItems Condition="$(OS) == 'Windows_NT'">false</EnableDefaultItems>
   </PropertyGroup>
+  
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <Compile Include="ItemType.cs" />
     <Compile Include="TelemetryItem.cs" />
     <Compile Include="TelemetryItemType.cs" />
   </ItemGroup>
+  
   <ItemGroup>
     <PackageReference Include="Bond.CSharp" Version="7.0.1">
       <PrivateAssets>build</PrivateAssets>
     </PackageReference>
   </ItemGroup>
+  
   <ItemGroup Condition="$(OS) == 'Windows_NT'">
     <BondCodegen Include="..\..\..\Schema\PublicSchema\AvailabilityData.bond">
       <Link>StackFrame.bond</Link>
@@ -85,4 +82,5 @@
       <Link>StackFrame.bond</Link>
     </BondCodegen>
   </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
#2387

## Changes
- remove unnecessary properties from csproj
- cleanup whitespace

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
