### PR TITLE
Support Azure.Mesasging.ServiceBus (Track2) SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [LOGGING: Make TelemetryConfiguration configurable in ApplicationInsightsLoggingBuilderExtensions](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1944)
+- [Added support for distributed tracing with Azure.Messaging.ServiceBus](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2593)
 
 ## Version 2.21.0-beta1
 - [Support IPv6 in request headers](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2521)

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -65,9 +65,11 @@
                         telemetry = new DependencyTelemetry { Type = type };
                     }
 
-                    if (type != null && type.EndsWith(RemoteDependencyConstants.AzureEventHubs, StringComparison.Ordinal))
+                    if (type != null && 
+                        (type.EndsWith(RemoteDependencyConstants.AzureEventHubs, StringComparison.Ordinal)) || 
+                         type.EndsWith(RemoteDependencyConstants.AzureServiceBus, StringComparison.Ordinal))
                     {
-                        SetEventHubsProperties(currentActivity, telemetry);
+                        SetMessagingProperties(currentActivity, telemetry);
                     }
 
                     if (this.linksPropertyFetcher.Fetch(evnt.Value) is IEnumerable<Activity> activityLinks)
@@ -225,6 +227,12 @@
                         break;
 
                     case "component":
+                        // old tag populated for back-compat, if az.namespace is set - ignore it.
+                        if (component == null)
+                        {
+                            component = tag.Value;
+                        }
+                        break;
                     case "az.namespace":
                         component = tag.Value;
                         break;
@@ -233,9 +241,11 @@
 
             if (component == "eventhubs" || component == "Microsoft.EventHub")
             {
-                return kind == null
-                    ? RemoteDependencyConstants.AzureEventHubs
-                    : string.Concat(kind, " | ", RemoteDependencyConstants.AzureEventHubs);
+                component = RemoteDependencyConstants.AzureEventHubs;
+            } 
+            else if (component == "Microsoft.ServiceBus")
+            {
+                component = RemoteDependencyConstants.AzureServiceBus;
             }
 
             if (component != null)
@@ -310,10 +320,10 @@
             }
         }
 
-        private static void SetEventHubsProperties(Activity activity, OperationTelemetry telemetry)
+        private static void SetMessagingProperties(Activity activity, OperationTelemetry telemetry)
         {
             string endpoint = null;
-            string queueName = null;
+            string entityName = null;
 
             foreach (var tag in activity.Tags)
             {
@@ -323,16 +333,16 @@
                 }
                 else if (tag.Key == "message_bus.destination")
                 {
-                    queueName = tag.Value;
+                    entityName = tag.Value;
                 }
             }
 
-            if (endpoint == null || queueName == null)
+            if (endpoint == null || entityName == null)
             {
                 return;
             }
 
-            // Target uniquely identifies the resource, we use both: queueName and endpoint
+            // Target uniquely identifies the resource, we use both: entityName and endpoint
             // with schema used for SQL-dependencies
             string separator = "/";
             if (endpoint.EndsWith(separator, StringComparison.Ordinal))
@@ -340,15 +350,15 @@
                 separator = string.Empty;
             }
 
-            string eventHubInfo = string.Concat(endpoint, separator, queueName);
+            string brokerInfo = string.Concat(endpoint, separator, entityName);
 
             if (telemetry is DependencyTelemetry dependency)
             {
-                dependency.Target = eventHubInfo;
+                dependency.Target = brokerInfo;
             }
             else if (telemetry is RequestTelemetry request)
             {
-                request.Source = eventHubInfo;
+                request.Source = brokerInfo;
             }
         }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -65,9 +65,7 @@
                         telemetry = new DependencyTelemetry { Type = type };
                     }
 
-                    if (type != null && 
-                        (type.EndsWith(RemoteDependencyConstants.AzureEventHubs, StringComparison.Ordinal)) || 
-                         type.EndsWith(RemoteDependencyConstants.AzureServiceBus, StringComparison.Ordinal))
+                    if (IsMessagingDependency(type))
                     {
                         SetMessagingProperties(currentActivity, telemetry);
                     }
@@ -232,6 +230,7 @@
                         {
                             component = tag.Value;
                         }
+
                         break;
                     case "az.namespace":
                         component = tag.Value;
@@ -318,6 +317,12 @@
             {
                 dependency.Success = false;
             }
+        }
+
+        private static bool IsMessagingDependency(string dependencyType)
+        {
+            return dependencyType != null && (dependencyType.EndsWith(RemoteDependencyConstants.AzureEventHubs, StringComparison.Ordinal) ||
+                         dependencyType.EndsWith(RemoteDependencyConstants.AzureServiceBus, StringComparison.Ordinal));
         }
 
         private static void SetMessagingProperties(Activity activity, OperationTelemetry telemetry)


### PR DESCRIPTION
Fix Issue #2151, https://github.com/Azure/azure-sdk-for-net/issues/18002.

## Changes
Adds support for ServiceBus Track 2 SDK


![image](https://user-images.githubusercontent.com/2347409/167053633-73e20a3a-7072-44c3-8063-2c09cf5d3dbd.png)

(time skew does not come from telemetry; timestamps and duration are correct. The issue is reported to the portal team)

![image](https://user-images.githubusercontent.com/2347409/167053853-9bd97ac6-fca7-4e52-9e2d-d7dc5fcfdbd8.png)


### Checklist
- [x] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
