### PR TITLE
fix Metric livelock by replacing potential infinate loop in MetricValuesBuffer.GetAndResetValue

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -675,7 +675,6 @@
         [Event(76, Message = "MetricValueBuffer exceeded spin count.", Level = EventLevel.Warning)]
         public void MetricValueBufferExceededSpinCount(string appDomainName = "Incorrect") => this.WriteEvent(76, this.nameProvider.Name);
 
-
         [NonEvent]
         public void TransmissionStatusEventFailed(Exception ex)
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -672,6 +672,10 @@
         [Event(75, Message = "Ingestion Service responded with redirect. {0}", Level = EventLevel.Error)]
         public void IngestionRedirectError(string message, string appDomainName = "Incorrect") => this.WriteEvent(75, message, this.nameProvider.Name);
 
+        [Event(76, Message = "MetricValueBuffer exceeded spin count.", Level = EventLevel.Warning)]
+        public void MetricValueBufferExceededSpinCount(string appDomainName = "Incorrect") => this.WriteEvent(76, this.nameProvider.Name);
+
+
         [NonEvent]
         public void TransmissionStatusEventFailed(Exception ex)
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
@@ -1,11 +1,11 @@
 ﻿namespace Microsoft.ApplicationInsights.Metrics.Extensibility
 {
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-
     using System;
     using System.Runtime.CompilerServices;
     using System.Threading;
     using System.Threading.Tasks;
+
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
 #pragma warning disable SA1649 // File name must match first type name
 #pragma warning disable SA1402 // File may only contain a single class

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
@@ -46,8 +46,6 @@
             set { this.nextFlushIndex = value; }
         }
 
-        protected abstract TValue InvalidValue { get; }
-
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int IncWriteIndex()
         {
@@ -103,7 +101,7 @@
                     else if (spinWait.Count > 10000)
                     {
                         // exceeded maximum spin count. Break out to avoid infinite loop.
-                        return this.InvalidValue;
+                        break;
                     }
 
                     value = this.GetAndResetValueOnce(this.values, index);
@@ -133,8 +131,6 @@
             : base(capacity)
         {
         }
-
-        protected override double InvalidValue => double.NaN;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override bool IsInvalidValue(double value)
@@ -170,8 +166,6 @@
             : base(capacity)
         {
         }
-
-        protected override object InvalidValue => null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override bool IsInvalidValue(object value)

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
@@ -46,7 +46,7 @@
             set { this.nextFlushIndex = value; }
         }
 
-        protected abstract TValue DefaultValue { get; }
+        protected abstract TValue InvalidValue { get; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public int IncWriteIndex()
@@ -103,7 +103,7 @@
                     else if (spinWait.Count > 10000)
                     {
                         // exceeded maximum spin count. Break out to avoid infinite loop.
-                        return this.DefaultValue;
+                        return this.InvalidValue;
                     }
 
                     value = this.GetAndResetValueOnce(this.values, index);
@@ -134,7 +134,7 @@
         {
         }
 
-        protected override double DefaultValue => double.NaN;
+        protected override double InvalidValue => double.NaN;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override bool IsInvalidValue(double value)
@@ -171,7 +171,7 @@
         {
         }
 
-        protected override object DefaultValue => null;
+        protected override object InvalidValue => null;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         protected override bool IsInvalidValue(object value)

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs
@@ -1,5 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Metrics.Extensibility
 {
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+
     using System;
     using System.Runtime.CompilerServices;
     using System.Threading;
@@ -94,13 +96,14 @@
 
                     if (spinWait.Count % 100 == 0)
                     {
-                        // In tests (including stress tests) we always finished wating before 100 cycles.
+                        // In tests (including stress tests) we always finished waiting before 100 cycles.
                         // However, this is a protection against en extreme case on a slow machine. 
                         Task.Delay(10).ConfigureAwait(continueOnCapturedContext: false).GetAwaiter().GetResult();
                     }
                     else if (spinWait.Count > 10000)
                     {
-                        // exceeded maximum spin count. Break out to avoid infinite loop.
+                        // Exceeded maximum spin count. Break out to avoid infinite loop.
+                        CoreEventSource.Log.MetricValueBufferExceededSpinCount();
                         break;
                     }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - [Extension methods to retrive specific operation details.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1350)
 - [Mark Instrumentation Key based APIs as Obsolete](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560).
   - See also: https://docs.microsoft.com/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings
+- [Fix: Deadlock when Flushing Metrics.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2612)
 
 ## Version 2.21.0-beta1
 - [Support IPv6 in request headers](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2521)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@
 - [Extension methods to retrive specific operation details.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1350)
 - [Mark Instrumentation Key based APIs as Obsolete](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560).
   - See also: https://docs.microsoft.com/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings
-- [Fix: Deadlock when Flushing Metrics.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2612)
+- [Fix: Livelock in MetricValuesBuffer.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2612)
 
 ## Version 2.21.0-beta1
 - [Support IPv6 in request headers](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2521)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [Mark Instrumentation Key based APIs as Obsolete](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560).
   - See also: https://docs.microsoft.com/azure/azure-monitor/app/migrate-from-instrumentation-keys-to-connection-strings
 - [Fix: Livelock in MetricValuesBuffer.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2612)
+  Mitigation for TelemetryClient.Flush deadlocks ([#1186](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1186))
 
 ## Version 2.21.0-beta1
 - [Support IPv6 in request headers](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2521)


### PR DESCRIPTION
Fix Issue #1186.

This PR mitigates the potential infinite while loop in `MetricValuesBuffer` by adding an exit condition.

## Changes
- added an exit condition to `MetricValuesBuffer.GetAndResetValue()`.


## Explanation

`MetricValuesBuffer` has a section that could get stuck in an infinate loop here:
https://github.com/microsoft/ApplicationInsights-dotnet/blob/92766878547151706353cbe5a916724e53b47199/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricValuesBuffer.cs#L90-L103

`GetAndResetValueOnce` will read a value from the buffer at an index and set reset that to `Double.NaN`.
This loop has no way to breakout if another thread has already reset this value.

This would also affect the `lock` in `MetricSeriesAggregatorBase`: 
https://github.com/microsoft/ApplicationInsights-dotnet/blob/5aed71ee55973e20808b06bd06d67d96157e787b/BASE/src/Microsoft.ApplicationInsights/Metrics/Extensibility/MetricSeriesAggregatorBase.cs#L398-L411


## Alternatives considered
My previous PR replaced the lock in MetricSeriesAggregatorBase. #2595.

However, when considering what happens when we break out... 
Breaking out of `MetricSeriesAggregatorBase` may cause the SDK to lose a complete batch of metrics.
Instead, we should only drop a single metric if breaking out of `MetricValuesBuffer`.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
