### PR TITLE
Remove two unnecessary .NET Standard 1.x dependencies.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VNext
+- [Remove two unnecessary .NET Standard 1.x dependencies.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2613)
 
 ## Version 2.21.0-beta2
 - [LOGGING: Make TelemetryConfiguration configurable in ApplicationInsightsLoggingBuilderExtensions](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1944)

--- a/LOGGING/src/TraceListener/TraceListener.csproj
+++ b/LOGGING/src/TraceListener/TraceListener.csproj
@@ -22,10 +22,6 @@
     <ProjectReference Include="..\..\..\BASE\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup>
     <Content Include="app.config.install.xdt" />
     <Content Include="app.config.uninstall.xdt" />

--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -35,10 +35,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.Diagnostics.StackTrace" Version="4.3.0" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <!--Framework References-->
     <Reference Include="System.Runtime.Caching" />


### PR DESCRIPTION
Fix Issue N/A.

## Changes
System.Diagnostics.StackTrace and TraceSource are not needed in projects that target .NET Standard 2.0. Referencing them substantially increases the transitive dependencies.

### Checklist
- [ ] I ran Unit Tests locally. - _couldn't because I was getting errors CS7034 - seem unrelated to my change_
- [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
