### PR TITLE
Update dependencies to remove Newtonsoft.Json. (GHSA-5crp-9r3c-p9vr)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
 ## VNext
-- Address vulnerability in `Newtonsoft.Json` ([GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)). ([#2615](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2615))
+- Address vulnerability in `Newtonsoft.Json` ([GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)). 
+  Mitigation is to upgrade dependencies in `Microsoft.ApplicationInsights.AspNetCore` ([#2615](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2615))
   - Upgrade `Microsoft.Extensions.Configuration.Json` from v2.1.0 to v3.1.0. 
   - Upgrade `System.Text.Encodings.Web` from 4.5.1 to 4.7.2.
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 ## VNext
+- Address vulnerability in `Newtonsoft.Json` ([GHSA-5crp-9r3c-p9vr](https://github.com/advisories/GHSA-5crp-9r3c-p9vr)). ([#2615](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2615))
+  - Upgrade `Microsoft.Extensions.Configuration.Json` from v2.1.0 to v3.1.0. 
+  - Upgrade `System.Text.Encodings.Web` from 4.5.1 to 4.7.2.
+  
 
 ## Version 2.21.0-beta2
 - [LOGGING: Make TelemetryConfiguration configurable in ApplicationInsightsLoggingBuilderExtensions](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1944)

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -34,7 +34,7 @@
     <ProjectReference Include="..\..\..\LOGGING\src\ILogger\ILogger.csproj" />
     
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -57,7 +57,7 @@
     <!-- 
     We must take a temporary dependency on this newer version until Microsoft.AspNetCore.Hosting updates their dependencies.
     -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.5.1" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -26,7 +26,6 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.1" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />


### PR DESCRIPTION
#2468

`Newtonsoft.Json` has a security vulnerability that affects all versions < 13.0.1.
- https://github.com/advisories/GHSA-5crp-9r3c-p9vr

This is an implicit dependency in the AspNetCore SDK.
- Microsoft.ApplicationInsights.AspNetCore v2.20.0
	- Microsoft.Extensions.Configuration.Json v2.1.0
		- Newtonsoft.Json v11.02



### Changes
- Upgrade `Microsoft.Extensions.Configuration.Json` from v2.1.0 to v3.1.0. 
  `Microsoft.Extensions.Configuration.Json` removed its dependency on `Newtonsoft.Json` in v3.0.0. v3.0.0 is no longer supported, next lowest supported version is v3.1.0.
- Upgrade `System.Text.Encodings.Web` from 4.5.1 to 4.7.2.
  Upgrading `Microsoft.Extensions.Configuration.Json` has a side effect of implicitly upgrading our dependency on `System.Text.Encodings.Web` from v4.5.1 to v4.7.0. Unfortunately, v4.7.0 also has a security vulnerability. Next lowest supported version is v4.7.2.
- Remove dependency from Test project.