### PR TITLE
Upgrade `Microsoft.Extensions.Configuration.Json` from v3.1.0 to v3.1.27 in `Microsoft.ApplicationInsights.AspNetCore`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-
+- Remove unused `System.Text.Encodings.Web` package reference from `Microsoft.ApplicationInsights.AspNetCore` ([#2633](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2633))
 
 ## Version 2.21.0
 - no changes since beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-- Remove unused `System.Text.Encodings.Web` package reference from `Microsoft.ApplicationInsights.AspNetCore` ([#2633](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2633))
+- Upgrade `Microsoft.Extensions.Configuration.Json` from v3.1.0 to v3.1.26 in `Microsoft.ApplicationInsights.AspNetCore` ([#2633](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2633))
 
 ## Version 2.21.0
 - no changes since beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-- Upgrade `Microsoft.Extensions.Configuration.Json` from v3.1.0 to v3.1.26 in `Microsoft.ApplicationInsights.AspNetCore` ([#2633](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2633))
+- Upgrade `Microsoft.Extensions.Configuration.Json` from v3.1.0 to v3.1.27 in `Microsoft.ApplicationInsights.AspNetCore` ([#2633](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2633))
 
 ## Version 2.21.0
 - no changes since beta.

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -34,7 +34,7 @@
     <ProjectReference Include="..\..\..\LOGGING\src\ILogger\ILogger.csproj" />
     
     <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -53,11 +53,6 @@
     We can remove this when NetCore v2.1 reaches EOL on August 21, 2021.
     -->
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-
-    <!-- 
-    We must take a temporary dependency on this newer version until Microsoft.AspNetCore.Hosting updates their dependencies.
-    -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
**Issue:** Package `System.Text.Encodings.Web` was updated recently, this causes an issue with ILRepack for Auto-Instrumentation. Based on research this package is not used directly by application insights. 

## Changes
* Upgrade `Microsoft.Extensions.Configuration.Json` from v3.1.0 to v3.1.27 in `Microsoft.ApplicationInsights.AspNetCore`
* Removed reference to `System.Text.Encodings.Web`. `Microsoft.Extensions.Configuration.Json` has indirect reference to it.

### Checklist
- [X] I ran Unit Tests locally.
- [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.
