### PR TITLE
Support CosmosDb dependency tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - AzureSdkDiagnosticListener modified to use sdkversion prefix "rdddsaz" instead of "dotnet".
 - [ILogger logs with LogLevel.None severity are now ignored by ApplicationInsightsLogger](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2667). Fixes ([#2666](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2666))
 - [Fix ExceptionTelemetry clears all Context when updating Exception property](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2086)
+- [Support dependency tracking and diagnostics events for Microsoft.Azure.Cosmos v3](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2635)
 
 ## Version 2.21.0
 - no changes since beta.

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1300,7 +1300,7 @@
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
                 Assert.AreEqual("503", dependency.ResultCode);
-                Assert.AreEqual("Azure DocumentDB", dependency.Type);
+                Assert.AreEqual("Azure CosmosDB", dependency.Type);
                 Assert.IsTrue(String.IsNullOrEmpty(dependency.Data));
 
                 Assert.IsTrue(dependency.Properties.ContainsKey("db.name"));
@@ -1348,7 +1348,7 @@
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
                 Assert.AreEqual("200", dependency.ResultCode);
-                Assert.AreEqual("Azure DocumentDB", dependency.Type);
+                Assert.AreEqual("Azure CosmosDB", dependency.Type);
             }
         }
 
@@ -1383,7 +1383,7 @@
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
                 Assert.AreEqual("503", dependency.ResultCode);
-                Assert.AreEqual("Azure DocumentDB", dependency.Type);
+                Assert.AreEqual("Azure CosmosDB", dependency.Type);
                 Assert.AreEqual("2", dependency.Properties["db.cosmosdb.retry_count"]);
                 Assert.AreEqual("0.123", dependency.Properties["db.cosmosdb.request_charge"]);
                 Assert.AreEqual("Direct", dependency.Properties["db.cosmosdb.connection_mode"]);

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1521,7 +1521,7 @@
         class CosmosDbEventSource : EventSource
         {
             private CosmosDbEventSource()
-                : base("Azure.Cosmos", EventSourceSettings.Default, "Azure.Cosmos", "true")
+                : base("Azure.Cosmos_foo")
             {
             }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1299,9 +1299,18 @@
                 Assert.AreEqual(sendActivity.SpanId.ToHexString(), dependency.Id);
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
-                Assert.AreEqual("ReadItems", dependency.Data);
                 Assert.AreEqual("503", dependency.ResultCode);
                 Assert.AreEqual("Azure DocumentDB", dependency.Type);
+                Assert.IsTrue(String.IsNullOrEmpty(dependency.Data));
+
+                Assert.IsTrue(dependency.Properties.ContainsKey("db.name"));
+                Assert.IsTrue(dependency.Properties.ContainsKey("db.operation"));
+                Assert.IsTrue(dependency.Properties.ContainsKey("net.peer.name"));
+                Assert.IsTrue(dependency.Properties.ContainsKey("db.cosmosdb.container"));
+                Assert.AreEqual("container", dependency.Properties["db.cosmosdb.container"]);
+                Assert.AreEqual("database", dependency.Properties["db.name"]);
+                Assert.AreEqual("ReadItems", dependency.Properties["db.operation"]);
+                Assert.AreEqual("my.documents.azure.com", dependency.Properties["net.peer.name"]);
             }
         }
 
@@ -1338,11 +1347,8 @@
                 Assert.AreEqual(sendActivity.SpanId.ToHexString(), dependency.Id);
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
-                Assert.AreEqual("ReadItems", dependency.Data);
                 Assert.AreEqual("200", dependency.ResultCode);
                 Assert.AreEqual("Azure DocumentDB", dependency.Type);
-                Assert.IsTrue(dependency.Properties.ContainsKey("db.cosmosdb.container"));
-                Assert.AreEqual("container", dependency.Properties["db.cosmosdb.container"]);
             }
         }
 
@@ -1365,6 +1371,7 @@
                     .AddTag("db.cosmosdb.connection_mode", "Direct")
                     .AddTag("db.cosmosdb.item_count", "42")
                     .AddTag("db.cosmosdb.request_charge", "0.123")
+                    .AddTag("foo", "bar")
                     .AddTag("az.namespace", "Microsoft.DocumentDB");
 
                 listener.StartActivity(sendActivity, null);
@@ -1375,13 +1382,18 @@
                 DependencyTelemetry dependency = telemetry as DependencyTelemetry;
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
-                Assert.AreEqual("ReadItems", dependency.Data);
                 Assert.AreEqual("503", dependency.ResultCode);
                 Assert.AreEqual("Azure DocumentDB", dependency.Type);
                 Assert.AreEqual("2", dependency.Properties["db.cosmosdb.retry_count"]);
                 Assert.AreEqual("0.123", dependency.Properties["db.cosmosdb.request_charge"]);
                 Assert.AreEqual("Direct", dependency.Properties["db.cosmosdb.connection_mode"]);
                 Assert.AreEqual("42", dependency.Properties["db.cosmosdb.item_count"]);
+
+                Assert.AreEqual("container", dependency.Properties["db.cosmosdb.container"]);
+                Assert.AreEqual("database", dependency.Properties["db.name"]);
+                Assert.AreEqual("ReadItems", dependency.Properties["db.operation"]);
+                Assert.AreEqual("my.documents.azure.com", dependency.Properties["net.peer.name"]);
+                Assert.IsFalse(dependency.Properties.ContainsKey("foo"));
             }
         }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1421,7 +1421,8 @@
 
                 listener.StartActivity(sendActivity, null);
 
-                CosmosDbEventSource.Singleton.RecordInfo("info message - ignored");
+                CosmosDbEventSource.Singleton.RecordVerbose("verbose message - ignored");
+                CosmosDbEventSource.Singleton.RecordInfo("info message");
                 CosmosDbEventSource.Singleton.RecordWarn("warn message");
                 CosmosDbEventSource.Singleton.RecordError("error message");
                 CosmosDbEventSource.Singleton.RecordWarnNoMessage("payload only");
@@ -1437,32 +1438,38 @@
 
                 Assert.IsTrue(dependency.Success.Value);
                 Assert.IsTrue(String.IsNullOrEmpty(dependency.ResultCode));
-                Assert.AreEqual(5, logs.Count);
-                
-                Assert.AreEqual("warn message", logs[0].Message);
-                Assert.AreEqual("error message", logs[1].Message);
-                Assert.AreEqual("payload only", logs[2].Message);
-                Assert.AreEqual("payload1, payload2", logs[3].Message);
-                Assert.AreEqual("payload1, ", logs[4].Message);
+                Assert.AreEqual(6, logs.Count);
 
-                Assert.AreEqual(SeverityLevel.Warning, logs[0].SeverityLevel);
-                Assert.AreEqual(SeverityLevel.Error, logs[1].SeverityLevel);
+                Assert.AreEqual("info message", logs[0].Message);
+                Assert.AreEqual("warn message", logs[1].Message);
+                Assert.AreEqual("error message", logs[2].Message);
+                Assert.AreEqual("payload only", logs[3].Message);
+                Assert.AreEqual("payload1, payload2", logs[4].Message);
+                Assert.AreEqual("payload1, ", logs[5].Message);
+
+                Assert.AreEqual(SeverityLevel.Information, logs[0].SeverityLevel);
+                Assert.AreEqual(SeverityLevel.Warning, logs[1].SeverityLevel);
+                Assert.AreEqual(SeverityLevel.Error, logs[2].SeverityLevel);
                 
                 Assert.AreEqual(dependency.Id, logs[0].Context.Operation.ParentId);
                 Assert.AreEqual(dependency.Id, logs[1].Context.Operation.ParentId);
-                
+                Assert.AreEqual(dependency.Id, logs[2].Context.Operation.ParentId);
+
                 Assert.AreEqual(dependency.Context.Operation.Id, logs[0].Context.Operation.Id);
                 Assert.AreEqual(dependency.Context.Operation.Id, logs[1].Context.Operation.Id);
+                Assert.AreEqual(dependency.Context.Operation.Id, logs[2].Context.Operation.Id);
 
-                Assert.AreEqual("2", logs[0].Properties["EventId"]);
-                Assert.AreEqual("1", logs[1].Properties["EventId"]);
+                Assert.AreEqual("3", logs[0].Properties["EventId"]);
+                Assert.AreEqual("2", logs[1].Properties["EventId"]);
+                Assert.AreEqual("1", logs[2].Properties["EventId"]);
 
 #if NET5_0_OR_GREATER || NETCOREAPP2_0_OR_GREATER
                 // DependencyCollector has net452 and netstandard20 targets
                 // test targets that falls back to net452 dependency would not have EventName available
                 // because EventSource on .NET 4.5.2 does not support it
-                Assert.AreEqual("RecordWarn", logs[0].Properties["EventName"]);
-                Assert.AreEqual("RecordError", logs[1].Properties["EventName"]);
+                Assert.AreEqual("RecordInfo", logs[0].Properties["EventName"]);
+                Assert.AreEqual("RecordWarn", logs[1].Properties["EventName"]);
+                Assert.AreEqual("RecordError", logs[2].Properties["EventName"]);
 #endif
             }
         }
@@ -1573,6 +1580,13 @@
             public void RecordWarnNoMessageTwoArguments(string diagnostics1, string diagnostics2)
             {
                 this.WriteEvent(5, diagnostics1, diagnostics2);
+            }
+
+
+            [Event(6, Level = EventLevel.Verbose, Message = "{0}")]
+            public void RecordVerbose(string diagnostics)
+            {
+                this.WriteEvent(6, diagnostics);
             }
         }
 #endif

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -14,7 +14,6 @@
     using Microsoft.ApplicationInsights.Web.TestFramework;
     using Microsoft.VisualStudio.TestTools.UnitTesting;
     using Newtonsoft.Json;
-    using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
     [TestClass]
     public class AzureSdkDiagnosticListenerTest

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1394,6 +1394,7 @@
                 Assert.AreEqual("ReadItems", dependency.Properties["db.operation"]);
                 Assert.AreEqual("my.documents.azure.com", dependency.Properties["net.peer.name"]);
                 Assert.IsFalse(dependency.Properties.ContainsKey("foo"));
+                Assert.IsFalse(dependency.Properties.ContainsKey("db.system"));
             }
         }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1300,7 +1300,7 @@
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
                 Assert.AreEqual("503", dependency.ResultCode);
-                Assert.AreEqual("Azure CosmosDB", dependency.Type);
+                Assert.AreEqual("Microsoft.DocumentDB", dependency.Type);
                 Assert.IsTrue(String.IsNullOrEmpty(dependency.Data));
 
                 Assert.IsTrue(dependency.Properties.ContainsKey("db.name"));
@@ -1348,7 +1348,7 @@
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
                 Assert.AreEqual("200", dependency.ResultCode);
-                Assert.AreEqual("Azure CosmosDB", dependency.Type);
+                Assert.AreEqual("Microsoft.DocumentDB", dependency.Type);
             }
         }
 
@@ -1383,7 +1383,7 @@
                 Assert.AreEqual("container | ReadItems", dependency.Name);
                 Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
                 Assert.AreEqual("503", dependency.ResultCode);
-                Assert.AreEqual("Azure CosmosDB", dependency.Type);
+                Assert.AreEqual("Microsoft.DocumentDB", dependency.Type);
                 Assert.AreEqual("2", dependency.Properties["db.cosmosdb.retry_count"]);
                 Assert.AreEqual("0.123", dependency.Properties["db.cosmosdb.request_charge"]);
                 Assert.AreEqual("Direct", dependency.Properties["db.cosmosdb.connection_mode"]);

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1425,6 +1425,9 @@
                 CosmosDbEventSource.Singleton.RecordInfo("info message - ignored");
                 CosmosDbEventSource.Singleton.RecordWarn("warn message");
                 CosmosDbEventSource.Singleton.RecordError("error message");
+                CosmosDbEventSource.Singleton.RecordWarnNoMessage("payload only");
+                CosmosDbEventSource.Singleton.RecordWarnNoMessageTwoArguments("payload1", "payload2");
+                CosmosDbEventSource.Singleton.RecordWarnNoMessageTwoArguments("payload1", null);
                 listener.StopActivity(sendActivity, null);
 
                 var dependency = this.sentItems.Single(t => t is DependencyTelemetry) as DependencyTelemetry;
@@ -1435,11 +1438,14 @@
 
                 Assert.IsTrue(dependency.Success.Value);
                 Assert.IsTrue(String.IsNullOrEmpty(dependency.ResultCode));
-                Assert.AreEqual(2, logs.Count);
+                Assert.AreEqual(5, logs.Count);
                 
                 Assert.AreEqual("warn message", logs[0].Message);
                 Assert.AreEqual("error message", logs[1].Message);
-                
+                Assert.AreEqual("payload only", logs[2].Message);
+                Assert.AreEqual("payload1, payload2", logs[3].Message);
+                Assert.AreEqual("payload1, ", logs[4].Message);
+
                 Assert.AreEqual(SeverityLevel.Warning, logs[0].SeverityLevel);
                 Assert.AreEqual(SeverityLevel.Error, logs[1].SeverityLevel);
                 
@@ -1556,6 +1562,18 @@
             public void RecordInfo(string diagnostics)
             {
                 this.WriteEvent(3, diagnostics);
+            }
+
+            [Event(4, Level = EventLevel.Warning)]
+            public void RecordWarnNoMessage(string diagnostics)
+            {
+                this.WriteEvent(4, diagnostics);
+            }
+
+            [Event(5, Level = EventLevel.Warning)]
+            public void RecordWarnNoMessageTwoArguments(string diagnostics1, string diagnostics2)
+            {
+                this.WriteEvent(5, diagnostics1, diagnostics2);
             }
         }
 #endif

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -15,7 +15,7 @@
         public AzureSdkDiagnosticListenerSubscriber(TelemetryConfiguration configuration) : base(configuration)
         {
             // listen to Cosmos EventSource only - other logs can be sent using ILogger
-            this.logsListener = new AzureSdkEventListener(this.Client, EventLevel.Warning, "Azure.Cosmos");
+            this.logsListener = new AzureSdkEventListener(this.Client, EventLevel.Informational, "Azure.Cosmos");
             this.Client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceListenerAzure + ":");
         }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -3,16 +3,26 @@
     using System;
     using System.Diagnostics;
     using Microsoft.ApplicationInsights.Common;
+    using System.Diagnostics.Tracing;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
-    internal sealed class AzureSdkDiagnosticListenerSubscriber : DiagnosticSourceListenerBase<object>
+    internal sealed class AzureSdkDiagnosticListenerSubscriber : DiagnosticSourceListenerBase<object>, IDisposable
     {
         public const string DiagnosticListenerName = "Azure.";
+        private readonly IDisposable logsListener;
 
         public AzureSdkDiagnosticListenerSubscriber(TelemetryConfiguration configuration) : base(configuration)
         {
+            // listen to Cosmos EventSource only - other logs can be sent using ILogger
+            this.logsListener = new AzureSdkEventListener(this.Client, EventLevel.Warning, "Azure.Cosmos");
             this.Client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceListenerAzure + ":");
+        }
+
+        public override void Dispose()
+        {
+            this.logsListener?.Dispose();
+            base.Dispose();
         }
 
         internal override bool IsSourceEnabled(DiagnosticListener diagnosticListener)

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -2,8 +2,8 @@
 {
     using System;
     using System.Diagnostics;
-    using Microsoft.ApplicationInsights.Common;
     using System.Diagnostics.Tracing;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -361,22 +361,22 @@
                 else if (tag.Key == "db.cosmosdb.container")
                 {
                     dbContainer = tag.Value;
-                    telemetry.Properties[tag.Key] = dbContainer;
                 }
                 else if (tag.Key == "db.cosmosdb.status_code")
                 {
                     telemetry.ResultCode = tag.Value;
                 }
-                else if (tag.Key.StartsWith("db.cosmosdb.", StringComparison.Ordinal))
+                else if (!tag.Key.StartsWith("db.cosmosdb.", StringComparison.Ordinal))
                 {
-                    telemetry.Properties[tag.Key] = tag.Value;
+                    continue;
                 }
+                
+                telemetry.Properties[tag.Key] = tag.Value;
             }
 
             // similar to SqlClientDiagnosticSourceListener
             telemetry.Target = string.Join(" | ", dbAccount, dbName);
             telemetry.Name = string.Join(" | ", dbContainer, dbOperation);
-            telemetry.Data = dbOperation;
         }
 
         private static void SetMessagingProperties(Activity activity, OperationTelemetry telemetry)

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -16,6 +16,7 @@
 
     internal class AzureSdkDiagnosticsEventHandler : DiagnosticsEventHandlerBase
     {
+        private const string CosmosDBResourceProviderNs = "Microsoft.DocumentDB";
 #if NET452
         private static readonly DateTimeOffset EpochStart = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
 #endif
@@ -100,7 +101,7 @@
                                 dependency.SetOperationDetail(evnt.Value.GetType().FullName, evnt.Value);
                             }
                         }
-                        else if (dependency.Type.EndsWith(RemoteDependencyConstants.AzureCosmosDb, StringComparison.Ordinal))
+                        else if (dependency.Type == CosmosDBResourceProviderNs)
                         {
                             SetCosmosDbProperties(currentActivity, dependency);
                         }
@@ -254,10 +255,6 @@
             {
                 component = RemoteDependencyConstants.AzureServiceBus;
             } 
-            else if (component == "Microsoft.DocumentDB") 
-            {
-                component = RemoteDependencyConstants.AzureCosmosDb;
-            }
 
             if (component != null)
             {

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -12,7 +12,6 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-    using static Microsoft.ApplicationInsights.MetricDimensionNames.TelemetryContext;
 
     internal class AzureSdkDiagnosticsEventHandler : DiagnosticsEventHandlerBase
     {
@@ -254,7 +253,7 @@
             else if (component == "Microsoft.ServiceBus")
             {
                 component = RemoteDependencyConstants.AzureServiceBus;
-            } 
+            }
 
             if (component != null)
             {

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -100,7 +100,7 @@
                                 dependency.SetOperationDetail(evnt.Value.GetType().FullName, evnt.Value);
                             }
                         }
-                        else if (dependency.Type.EndsWith(RemoteDependencyConstants.AzureDocumentDb, StringComparison.Ordinal))
+                        else if (dependency.Type.EndsWith(RemoteDependencyConstants.AzureCosmosDb, StringComparison.Ordinal))
                         {
                             SetCosmosDbProperties(currentActivity, dependency);
                         }
@@ -256,7 +256,7 @@
             } 
             else if (component == "Microsoft.DocumentDB") 
             {
-                component = RemoteDependencyConstants.AzureDocumentDb;
+                component = RemoteDependencyConstants.AzureCosmosDb;
             }
 
             if (component != null)

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -365,6 +365,7 @@
                 else if (tag.Key == "db.cosmosdb.status_code")
                 {
                     telemetry.ResultCode = tag.Value;
+                    continue;
                 }
                 else if (!tag.Key.StartsWith("db.cosmosdb.", StringComparison.Ordinal))
                 {

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkEventListener.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkEventListener.cs
@@ -19,11 +19,11 @@
         private readonly List<EventSource> eventSources = new List<EventSource>();
         private readonly TelemetryClient telemetryClient;
         private readonly EventLevel level;
-        private readonly string traitName;
+        private readonly string prefix;
 
-        public AzureSdkEventListener(TelemetryClient telemetryClient, EventLevel level, string traitName)
+        public AzureSdkEventListener(TelemetryClient telemetryClient, EventLevel level, string prefix)
         {
-            this.traitName = traitName ?? throw new ArgumentNullException(nameof(traitName));
+            this.prefix = prefix ?? throw new ArgumentNullException(nameof(prefix));
             this.level = level;
             this.telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
 
@@ -48,7 +48,7 @@
             // EventSource names are deduplicated for environments like
             // Functions where the same library can be loaded twice.
             // Two EventSources with the same name are not allowed.
-            if (eventSource.Name != null && eventSource.Name.StartsWith(this.traitName, StringComparison.Ordinal))
+            if (eventSource.Name != null && eventSource.Name.StartsWith(this.prefix, StringComparison.Ordinal))
             {
                 this.EnableEvents(eventSource, this.level);
             }

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkEventListener.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkEventListener.cs
@@ -10,7 +10,11 @@
 
     internal class AzureSdkEventListener : EventListener
     {
+#if NET452
         private static readonly object[] EmptyArray = new object[0];
+#else
+        private static readonly object[] EmptyArray = Array.Empty<object>();
+#endif
 
         private readonly List<EventSource> eventSources = new List<EventSource>();
         private readonly TelemetryClient telemetryClient;
@@ -69,6 +73,10 @@
                 catch (FormatException)
                 {
                 }
+            }
+            else
+            {
+                message = String.Join(", ", payloadArray); 
             }
 
             var trace = new TraceTelemetry(message, FromEventLevel(eventData.Level));

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkEventListener.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkEventListener.cs
@@ -1,0 +1,110 @@
+﻿namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics.Tracing;
+    using System.Globalization;
+    using System.Linq;
+    using Microsoft.ApplicationInsights;
+    using Microsoft.ApplicationInsights.DataContracts;
+
+    internal class AzureSdkEventListener : EventListener
+    {
+        private const string TraitValue = "true";
+        private readonly object[] EmptyArray = new object[0];
+
+        private readonly List<EventSource> eventSources = new List<EventSource>();
+        private readonly TelemetryClient telemetryClient;
+        private readonly EventLevel level;
+        private readonly string traitName;
+
+        public AzureSdkEventListener(TelemetryClient telemetryClient, EventLevel level, string traitName)
+        {
+            this.telemetryClient = telemetryClient ?? throw new ArgumentNullException(nameof(telemetryClient));
+            this.level = level;
+            this.traitName = traitName;
+
+            foreach (EventSource eventSource in this.eventSources)
+            {
+                this.OnEventSourceCreated(eventSource);
+            }
+
+            this.eventSources.Clear();
+        }
+
+        protected sealed override void OnEventSourceCreated(EventSource eventSource)
+        {
+            base.OnEventSourceCreated(eventSource);
+
+            if (this.telemetryClient == null)
+            {
+                this.eventSources.Add(eventSource);
+            }
+
+#if NET452
+            if (eventSource.Name == this.traitName)
+#else
+            if (eventSource.GetTrait(this.traitName) == TraitValue)
+#endif
+            {
+                this.EnableEvents(eventSource, this.level);
+            }
+        }
+        
+        protected sealed override void OnEventWritten(EventWrittenEventArgs eventData)
+        {
+            // Workaround https://github.com/dotnet/corefx/issues/42600
+            if (eventData.EventId == -1)
+            {
+                return;
+            }
+
+            var payloadArray = eventData.Payload?.ToArray() ?? EmptyArray;
+            string message = string.Empty;
+            if (eventData.Message != null)
+            {
+                try
+                {
+                    message = string.Format(CultureInfo.InvariantCulture, eventData.Message, payloadArray);
+                }
+                catch (FormatException)
+                {
+                }
+            }
+
+            var trace = new TraceTelemetry(message, FromEventLevel(eventData.Level));
+            trace.Properties["CategoryName"] = eventData.EventSource.Name;
+
+            if (eventData.EventId > 0)
+            {
+                trace.Properties["EventId"] = eventData.EventId.ToString(CultureInfo.InvariantCulture);
+            }
+
+#if !NET452
+            if (!string.IsNullOrEmpty(eventData.EventName))
+            {
+                trace.Properties["EventName"] = eventData.EventName;
+            }
+#endif
+            this.telemetryClient?.TrackTrace(trace);
+        }
+
+        private static SeverityLevel FromEventLevel(EventLevel level)
+        {
+            switch (level)
+            {
+                case EventLevel.Critical:
+                    return SeverityLevel.Critical;
+                case EventLevel.Error:
+                    return SeverityLevel.Error;
+                case EventLevel.Warning:
+                    return SeverityLevel.Warning;
+                case EventLevel.Informational:
+                    return SeverityLevel.Information;
+                case EventLevel.Verbose:
+                default:
+                    return SeverityLevel.Verbose;
+            }
+        }
+    }
+}

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/DiagnosticSourceListenerBase.cs
@@ -113,7 +113,7 @@ namespace Microsoft.ApplicationInsights.DependencyCollector.Implementation
         {
         }
 
-        public void Dispose()
+        public virtual void Dispose()
         {
             this.Dispose(true);
             GC.SuppressFinalize(this);

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/RemoteDependencyConstants.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/RemoteDependencyConstants.cs
@@ -10,6 +10,7 @@
         public const string AzureTable = "Azure table";
         public const string AzureQueue = "Azure queue";
         public const string AzureDocumentDb = "Azure DocumentDB";
+        public const string AzureCosmosDb = "Azure CosmosDB";
         public const string AzureEventHubs = "Azure Event Hubs";
         public const string AzureServiceBus = "Azure Service Bus";
         public const string AzureIotHub = "Azure IoT Hub";

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/RemoteDependencyConstants.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/RemoteDependencyConstants.cs
@@ -10,7 +10,6 @@
         public const string AzureTable = "Azure table";
         public const string AzureQueue = "Azure queue";
         public const string AzureDocumentDb = "Azure DocumentDB";
-        public const string AzureCosmosDb = "Azure CosmosDB";
         public const string AzureEventHubs = "Azure Event Hubs";
         public const string AzureServiceBus = "Azure Service Bus";
         public const string AzureIotHub = "Azure IoT Hub";


### PR DESCRIPTION
Cosmos DB SDK ([Microsoft.Azure.Cosmos v3.TODO](https://www.nuget.org/packages/Microsoft.Azure.Cosmos) now supports dependency tracking, even when used in `Direct` (TCP) mode.

You should see `DependencyTelemetry` reported for all public API calls (that involve network communication with the service). If you use `Gateway` (HTTP) mode, you would also see dependencies for underlying HTTP calls. For `Direct` calls, you might see a few nested HTTP dependencies too, but low-level TCP calls are not traced.

Attributes reported by Cosmos SDK can be found here: https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3058. They are populated as custom dimensions.

New dependencies tracing public API calls should have:
- `Target` following `{CosmosDB resource name} | {database name}` pattern, e.g. `cosmos-tracing-demo | my-store`. 
- `Name` follows `{container name} | {operation}` pattern, e.g. `orders | Read`
- `Type` matches Resource Provider namespace (`Microsoft.DocumentDB`)
- And `sdkversion` matches `rdddsaz`.

You can enable distributed tracing for Cosmos with the following API: TODO, add a link to cosmos docs.

In addition to dependency calls, Cosmos DB reports extensive diagnostics when an operation fails or takes too long. You can configure it with the following settings on the Cosmos DB client - TODO.
This diagnostics is sent as a log (`TraceTelemetry`) with `Warning` severity having `CosmosDiagnostics` as JSON in the message. You can identify it using `EventName` (in custom dimensions) with the `RecordDiagnosticsForRequests` value.
Such `TraceTelemetry` should be a child of Cosmos DB dependency telemetry described above.


## Changes

CosmosDB direct (TCP mode) dependency tracking (coming in future versions of Cosmos DB v3 SDK). 
Uses attributes outlined [here](https://github.com/Azure/azure-cosmos-dotnet-v3/issues/3058) and additional cosmos diagnostics is coming from the specific event source and is tracked as `TraceTelemetry`. 

EventSource verbosity is expected to be low - it will be controlled by CosmosDb customers on CosmosDb side. Cosmos would write it when an operation takes longer than a configurable threshold or when an error happens.


### Checklist
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
