### PR TITLE
AzureSdk DependencyCollector to use sdkversion prefix rdddsaz

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 
+- AzureSdkDiagnosticListener modified to use sdkverion prefix "rdddsaz" instead of "dotnet".
 
 ## Version 2.21.0
 - no changes since beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## VNext
 
-- AzureSdkDiagnosticListener modified to use sdkverion prefix "rdddsaz" instead of "dotnet".
+- AzureSdkDiagnosticListener modified to use sdkversion prefix "rdddsaz" instead of "dotnet".
 
 ## Version 2.21.0
 - no changes since beta.

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -2,7 +2,9 @@
 {
     using System;
     using System.Diagnostics;
+    using Microsoft.ApplicationInsights.Common;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
 
     internal sealed class AzureSdkDiagnosticListenerSubscriber : DiagnosticSourceListenerBase<object>
     {
@@ -10,6 +12,7 @@
 
         public AzureSdkDiagnosticListenerSubscriber(TelemetryConfiguration configuration) : base(configuration)
         {
+            this.Client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceListenerAzure + ":");
         }
 
         internal override bool IsSourceEnabled(DiagnosticListener diagnosticListener)

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/RDDSource.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/RDDSource.cs
@@ -7,5 +7,6 @@
         internal static string DiagnosticSourceDesktop = "dsd";
         internal static string DiagnosticSourceCore = "dsc";
         internal static string DiagnosticSourceListener = "dsl";
+        internal static string DiagnosticSourceListenerAzure = "dsaz";
     }
 }

--- a/docs/versions_and_names.md
+++ b/docs/versions_and_names.md
@@ -95,6 +95,7 @@ Define your own SDK name and send PR to update the list below. Please do not re-
 | rddp | Remote dependency telemetry collected via Profiler instrumentation | [github](https://github.com/Microsoft/ApplicationInsights-dotnet-server/releases)
 | rddsr | Azure Service Fabric service remoting call - Client side | [github](https://github.com/Microsoft/ApplicationInsights-ServiceFabric/blob/275166d8034f1b94881982073e304166fbaef6bd/src/ApplicationInsights.ServiceFabric.Native.Shared/DependencyTrackingModule/ServiceRemotingClientEventListener.cs#L41)
 | rdddsc | Remote dependency telemetry collected via Diagnostic Source for .NET Core | [github](https://github.com/Microsoft/ApplicationInsights-dotnet-server/releases)
+| rdddsaz | Remote dependency telemetry collected via Diagnostic Source callbacks from Azure SDKs | [github](https://github.com/Microsoft/ApplicationInsights-dotnet/releases)
 | rdddsd | Remote dependency telemetry collected via Diagnostic Source for Desktop framework | [github](https://github.com/Microsoft/ApplicationInsights-dotnet-server/releases)
 | rb | Ruby SDK | [github](https://github.com/Microsoft/ApplicationInsights-Ruby/blob/c78bb54c8b5c0f70218482219fb8447416cfe550/lib/application_insights/channel/telemetry_channel.rb#L89)
 | sc | Snapshot Debugger (Microsoft.ApplicationInsights.SnapshotCollector) | [nuget](https://www.nuget.org/packages/Microsoft.ApplicationInsights.SnapshotCollector)


### PR DESCRIPTION
DependencyCollector by default enables subscribing to DiagnosticSources starting with "Azure.". These events are published by track2 Azure SDKs.
However, the telemetryclient used for tracking telemetry from above is using the default SDK Version of "dotnet", which makes it difficult to identify how the telemetry was collected.

This PR introduced a new prefix "rdddsaz", following existing conventions, and can be expanded to "Remote Dependency Data collected via Diagnostic Source from Azure SDKs".