### PR TITLE
stop considering log entries with LogLevel.None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## VNext
 - Update endpoint redirect header name for QuickPulse module to v2
 - AzureSdkDiagnosticListener modified to use sdkversion prefix "rdddsaz" instead of "dotnet".
-- [Log entries marked with LogLeve.None are now ignored by ApplicationInsightsLogger](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2667). Fixes ([#2666](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2666))
+- [ILogger logs with LogLevel.None severity are now ignored by ApplicationInsightsLogger](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2667). Fixes ([#2666](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2666))
 
 ## Version 2.21.0
 - no changes since beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - Update endpoint redirect header name for QuickPulse module to v2
 - AzureSdkDiagnosticListener modified to use sdkversion prefix "rdddsaz" instead of "dotnet".
+- [Log entries marked with LogLeve.None are now ignored by ApplicationInsightsLogger](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2667). Fixes ([#2666](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2666))
 
 ## Version 2.21.0
 - no changes since beta.

--- a/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
+++ b/LOGGING/src/ILogger/ApplicationInsightsLogger.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Extensions.Logging.ApplicationInsights
         /// </returns>
         public bool IsEnabled(LogLevel logLevel)
         {
-            return this.telemetryClient.IsEnabled();
+            return logLevel != LogLevel.None && this.telemetryClient.IsEnabled();
         }
 
         /// <summary>

--- a/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
+++ b/LOGGING/test/ILogger.Tests/ILoggerIntegrationTests.cs
@@ -96,6 +96,7 @@ namespace Microsoft.ApplicationInsights
             testLogger.LogTrace("Trace");
             testLogger.LogWarning("Warning");
             testLogger.LogDebug("Debug");
+            testLogger.Log(LogLevel.None, "None");
 
             Assert.AreEqual(7, itemsReceived.Count);
 
@@ -123,6 +124,37 @@ namespace Microsoft.ApplicationInsights
             Assert.AreEqual("Trace", (itemsReceived[4] as TraceTelemetry).Message);
             Assert.AreEqual("Warning", (itemsReceived[5] as TraceTelemetry).Message);
             Assert.AreEqual("Debug", (itemsReceived[6] as TraceTelemetry).Message);
+        }
+
+        /// <summary>
+        /// Ensures that <see cref="ApplicationInsightsLogger"/> is invoked when user logs using <see cref="ILogger"/>.
+        /// </summary>
+        [TestMethod]
+        [TestCategory("ILogger")]
+        public void ApplicationInsightsLoggerIsNotInvokedWhenUsingILoggerAndTelemetryIsDisabled()
+        {
+            List<ITelemetry> itemsReceived = new List<ITelemetry>();
+
+            IServiceProvider serviceProvider = ILoggerIntegrationTests.SetupApplicationInsightsLoggerIntegration((telemetryItem, telemetryProcessor) =>
+            {
+                itemsReceived.Add(telemetryItem);
+            }, configuration =>
+            {
+                configuration.DisableTelemetry = true;
+            });
+
+            ILogger<ILoggerIntegrationTests> testLogger = serviceProvider.GetRequiredService<ILogger<ILoggerIntegrationTests>>();
+
+            testLogger.LogInformation("Testing");
+            testLogger.LogError(new Exception("ExceptionMessage"), "LoggerMessage");
+            testLogger.LogInformation(new EventId(100, "TestEvent"), "TestingEvent");
+            testLogger.LogCritical("Critical");
+            testLogger.LogTrace("Trace");
+            testLogger.LogWarning("Warning");
+            testLogger.LogDebug("Debug");
+            testLogger.Log(LogLevel.None, "None");
+
+            Assert.AreEqual(0, itemsReceived.Count);
         }
 
         /// <summary>


### PR DESCRIPTION
Fix Issue #2666

## Changes
As referenced in https://github.com/microsoft/ApplicationInsights-dotnet/issues/2666#issuecomment-1226565942, `ApplicationInsightsLogger` to ignore LogLevel.None entries.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
