### PR TITLE
Preserve Context when setting ExceptionTelemetry.Exception

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/DataContracts/ExceptionTelemetryTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/DataContracts/ExceptionTelemetryTest.cs
@@ -265,6 +265,30 @@
             Assert.AreEqual(nextException.Message, testExceptionTelemetry.ExceptionDetailsInfoList.First().Message);
         }
 
+        [TestMethod]
+        public void ExceptionPropertySetterPreservesContext()
+        {
+            // ARRANGE
+            Exception constructorException = new Exception("ConstructorException");
+            var testExceptionTelemetry = new ExceptionTelemetry(constructorException);
+
+            const string expectedAccountId = "AccountId";
+            testExceptionTelemetry.Context.User.AccountId = expectedAccountId;
+            const string expectedAuthenticatedUserId = "AuthUserId";
+            testExceptionTelemetry.Context.User.AuthenticatedUserId = expectedAuthenticatedUserId;
+            const string expectedUserAgent = "ExceptionComponent";
+            testExceptionTelemetry.Context.User.UserAgent = expectedUserAgent;
+
+            // ACT
+            Exception nextException = new Exception("NextException");
+            testExceptionTelemetry.Exception = nextException;
+
+            // ASSERT
+            Assert.AreEqual(expectedAccountId, testExceptionTelemetry.Context.User.AccountId);
+            Assert.AreEqual(expectedAuthenticatedUserId, testExceptionTelemetry.Context.User.AuthenticatedUserId);
+            Assert.AreEqual(expectedUserAgent, testExceptionTelemetry.Context.User.UserAgent);
+        }
+
 #pragma warning disable 618
         [TestMethod]
         public void HandledAtReturnsUnhandledByDefault()

--- a/BASE/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/DataContracts/ExceptionTelemetry.cs
@@ -449,7 +449,15 @@
 
                 this.Data = new ExceptionInfo(exceptions.Select(ex => new ExceptionDetailsInfo(ex)), this.SeverityLevel,
                     this.ProblemId, this.Properties, this.Metrics);
-                this.context = new TelemetryContext(this.Data.Properties);
+
+                if (this.context == null)
+                {
+                    this.context = new TelemetryContext(this.Data.Properties);
+                }
+                else
+                {
+                    this.context = this.context.DeepClone(this.Data.Properties);
+                }
             }
             catch (Exception ex)
             {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## VNext
 - Update endpoint redirect header name for QuickPulse module to v2
 - AzureSdkDiagnosticListener modified to use sdkversion prefix "rdddsaz" instead of "dotnet".
+- [Fix ExceptionTelemetry clears all Context when updating Exception property](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2086)
 
 ## Version 2.21.0
 - no changes since beta.


### PR DESCRIPTION
Fix Issue #2086 

## Changes
Preserve any existing context by calling DeepClone

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.