### PR TITLE
remove "Proprietary" comment from CustomTelemetryChannel in test project

### DIFF
--- a/LOGGING/test/Shared/CustomTelemetryChannel.cs
+++ b/LOGGING/test/Shared/CustomTelemetryChannel.cs
@@ -1,7 +1,6 @@
 ﻿//-----------------------------------------------------------------------------------
 // <copyright file='CustomTelemetryChannel.cs' company='Microsoft Corporation'>
 //     Copyright (c) Microsoft Corporation. All Rights Reserved.
-//     Information Contained Herein is Proprietary and Confidential.
 // </copyright>
 //-----------------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes #2670

`CustomTelemetryChannel` in a test project has the text 
> Information Contained Herein is Proprietary and Confidential.

This is an error and is the only file in the repo with this message.

This message has existed since the "initial commit" in 2015.
https://github.com/microsoft/ApplicationInsights-dotnet-logging/blob/dfce7dccf91fb5ecc50f8888350fbc2505fb39c2/Adapters.Tests/Shared/CustomTelemetryChannel.cs

