### PR TITLE
add links to doc regarding flushing

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -683,6 +683,9 @@
         /// <summary>
         /// Asynchronously Flushes the in-memory buffer and any metrics being pre-aggregated.
         /// </summary>
+        /// <remarks>
+        /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#flushing-data">Learn more</a>
+        /// </remarks>
         /// <returns>
         /// Returns true when telemetry data is transferred out of process (application insights server or local storage) and are emitted before the flush invocation.
         /// Returns false when transfer of telemetry data to server has failed with non-retriable http status.

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -51,6 +51,11 @@ catch(Exception ex)
 }
 ``` 
 
+### Flushing
+When your application is shutting down, we recommend Flushing the `TelemetryClient` to clear the buffer and prevent telemetry from being lost.
+
+Please review our examples here: [Flushing data](https://learn.microsoft.com/azure/azure-monitor/app/api-custom-events-metrics#flushing-data).
+
 ## Telemetry Channels
 Telemetry channels are responsible for sending the telemetry data to the designated place. Optional features can be provided by the telemetry channels, for example, buffering the data and sending in them in batches, persisting the data to a local storage in case of transmission failure (e.g. network outage), traffic shaping and retry mechanisms
 


### PR DESCRIPTION
Flushing is our most frequently asked question.
I found a public doc which describes flushing.
I want to add links to this doc to improve it's discoverability.

## Changes
- Add the "fwlink" from the `Flush()` method to the `FlushAsync()` method.
  - https://go.microsoft.com/fwlink/?linkid=525722#flushing-data
- Add a link to flush examples in our "Concepts" doc.
  - https://learn.microsoft.com/azure/azure-monitor/app/api-custom-events-metrics#flushing-data


## Other
I opened an issue on our docs repo to get this link added to our TelemetryChannels doc.
The TelemetryChannel doc already briefly mentions flushing.
https://github.com/MicrosoftDocs/azure-docs/issues/99092