### PR TITLE
Populate required string value for property Message

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
@@ -1,6 +1,7 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
     using System;
+    using Microsoft.ApplicationInsights.DataContracts;
 
     /// <summary>
     /// Additional implementation for ExceptionDetails.
@@ -21,7 +22,7 @@
             {
                 id = exception.GetHashCode(),
                 typeName = exception.GetType().FullName,
-                message = exception.Message,
+                message = Utils.PopulateRequiredStringValue(exception.Message, "message", typeof(ExceptionTelemetry).FullName),
             };
 
             if (parentExceptionDetails != null)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - AzureSdkDiagnosticListener modified to use sdkversion prefix "rdddsaz" instead of "dotnet".
 - [ILogger logs with LogLevel.None severity are now ignored by ApplicationInsightsLogger](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2667). Fixes ([#2666](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2666))
 - [Fix ExceptionTelemetry clears all Context when updating Exception property](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2086)
+- [Populate required string value for property Message](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1066)
 
 ## Version 2.21.0
 - no changes since beta.


### PR DESCRIPTION
Fix Issue #1066.

**Note: This change requires careful review. Also, I have not run the tests, since it's [not possible to build the projects locally](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2178).**

## Changes
Application Insights [is rejecting exceptions](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1066) with `Exception.Message` property being empty or null, as illustrated by an example:

```c#
var configuration = TelemetryConfiguration.CreateDefault();
configuration.ConnectionString = "InstrumentationKey=...";
var telemetryClient = new TelemetryClient(configuration);
telemetryClient.TrackException(new Exception("")); // ignored
telemetryClient.TrackException(new Exception("foo")); // logged
telemetryClient.Flush();
```
Response:
```json
{
    "itemsReceived": 1,
    "itemsAccepted": 0,
    "errors":
    [
        {
            "index": 0,
            "statusCode": 400,
            "message": "109: Field 'message' on type 'ExceptionDetails' is required but missing or empty. Expected: string, Actual: undefined"
        }
    ]
}
```


### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.


For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
