### PR TITLE
(WIP) refactor test frameworks

### DIFF
--- a/.props/Test.props
+++ b/.props/Test.props
@@ -19,19 +19,15 @@
           - net6.0 (EoL Nov 2024)
           - net7.0 (GA Nov 2022)
     -->
-    
-    
-    
-    
-    
-    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481;net480;net472</TargetFrameworks>
 
-    <TargetFrameworks_WithLegacy>$(TargetFrameworks);net462;net46;net452</TargetFrameworks_WithLegacy>
-    <TargetFrameworks_WithLegacy Condition="$(OS) != 'Windows_NT'">$(TargetFrameworks)</TargetFrameworks_WithLegacy>
-
-    <TargetFrameworks_NetCoreOnly>net7.0;net6.0;netcoreapp3.1</TargetFrameworks_NetCoreOnly>
-    <TargetFrameworks_NetFrameworkOnly>net481;net480;net472;net462;net46;net452</TargetFrameworks_NetFrameworkOnly>
+    <SupportedFrameworks_NetCore>net7.0;net6.0;netcoreapp3.1;</SupportedFrameworks_NetCore>
+    <SupportedFrameworks_NetFx Condition="$(OS) == 'Windows_NT'">net481;net480;net472;</SupportedFrameworks_NetFx>
+    <LegacyFrameworks_NetFx Condition="$(OS) == 'Windows_NT'">net462;net46;net452;</LegacyFrameworks_NetFx>
+    
+    <TargetFrameworks>$(SupportedFrameworks_NetCore)$(SupportedFrameworks_NetFx)</TargetFrameworks>
+    <TargetFrameworks_WithLegacy>$(SupportedFrameworks_NetCore)$(SupportedFrameworks_NetFx)$(LegacyFrameworks_NetFx)</TargetFrameworks_WithLegacy>
+    <TargetFrameworks_NetCoreOnly>$(SupportedFrameworks_NetCore)</TargetFrameworks_NetCoreOnly>
+    <TargetFrameworks_NetFrameworkOnly>$(SupportedFrameworks_NetFx)$(LegacyFrameworks_NetFx)</TargetFrameworks_NetFrameworkOnly>
     
     <TargetFrameworks_LatestNetFramework>net481</TargetFrameworks_LatestNetFramework>
   </PropertyGroup>

--- a/.props/Test.props
+++ b/.props/Test.props
@@ -19,8 +19,21 @@
           - net6.0 (EoL Nov 2024)
           - net7.0 (GA Nov 2022)
     -->
-    <TargetFrameworks>net462;net472;net480;net481;netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
-    <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netcoreapp3.1;net6.0;net7.0</TargetFrameworks>
+    
+    
+    
+    
+    
+    <TargetFrameworks>net7.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">$(TargetFrameworks);net481;net480;net472</TargetFrameworks>
+
+    <TargetFrameworks_WithLegacy>$(TargetFrameworks);net462;net46;net452</TargetFrameworks_WithLegacy>
+    <TargetFrameworks_WithLegacy Condition="$(OS) != 'Windows_NT'">$(TargetFrameworks)</TargetFrameworks_WithLegacy>
+
+    <TargetFrameworks_NetCoreOnly>net7.0;net6.0;netcoreapp3.1</TargetFrameworks_NetCoreOnly>
+    <TargetFrameworks_NetFrameworkOnly>net481;net480;net472;net462;net46;net452</TargetFrameworks_NetFrameworkOnly>
+    
+    <TargetFrameworks_LatestNetFramework>net481</TargetFrameworks_LatestNetFramework>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Microsoft.ApplicationInsights.Tests.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">net452;net46;net461;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks_WithLegacy)</TargetFrameworks>
+    
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Nuget.Tests/TelemetryChannel.Nuget.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Nuget.Tests/TelemetryChannel.Nuget.Tests.csproj
@@ -3,8 +3,9 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_LatestNetFramework)</TargetFrameworks>
+    
     <ProjectGuid>{21CB9A8A-F25B-4DEB-92CB-ACB6920EB8BC}</ProjectGuid>
-    <TargetFrameworks>net480</TargetFrameworks>
     <AssemblyName>TelemetryChannel.Nuget.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
+++ b/BASE/Test/ServerTelemetryChannel.Test/TelemetryChannel.Tests/TelemetryChannel.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks Condition="$(OS) == 'Windows_NT'">net452;net46;net461;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks_WithLegacy)</TargetFrameworks>
     
     <AssemblyName>Microsoft.ApplicationInsights.TelemetryChannel.Tests</AssemblyName>
   </PropertyGroup>

--- a/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(PropsRoot)\Test.props" />
 
+  
   <PropertyGroup>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_NetCoreOnly)</TargetFrameworks>
+
     <VersionPrefix>2.0.0</VersionPrefix>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTests.MVC.Tests</AssemblyName>
     <PackageId>FunctionalTests.MVC.Tests</PackageId>

--- a/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
+++ b/NETCORE/test/FunctionalTests.Utils/FunctionalTests.Utils.csproj
@@ -2,7 +2,9 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_NetCoreOnly)</TargetFrameworks>
+    
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>FunctionalTests.Utils</AssemblyName>
     <PackageId>FunctionalTests.Utils</PackageId>

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -2,7 +2,9 @@
   <Import Project="$(PropsRoot)\Test.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_NetCoreOnly)</TargetFrameworks>
+    
     <AssemblyName>FunctionalTests.WebApi.Tests</AssemblyName>
     <PackageId>FunctionalTests.WebApi.Tests</PackageId>
   </PropertyGroup>

--- a/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
+++ b/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
@@ -10,7 +10,8 @@
   -->
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_NetCoreOnly)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NETCORE/test/IntegrationTests.WebApp/IntegrationTests.WebApp.csproj
+++ b/NETCORE/test/IntegrationTests.WebApp/IntegrationTests.WebApp.csproj
@@ -2,7 +2,8 @@
   <Import Project="$(PropsRoot)\Test.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_NetCoreOnly)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks_NetCoreOnly)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/DependencyCollector.Tests.csproj
@@ -3,7 +3,8 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <TargetFrameworks>net452;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks_WithLegacy)</TargetFrameworks>
+    
     <AssemblyName>Microsoft.ApplicationInsights.DependencyCollector.Tests</AssemblyName>
     <PackageId>Microsoft.AI.DependencyCollector.Tests</PackageId>
   </PropertyGroup>

--- a/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/Perf.Tests.csproj
@@ -3,8 +3,8 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
-    <!--<TargetFrameworks>net452;netcoreapp3.1</TargetFrameworks>-->
-    <TargetFrameworks>net452;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks_WithLegacy)</TargetFrameworks>
+    
     <AssemblyName>Microsoft.AI.PerformanceCollector.Tests</AssemblyName>
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
   </PropertyGroup>

--- a/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
+++ b/WEB/Src/PerformanceCollector/Xdt.Tests/Xdt.Tests.csproj
@@ -3,9 +3,10 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_LatestNetFramework)</TargetFrameworks>
+    
     <RootNamespace>Xdt.Tests</RootNamespace>
     <AssemblyName>Xdt.Tests</AssemblyName>
-    <TargetFrameworks>net480</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   

--- a/WEB/Src/Web/Web.Tests/Web.Tests.csproj
+++ b/WEB/Src/Web/Web.Tests/Web.Tests.csproj
@@ -4,7 +4,8 @@
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
     <!-- Important: This project is exclusively NetFramework. This will not be upgraded to NetStandard nor NetCore. -->
-    <TargetFrameworks>net452;net462;net472;net480</TargetFrameworks>
+    <TargetFrameworks>$(TargetFrameworks_NetFrameworkOnly)</TargetFrameworks>
+    
     <AssemblyName>Microsoft.ApplicationInsights.Web.Tests</AssemblyName>
   </PropertyGroup>
 

--- a/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer.Tests/WindowsServer.Tests.csproj
@@ -3,9 +3,10 @@
 
   <PropertyGroup>
     <!-- TargetFrameworks are defined in Test.props, but can be overridden here if needed. -->
+    <TargetFrameworks>$(TargetFrameworks_WithLegacy)</TargetFrameworks>
+    
     <AssemblyName>Microsoft.AI.WindowsServer.Tests</AssemblyName>
     <RootNamespace>Microsoft.ApplicationInsights.Tests</RootNamespace>
-    <TargetFrameworks>net452;$(TargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Some of the test projects were overriding the frameworks defined in Test.props.
This was a good opportunity to revisit all test projects.

### Changes
- moved all variations of Test Frameworks to the Test.props
- update all Test projects