### PR TITLE
address CVE-2021-24112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [Support dependency tracking and diagnostics events for Microsoft.Azure.Cosmos v3](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2635)
 
 # Version 2.21.1
-  - System.Diagnostics.PerformanceCounter v4.7.0 -> v4.7.2 to address CVE-2021-26701
+  - System.Diagnostics.PerformanceCounter v4.7.0 -> v4.7.2 to address CVE-2021-24112
 
 ## Version 2.21.0
 - no changes since beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - [Support dependency tracking and diagnostics events for Microsoft.Azure.Cosmos v3](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2635)
 
 # Version 2.21.1
-  - System.Diagnostics.PerformanceCounter v4.7.0 -> v4.7.2 to address CVE-2021-24112
+  - Include System.Drawing.Common 4.7.2 since System.Diagnostics.PerformanceCounter can't be updated to address CVE-2021-26701
 
 ## Version 2.21.0
 - no changes since beta.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - [Fix ExceptionTelemetry clears all Context when updating Exception property](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2086)
 - [Support dependency tracking and diagnostics events for Microsoft.Azure.Cosmos v3](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2635)
 
+# Version 2.21.1
+  - System.Diagnostics.PerformanceCounter v4.7.0 -> v4.7.2 to address CVE-2021-26701
+
 ## Version 2.21.0
 - no changes since beta.
 

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -29,7 +29,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -29,7 +29,8 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.2" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Changes
Include System.Drawing.Common 4.7.2 since we can't update System.Diagnostics.PerformanceCounter to address [CVE-2021-24112](https://github.com/advisories/GHSA-rxg9-xrhp-64gj)

This would be temporary until the issue can be addressed as discussed [here](https://github.com/dotnet/runtime/issues/64592)

### Checklist
- [ ] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
