### PR TITLE
update setup-dotnet

### DIFF
--- a/.github/workflows/build-and-test-BASE.yml
+++ b/.github/workflows/build-and-test-BASE.yml
@@ -33,16 +33,12 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
-
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+            7.0.x
 
     - name: Restore
       run: dotnet restore ${{ env.SOLUTION }}

--- a/.github/workflows/build-and-test-LOGGING.yml
+++ b/.github/workflows/build-and-test-LOGGING.yml
@@ -30,16 +30,12 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
-
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+            7.0.x
 
     - name: Restore
       run: dotnet restore ${{ env.SOLUTION }} 

--- a/.github/workflows/build-and-test-NETCORE.yml
+++ b/.github/workflows/build-and-test-NETCORE.yml
@@ -33,16 +33,12 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
-
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+            7.0.x
 
     - name: Restore
       run: dotnet restore ${{ env.SOLUTION }}

--- a/.github/workflows/build-and-test-WEB.yml
+++ b/.github/workflows/build-and-test-WEB.yml
@@ -30,16 +30,12 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
-
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+            7.0.x
 
     - name: Restore
       run: dotnet restore ${{ env.SOLUTION }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -27,11 +27,12 @@ jobs:
         ref: ${{ matrix.branch }}
     
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
+            7.0.x
 
     - uses: nuget/setup-nuget@v1
       with:

--- a/.github/workflows/redfield-sanity-check.yml
+++ b/.github/workflows/redfield-sanity-check.yml
@@ -33,16 +33,12 @@ jobs:
     - uses: actions/checkout@v3
     
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
-
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+            7.0.x
 
     - name: Restore
       run: dotnet restore ${{ env.SOLUTION }}

--- a/.github/workflows/sanity.yml
+++ b/.github/workflows/sanity.yml
@@ -32,16 +32,12 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Setup dotnet
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v3.0.2
       with:
         dotnet-version: |
             3.1.x
             6.0.x
-
-    - uses: actions/setup-dotnet@v2
-      with:
-        dotnet-version: '7.0.x'
-        include-prerelease: true
+            7.0.x
 
     - name: Restore
       run: dotnet restore ${{ matrix.solution }}


### PR DESCRIPTION
Supersedes #2693 


### Changes
- update action `setup-dotnet` from version 2 to version 3.0.2
- remove second task for NET7
  v3 introduced new changes, the `include-prerelease` is no longer needed. Can do this as one task now