### PR TITLE
mitigate CVE-2021-24112

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## VNext
-- [Upgrade System.Drawing.Common to version 4.7.2 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)
+- [Upgrade System.Diagnostics.PerformanceCounter to version 6.0.0 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)
 
 ## Version 2.22.0-beta1
 - Update endpoint redirect header name for QuickPulse module to v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VNext
+- [Upgrade System.Drawing.Common to version 4.7.2 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)
 
 ## Version 2.22.0-beta1
 - Update endpoint redirect header name for QuickPulse module to v2

--- a/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
+++ b/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
@@ -23,8 +23,6 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
 
     <ProjectReference Include="..\IntegrationTests.WebApp\IntegrationTests.WebApp.csproj" />
-
-    <PackageReference Include="System.Security.Permissions" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -30,6 +30,17 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.0" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
+    
+    <!--
+    System.Drawing.Common 4.7.0 has a vulnerability https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-24112
+    
+    This is an implicit dependency from System.Diagnostics.PerformanceCounter.
+    (System.Diagnostics.PerformanceCounter 4.7.0 > System.Configuration.ConfigurationManager 4.7.0 > System.Security.Permissions 4.7.0 > System.Windows.Extensions 4.7.0 > System.Drawing.Common 4.7.0)
+    
+    The recommended mitigation is to take an explicit dependency on System.Drawing.Common 4.7.2.
+    -->
+    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
+    
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -29,18 +29,7 @@
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="1.0.0" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
-    
-    <!--
-    System.Drawing.Common 4.7.0 has a vulnerability https://msrc.microsoft.com/update-guide/en-US/vulnerability/CVE-2021-24112
-    
-    This is an implicit dependency from System.Diagnostics.PerformanceCounter.
-    (System.Diagnostics.PerformanceCounter 4.7.0 > System.Configuration.ConfigurationManager 4.7.0 > System.Security.Permissions 4.7.0 > System.Windows.Extensions 4.7.0 > System.Drawing.Common 4.7.0)
-    
-    The recommended mitigation is to take an explicit dependency on System.Drawing.Common 4.7.2.
-    -->
-    <PackageReference Include="System.Drawing.Common" Version="4.7.2" />
-    
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Supersedes: #2704 

- https://portal.msrc.microsoft.com/en-US/security-guidance/advisory/CVE-2021-24112



Our SDK has an implicit reference to `System.Drawing.Common`:
https://github.com/microsoft/ApplicationInsights-dotnet/blob/35b1a303f0fa07b9d93f178920ec65d400f729c8/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj#L30-L32

- Microsoft.ApplicationInsights.PerfCounterCollector
  - System.Diagnostics.PerformanceCounter https://www.nuget.org/packages/System.Diagnostics.PerformanceCounter/4.7.0
    - System.Configuration.ConfigurationManager https://www.nuget.org/packages/System.Configuration.ConfigurationManager/4.7.0
      - System.Security.Permissions https://www.nuget.org/packages/System.Security.Permissions/4.7.0
        - System.Windows.Extensions https://www.nuget.org/packages/System.Windows.Extensions/4.7.0
          - System.Drawing.Common https://www.nuget.org/packages/System.Drawing.Common/4.7.0
					

We could mitigate this by taking a dependency on `System.Drawing.Common` v4.7.2.

Instead, we're going to upgrade `System.Diagnostics.PerformanceCounter` from v4.7.0 to v6.0.0 to get a version of `System.Drawing.Common` without a vulnerability.
