### PR TITLE
Support internal and client spans from cosmos db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [Upgrade System.Diagnostics.PerformanceCounter to version 6.0.0 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)
+- [Report internal dependencies from Cosmos SDK as InProc and align with Cosmos SDK EventSource changes](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2712)
 
 ## Version 2.22.0-beta1
 - Update endpoint redirect header name for QuickPulse module to v2

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1398,42 +1398,7 @@
         }
 
         [TestMethod]
-        public void AzureCosmosDbClientSpansSuppressNestedOperations()
-        {
-            using (var listener = new DiagnosticListener("Azure.Cosmos"))
-            using (var module = new DependencyTrackingTelemetryModule())
-            {
-                module.Initialize(this.configuration);
-
-                Activity sendActivity = new Activity("Azure.Cosmos.ReadItems")
-                    .AddTag("kind", "client")
-                    .AddTag("net.peer.name", "my.documents.azure.com")
-                    .AddTag("db.name", "database")
-                    .AddTag("db.operation", "ReadItems")
-                    .AddTag("db.cosmosdb.container", "container")
-                    .AddTag("az.namespace", "Microsoft.DocumentDB");
-
-                listener.StartActivity(sendActivity, null);
-                sendActivity.AddTag("db.cosmosdb.status_code", "200");
-                
-                Assert.IsTrue(SdkInternalOperationsMonitor.IsEntered());
-                listener.StopActivity(sendActivity, null);
-                Assert.IsFalse(SdkInternalOperationsMonitor.IsEntered());
-
-                var telemetry = this.sentItems.Last();
-                DependencyTelemetry dependency = telemetry as DependencyTelemetry;
-                Assert.AreEqual("container | ReadItems", dependency.Name);
-                Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
-                Assert.AreEqual("200", dependency.ResultCode);
-                Assert.AreEqual("Microsoft.DocumentDB", dependency.Type);
-                Assert.AreEqual("database", dependency.Properties["db.name"]);
-                Assert.AreEqual("ReadItems", dependency.Properties["db.operation"]);
-                Assert.AreEqual("my.documents.azure.com", dependency.Properties["net.peer.name"]);
-            }
-        }
-
-        [TestMethod]
-        public void AzureCosmosDbInternalSpansDontSuppressNestedOperations()
+        public void AzureCosmosDbInternalSpansHaveInProcType()
         {
             using (var listener = new DiagnosticListener("Azure.Cosmos"))
             using (var module = new DependencyTrackingTelemetryModule())
@@ -1450,8 +1415,6 @@
 
                 listener.StartActivity(sendActivity, null);
                 sendActivity.AddTag("db.cosmosdb.status_code", "200");
-
-                Assert.IsFalse(SdkInternalOperationsMonitor.IsEntered());
                 listener.StopActivity(sendActivity, null);
 
                 var telemetry = this.sentItems.Last();

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1397,6 +1397,75 @@
             }
         }
 
+        [TestMethod]
+        public void AzureCosmosDbClientSpansSuppressNestedOperations()
+        {
+            using (var listener = new DiagnosticListener("Azure.Cosmos"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity sendActivity = new Activity("Azure.Cosmos.ReadItems")
+                    .AddTag("kind", "client")
+                    .AddTag("net.peer.name", "my.documents.azure.com")
+                    .AddTag("db.name", "database")
+                    .AddTag("db.operation", "ReadItems")
+                    .AddTag("db.cosmosdb.container", "container")
+                    .AddTag("az.namespace", "Microsoft.DocumentDB");
+
+                listener.StartActivity(sendActivity, null);
+                sendActivity.AddTag("db.cosmosdb.status_code", "200");
+                
+                Assert.IsTrue(SdkInternalOperationsMonitor.IsEntered());
+                listener.StopActivity(sendActivity, null);
+                Assert.IsFalse(SdkInternalOperationsMonitor.IsEntered());
+
+                var telemetry = this.sentItems.Last();
+                DependencyTelemetry dependency = telemetry as DependencyTelemetry;
+                Assert.AreEqual("container | ReadItems", dependency.Name);
+                Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
+                Assert.AreEqual("200", dependency.ResultCode);
+                Assert.AreEqual("Microsoft.DocumentDB", dependency.Type);
+                Assert.AreEqual("database", dependency.Properties["db.name"]);
+                Assert.AreEqual("ReadItems", dependency.Properties["db.operation"]);
+                Assert.AreEqual("my.documents.azure.com", dependency.Properties["net.peer.name"]);
+            }
+        }
+
+        [TestMethod]
+        public void AzureCosmosDbInternalSpansDontSuppressNestedOperations()
+        {
+            using (var listener = new DiagnosticListener("Azure.Cosmos"))
+            using (var module = new DependencyTrackingTelemetryModule())
+            {
+                module.Initialize(this.configuration);
+
+                Activity sendActivity = new Activity("Azure.Cosmos.ReadItems")
+                    .AddTag("kind", "internal")
+                    .AddTag("net.peer.name", "my.documents.azure.com")
+                    .AddTag("db.name", "database")
+                    .AddTag("db.operation", "ReadItems")
+                    .AddTag("db.cosmosdb.container", "container")
+                    .AddTag("az.namespace", "Microsoft.DocumentDB");
+
+                listener.StartActivity(sendActivity, null);
+                sendActivity.AddTag("db.cosmosdb.status_code", "200");
+
+                Assert.IsFalse(SdkInternalOperationsMonitor.IsEntered());
+                listener.StopActivity(sendActivity, null);
+
+                var telemetry = this.sentItems.Last();
+                DependencyTelemetry dependency = telemetry as DependencyTelemetry;
+                Assert.AreEqual("container | ReadItems", dependency.Name);
+                Assert.AreEqual("my.documents.azure.com | database", dependency.Target);
+                Assert.AreEqual("200", dependency.ResultCode);
+                Assert.AreEqual("InProc | Microsoft.DocumentDB", dependency.Type);
+                Assert.AreEqual("database", dependency.Properties["db.name"]);
+                Assert.AreEqual("ReadItems", dependency.Properties["db.operation"]);
+                Assert.AreEqual("my.documents.azure.com", dependency.Properties["net.peer.name"]);
+            }
+        }
+
 #if !NET452
         [TestMethod]
         public void AzureCosmosDbSpansAreCollectedWithLogs()

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -1578,7 +1578,7 @@
         class CosmosDbEventSource : EventSource
         {
             private CosmosDbEventSource()
-                : base("Azure.Cosmos_foo")
+                : base("Azure-Cosmos-Operation-Request-Diagnostics")
             {
             }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticListenerSubscriber.cs
@@ -15,7 +15,7 @@
         public AzureSdkDiagnosticListenerSubscriber(TelemetryConfiguration configuration) : base(configuration)
         {
             // listen to Cosmos EventSource only - other logs can be sent using ILogger
-            this.logsListener = new AzureSdkEventListener(this.Client, EventLevel.Informational, "Azure.Cosmos");
+            this.logsListener = new AzureSdkEventListener(this.Client, EventLevel.Informational, "Azure-Cosmos-Operation-Request-Diagnostics");
             this.Client.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("rdd" + RddSource.DiagnosticSourceListenerAzure + ":");
         }
 

--- a/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector/Implementation/AzureSdk/AzureSdkDiagnosticsEventHandler.cs
@@ -18,6 +18,8 @@
         // Microsoft.DocumentDB is an Azure Resource Provider namespace. We use it as a dependency span as-is
         // and portal will take care about visualizing it properly.
         private const string CosmosDBResourceProviderNs = "Microsoft.DocumentDB";
+        private const string ClientCosmosDbDependencyType = CosmosDBResourceProviderNs;
+        private const string InternalCosmosDbDependencyType = "InProc | " + CosmosDBResourceProviderNs;
 #if NET452
         private static readonly DateTimeOffset EpochStart = new DateTime(1970, 1, 1, 0, 0, 0, 0, System.DateTimeKind.Utc);
 #endif
@@ -41,15 +43,15 @@
         {
             try
             {
-                if (SdkInternalOperationsMonitor.IsEntered())
-                {
-                    // Because we support AAD, we must to check if an internal operation is being caught here (type = "InProc | Microsoft.AAD").
-                    return;
-                }
-
                 var currentActivity = Activity.Current;
                 if (evnt.Key.EndsWith(".Start", StringComparison.Ordinal))
                 {
+                    if (SdkInternalOperationsMonitor.IsEntered())
+                    {
+                        // Because we support AAD, we must to check if an internal operation is being caught here (type = "InProc | Microsoft.AAD").
+                        return;
+                    }
+
                     OperationTelemetry telemetry = null;
 
                     foreach (var tag in currentActivity.Tags)
@@ -71,6 +73,12 @@
                     if (IsMessagingDependency(type))
                     {
                         SetMessagingProperties(currentActivity, telemetry);
+                    } 
+                    else if (type == ClientCosmosDbDependencyType)
+                    {
+                        // client Cosmos spans come from new Cosmos SDK in Direct (TCP) mode. SDK might occasionally do
+                        // nested HTTP calls, but we'll suppress them because they are rare and break app-map
+                        SdkInternalOperationsMonitor.Enter();
                     }
 
                     if (this.linksPropertyFetcher.Fetch(evnt.Value) is IEnumerable<Activity> activityLinks)
@@ -88,7 +96,11 @@
                 }
                 else if (evnt.Key.EndsWith(".Stop", StringComparison.Ordinal))
                 {
-                    var telemetry = this.operationHolder.Get(currentActivity).Item1;
+                    var telemetry = this.operationHolder.Get(currentActivity)?.Item1;
+                    if (telemetry == null)
+                    {
+                        return;
+                    }
 
                     this.SetCommonProperties(evnt.Key, evnt.Value, currentActivity, telemetry);
 
@@ -102,8 +114,16 @@
                                 dependency.SetOperationDetail(evnt.Value.GetType().FullName, evnt.Value);
                             }
                         }
-                        else if (dependency.Type == CosmosDBResourceProviderNs)
+                        else if (dependency.Type == ClientCosmosDbDependencyType)
                         {
+                            SdkInternalOperationsMonitor.Exit();
+                            SetCosmosDbProperties(currentActivity, dependency);
+                        }
+                        else if (dependency.Type == InternalCosmosDbDependencyType)
+                        {
+                            // Internal cosmos spans come from SDK in Gateway mode - they are
+                            // logical operations. AppMap then uses HTTP spans to build cosmos node and 
+                            // metrics on it
                             SetCosmosDbProperties(currentActivity, dependency);
                         }
                     }


### PR DESCRIPTION
Addressing portal team feedback on new Cosmos instrumentation:
- in Direct (TCP mode), Cosmos will set Client kind on activities. Even though Cosmos uses TCP, some rare HTTP requests will be made under these activities, so there will be a few occasional client->client spans. 
- In Gateway (HTTP mode), Cosmos will set Internal kind on activities. Users are expected to get both internal (logical) activities and nested HTTP calls. 