### PR TITLE
fix: catch exceptions thrown in TelemetryProcessor

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/TelemetryProcessorChainTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/TelemetryProcessorChainTests.cs
@@ -1,0 +1,44 @@
+﻿namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementation
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation;
+    using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+    [TestClass]
+    public class TelemetryProcessorChainTests
+    {
+        [TestMethod]
+        public void VerefyTelemetryProcessorChainHandlesExceptions()
+        {
+            var telemetryProcessor = new ExceptionTelemetryProcessor();
+
+            var processorChain = new TelemetryProcessorChain(new ITelemetryProcessor[] { telemetryProcessor});
+
+            var telemetry = new EventTelemetry("test telemetry");
+
+            // Verify Does Not Throw
+            processorChain.Process(telemetry);
+
+            // Verify Processor was invoked
+            Assert.AreEqual(1, telemetryProcessor.InvokedCount);
+        }
+
+        internal class ExceptionTelemetryProcessor : ITelemetryProcessor
+        {
+            public int InvokedCount { get; set; }
+
+            public void Process(ITelemetry item)
+            {
+                this.InvokedCount++;
+                throw new Exception("test");
+            }
+        }
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
@@ -58,8 +58,8 @@
         {
             try
             {
-            this.telemetryProcessors.First().Process(item);
-        }
+                this.telemetryProcessors.First().Process(item);
+            }
             catch (Exception ex)
             {
                 CoreEventSource.Log.TelemetryProcessorFailed(item, ex);

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
@@ -2,9 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Globalization;
     using System.Linq;
     using System.Text;
     using Microsoft.ApplicationInsights.Channel;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
 
     /// <summary>
     /// Represents the TelemetryProcessor chain. Clients should use TelemetryProcessorChainBuilder to construct this object.
@@ -54,7 +56,14 @@
         /// </summary>        
         public void Process(ITelemetry item)
         {
+            try
+            {
             this.telemetryProcessors.First().Process(item);
+        }
+            catch (Exception ex)
+            {
+                CoreEventSource.Log.TelemetryProcessorFailed(item, ex);
+            }
         }
 
         /// <summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
+    using System.Globalization;
+    using Microsoft.ApplicationInsights.Channel;
 
 #if REDFIELD
     [EventSource(Name = "Redfield-Microsoft-ApplicationInsights-Core")]
@@ -681,6 +683,15 @@
             if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
             {
                 this.TransmissionStatusEventError(ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void TelemetryProcessorFailed(ITelemetry telemetryItem, Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+            {
+                this.LogError(string.Format(CultureInfo.InvariantCulture, "Exception while processing {0}: {1}", telemetryItem.GetType().Name, ex));
             }
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -3,8 +3,6 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
-    using System.Globalization;
-    using Microsoft.ApplicationInsights.Channel;
 
 #if REDFIELD
     [EventSource(Name = "Redfield-Microsoft-ApplicationInsights-Core")]
@@ -68,7 +66,7 @@
                 msg ?? string.Empty,
                 this.nameProvider.Name);
         }
-
+        
         [Event(
             4,
             Keywords = Keywords.Diagnostics | Keywords.UserActionable,
@@ -104,7 +102,7 @@
             string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                6,
+                6, 
                 exception ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -130,7 +128,7 @@
         {
             this.WriteEvent(8, this.nameProvider.Name);
         }
-
+        
         [Event(
             9,
             Message = "No Telemetry Configuration provided. Using the default TelemetryConfiguration.Active.",
@@ -147,8 +145,8 @@
         public void PopulateRequiredStringWithValue(string parameterName, string telemetryType, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                10,
-                parameterName ?? string.Empty,
+                10, 
+                parameterName ?? string.Empty, 
                 telemetryType ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -188,7 +186,7 @@
         public void LogError(string msg, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                14,
+                14, 
                 msg ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -384,7 +382,7 @@
         {
             this.WriteEvent(
                 29,
-                maxBacklogSize,
+                maxBacklogSize,               
                 this.nameProvider.Name);
         }
 
@@ -583,7 +581,7 @@
 
         [Event(50, Message = "Connection String contains invalid delimiters and cannot be parsed.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringInvalidDelimiters(string appDomainName = "Incorrect") => this.WriteEvent(50, this.nameProvider.Name);
-
+        
         [Event(51, Message = "Connection String cannot be NULL.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringNull(string appDomainName = "Incorrect") => this.WriteEvent(51, this.nameProvider.Name);
 
@@ -683,15 +681,6 @@
             if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
             {
                 this.TransmissionStatusEventError(ex.ToInvariantString());
-            }
-        }
-
-        [NonEvent]
-        public void TelemetryProcessorFailed(ITelemetry telemetryItem, Exception ex)
-        {
-            if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
-            {
-                this.LogError(string.Format(CultureInfo.InvariantCulture,"Exception while processing {0}: {1}", telemetryItem.GetType().Name, ex));
             }
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -3,6 +3,8 @@
     using System;
     using System.Diagnostics.CodeAnalysis;
     using System.Diagnostics.Tracing;
+    using System.Globalization;
+    using Microsoft.ApplicationInsights.Channel;
 
 #if REDFIELD
     [EventSource(Name = "Redfield-Microsoft-ApplicationInsights-Core")]
@@ -66,7 +68,7 @@
                 msg ?? string.Empty,
                 this.nameProvider.Name);
         }
-        
+
         [Event(
             4,
             Keywords = Keywords.Diagnostics | Keywords.UserActionable,
@@ -102,7 +104,7 @@
             string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                6, 
+                6,
                 exception ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -128,7 +130,7 @@
         {
             this.WriteEvent(8, this.nameProvider.Name);
         }
-        
+
         [Event(
             9,
             Message = "No Telemetry Configuration provided. Using the default TelemetryConfiguration.Active.",
@@ -145,8 +147,8 @@
         public void PopulateRequiredStringWithValue(string parameterName, string telemetryType, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                10, 
-                parameterName ?? string.Empty, 
+                10,
+                parameterName ?? string.Empty,
                 telemetryType ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -186,7 +188,7 @@
         public void LogError(string msg, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
-                14, 
+                14,
                 msg ?? string.Empty,
                 this.nameProvider.Name);
         }
@@ -382,7 +384,7 @@
         {
             this.WriteEvent(
                 29,
-                maxBacklogSize,               
+                maxBacklogSize,
                 this.nameProvider.Name);
         }
 
@@ -581,7 +583,7 @@
 
         [Event(50, Message = "Connection String contains invalid delimiters and cannot be parsed.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringInvalidDelimiters(string appDomainName = "Incorrect") => this.WriteEvent(50, this.nameProvider.Name);
-        
+
         [Event(51, Message = "Connection String cannot be NULL.", Level = EventLevel.Error, Keywords = Keywords.UserActionable)]
         public void ConnectionStringNull(string appDomainName = "Incorrect") => this.WriteEvent(51, this.nameProvider.Name);
 
@@ -681,6 +683,15 @@
             if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
             {
                 this.TransmissionStatusEventError(ex.ToInvariantString());
+            }
+        }
+
+        [NonEvent]
+        public void TelemetryProcessorFailed(ITelemetry telemetryItem, Exception ex)
+        {
+            if (this.IsEnabled(EventLevel.Error, (EventKeywords)(-1)))
+            {
+                this.LogError(string.Format(CultureInfo.InvariantCulture,"Exception while processing {0}: {1}", telemetryItem.GetType().Name, ex));
             }
         }
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [Upgrade System.Diagnostics.PerformanceCounter to version 6.0.0 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)
+- [Fix: Catch Exceptions thrown from TelemetryProcessor](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2729)
 
 ## Version 2.22.0-beta1
 - Update endpoint redirect header name for QuickPulse module to v2


### PR DESCRIPTION
Fix Issue #2728 .

## Changes
- add exception handling to `TelemetryProcessorChain`.
- add unit test

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
