### PR TITLE
Fix bug in ETW message

### DIFF
--- a/WEB/Src/WindowsServer/WindowsServer/Implementation/WindowsServerEventSource.cs
+++ b/WEB/Src/WindowsServer/WindowsServer/Implementation/WindowsServerEventSource.cs
@@ -135,7 +135,7 @@
             this.WriteEvent(13, exception, this.applicationNameProvider.Name);
         }
 
-        [Event(14, Message = "Unknown error occured in {0}. Exception: {0}", Level = EventLevel.Error)]
+        [Event(14, Message = "Unknown error occured in {0}. Exception: {1}", Level = EventLevel.Error)]
         public void UnknownErrorOccured(string source, string exception, string applicationName = "Incorrect")
         {
             this.WriteEvent(14, source, exception, this.applicationNameProvider.Name);


### PR DESCRIPTION
Fix Issue # .

## Changes
Fix bug in ETW message. The second `{0}` seems like a bug. When troubleshooting an issue from this exception, it'd be helpful to have the information from the exception.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

<!--
For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
-->