### PR TITLE
#2714

### DIFF
--- a/LOGGING/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/LOGGING/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
 
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Implementation;
 
@@ -31,6 +32,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         private TelemetryClient telemetryClient;
         private DateTime lastLogEventTime;
         private NLog.Layouts.Layout instrumentationKeyLayout = string.Empty;
+        private NLog.Layouts.Layout connectionStringLayout = string.Empty;
 
         /// <summary>
         /// Initializers a new instance of ApplicationInsightsTarget type.
@@ -48,6 +50,15 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         {
             get => (this.instrumentationKeyLayout as NLog.Layouts.SimpleLayout)?.Text ?? null;
             set => this.instrumentationKeyLayout = value ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets or sets the Application Insights connectionstring for your application
+        /// </summary>
+        public string ConnectionString
+        {
+            get => (this.connectionStringLayout as NLog.Layouts.SimpleLayout)?.Text ?? null;
+            set => this.connectionStringLayout = value ?? string.Empty;
         }
 
         /// <summary>
@@ -118,10 +129,24 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             this.telemetryClient = new TelemetryClient();
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            string instrumentationKey = this.instrumentationKeyLayout.Render(LogEventInfo.CreateNullEvent());
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            string connectionString = this.connectionStringLayout.Render(LogEventInfo.CreateNullEvent());
+           
+            // Check if nlog application insights target has connectionstring in config file then
+            // configure telemetryclient with the connectionstring otherwise using instrumentationkey.
+            if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
+                var configuration = TelemetryConfiguration.CreateDefault();
+                configuration.ConnectionString = connectionString;
+
+                this.telemetryClient.TelemetryConfiguration.ConnectionString = connectionString;
+            }
+            else
+            {
+                string instrumentationKey = this.instrumentationKeyLayout.Render(LogEventInfo.CreateNullEvent());
+                if (!string.IsNullOrWhiteSpace(instrumentationKey))
+                {
+                    this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
+                }
             }
 
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("nlog:");

--- a/LOGGING/test/Shared/AdapterHelper.cs
+++ b/LOGGING/test/Shared/AdapterHelper.cs
@@ -19,6 +19,8 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
     {
         public string InstrumentationKey { get; }
 
+        public string ConnectionString { get; }
+
 #if NET452 || NET46
         private static readonly string ApplicationInsightsConfigFilePath =
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ApplicationInsights.config");
@@ -27,16 +29,19 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
             Path.Combine(Path.GetDirectoryName(typeof(AdapterHelper).GetTypeInfo().Assembly.Location), "ApplicationInsights.config");
 #endif
 
-        public AdapterHelper(string instrumentationKey = "F8474271-D231-45B6-8DD4-D344C309AE69")
+        public AdapterHelper(string instrumentationKey = "F8474271-D231-45B6-8DD4-D344C309AE69", 
+            string connectionString= "Your_ApplicationInsights_ConnectionString")
         {
             this.InstrumentationKey = instrumentationKey;
+            this.ConnectionString = connectionString;
 
             string configuration = string.Format(InvariantCulture,
                                     @"<?xml version=""1.0"" encoding=""utf-8"" ?>
                                      <ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
                                         <InstrumentationKey>{0}</InstrumentationKey>
+                                        <ConnectionString>{1}</ConnectionString>
                                      </ApplicationInsights>",
-                                     instrumentationKey);
+                                     instrumentationKey, connectionString);
 
             File.WriteAllText(ApplicationInsightsConfigFilePath, configuration);
             this.Channel = new CustomTelemetryChannel();


### PR DESCRIPTION
Add support for connection string to Microsoft.ApplicationInsights.NLogTarget #2714

Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [x] Design discussion issue #
- [x] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
