### PR TITLE
Fix typo in MetricManager.cs

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricManager.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricManager.cs
@@ -9,7 +9,7 @@
 
     /// <summary>A metric manager coordinates metrics aggregation at a specific scope.
     /// It keeps track of the known metrics and is ultimately responsibe for correctly
-    /// initializeing metric data time series.
+    /// initializing metric data time series.
     /// Note that a metric manager deals with zero dimensional time series.
     /// Metric objects are multidimensional collections of such series and the manager 
     /// merely holds a collection of such containers for its scope.</summary>

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricManager.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricManager.cs
@@ -8,7 +8,7 @@
     using Microsoft.ApplicationInsights.Metrics.Extensibility;
 
     /// <summary>A metric manager coordinates metrics aggregation at a specific scope.
-    /// It keeps track of the known metrics and is ultimataly respnsibe for correctly
+    /// It keeps track of the known metrics and is ultimately responsibe for correctly
     /// initializeing metric data time series.
     /// Note that a metric manager deals with zero dimensional time series.
     /// Metric objects are multidimensional collections of such series and the manager 


### PR DESCRIPTION
## Changes
Fixed some typo's in the XML docs of the MetricManage. I came across this on the [(generated) docs](https://learn.microsoft.com/en-us/dotnet/api/microsoft.applicationinsights.metrics.metricmanager?view=azure-dotnet). I assume this is generated from the summary provided in this class.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
