### PR TITLE
ITelemetryClient to facilitate testing/mocking

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/ITelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/ITelemetryClient.cs
@@ -3,86 +3,33 @@
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
-    using System.Globalization;
     using System.Threading;
     using System.Threading.Tasks;
-    using Microsoft.ApplicationInsights.Channel;
-    using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Platform;
-    using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
-    using Microsoft.ApplicationInsights.Metrics;
-    using Microsoft.ApplicationInsights.Metrics.Extensibility;
+    using Channel;
+    using DataContracts;
+    using Extensibility;
+    using Metrics;
 
     /// <summary>
     /// Send events, metrics and other telemetry to the Application Insights service.
     /// <a href="https://go.microsoft.com/fwlink/?linkid=525722">Learn more</a>
     /// </summary>
-    public sealed class TelemetryClient : ITelemetryClient
+    public interface ITelemetryClient
     {
-#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
-        private const string VersionPrefix = "dotnetc:";
-#else
-        private const string VersionPrefix = "dotnet:";
-#endif  
-        private readonly TelemetryConfiguration configuration;
-
-        private string sdkVersion;
-
-#pragma warning disable 612, 618 // TelemetryConfiguration.Active
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the active configuration, usually loaded from ApplicationInsights.config.
-        /// </summary>
-#if NETSTANDARD // This constant is defined for all versions of NetStandard https://docs.microsoft.com/en-us/dotnet/core/tutorials/libraries#how-to-multitarget
-        [Obsolete("We do not recommend using TelemetryConfiguration.Active on .NET Core. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/1152 for more details")]
-#endif
-        public TelemetryClient() : this(TelemetryConfiguration.Active)
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TelemetryClient" /> class. Send telemetry with the specified <paramref name="configuration"/>.
-        /// </summary>
-        /// <exception cref="ArgumentNullException">The <paramref name="configuration"/> is null.</exception>
-        /// <exception cref="ArgumentException">The <paramref name="configuration"/> does not contain a telemetry channel.</exception>
-        public TelemetryClient(TelemetryConfiguration configuration)
-        {
-            if (configuration == null)
-            {
-                CoreEventSource.Log.TelemetryClientConstructorWithNoTelemetryConfiguration();
-                configuration = TelemetryConfiguration.Active;
-            }
-
-            this.configuration = configuration;
-
-            if (this.configuration.TelemetryChannel == null)
-            {
-                throw new ArgumentException("The specified configuration does not have a telemetry channel.", nameof(configuration));
-            }
-        }
-#pragma warning restore 612, 618 // TelemetryConfiguration.Active
-
         /// <summary>
         /// Gets the current context that will be used to augment telemetry you send.
         /// </summary>
-        public TelemetryContext Context
-        {
-            get;
-            internal set;
-        }
-
-        = new TelemetryContext();
+        TelemetryContext Context { get; }
 
         /// <summary>
         /// Gets or sets the default instrumentation key for all <see cref="ITelemetry"/> objects logged in this <see cref="TelemetryClient"/>.
         /// </summary>
-        public string InstrumentationKey
+        string InstrumentationKey
         {
-            get => this.Context.InstrumentationKey;
+            get;
 
             [Obsolete("InstrumentationKey based global ingestion is being deprecated. Recommended to set TelemetryConfiguration.ConnectionString. See https://github.com/microsoft/ApplicationInsights-dotnet/issues/2560 for more details.")]
-            set { this.Context.InstrumentationKey = value; }
+            set;
         }
 
         /// <summary>
@@ -90,18 +37,12 @@
         /// Changes made to the configuration can affect other clients.
         /// </summary>
         [EditorBrowsable(EditorBrowsableState.Never)]
-        public TelemetryConfiguration TelemetryConfiguration
-        {
-            get { return this.configuration; }
-        }
+        TelemetryConfiguration TelemetryConfiguration { get; }
 
         /// <summary>
         /// Check to determine if the tracking is enabled.
         /// </summary>
-        public bool IsEnabled()
-        {
-            return !this.configuration.DisableTelemetry;
-        }
+        bool IsEnabled();
 
         /// <summary>
         /// Send an <see cref="EventTelemetry"/> for display in Diagnostic Search and in the Analytics Portal.
@@ -112,22 +53,8 @@
         /// <param name="eventName">A name for the event.</param>
         /// <param name="properties">Named string values you can use to search and classify events.</param>
         /// <param name="metrics">Measurements associated with this event.</param>
-        public void TrackEvent(string eventName, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
-        {
-            var telemetry = new EventTelemetry(eventName);
-
-            if (properties != null && properties.Count > 0)
-            {
-                Utils.CopyDictionary(properties, telemetry.Properties);
-            }
-
-            if (metrics != null && metrics.Count > 0)
-            {
-                Utils.CopyDictionary(metrics, telemetry.Metrics);
-            }
-
-            this.TrackEvent(telemetry);
-        }
+        void TrackEvent(string eventName, IDictionary<string, string> properties = null,
+            IDictionary<string, double> metrics = null);
 
         /// <summary>
         /// Send an <see cref="EventTelemetry"/> for display in Diagnostic Search and in the Analytics Portal.
@@ -137,15 +64,7 @@
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackevent">Learn more</a>
         /// </remarks>
         /// <param name="telemetry">An event log item.</param>
-        public void TrackEvent(EventTelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                telemetry = new EventTelemetry();
-            }
-
-            this.Track(telemetry);
-        }
+        void TrackEvent(EventTelemetry telemetry);
 
         /// <summary>
         /// Send a trace message for display in Diagnostic Search.
@@ -154,10 +73,7 @@
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#tracktrace">Learn more</a>
         /// </remarks>
         /// <param name="message">Message to display.</param>
-        public void TrackTrace(string message)
-        {
-            this.TrackTrace(new TraceTelemetry(message));
-        }
+        void TrackTrace(string message);
 
         /// <summary>
         /// Send a trace message for display in Diagnostic Search.
@@ -167,10 +83,7 @@
         /// </remarks>
         /// <param name="message">Message to display.</param>
         /// <param name="severityLevel">Trace severity level.</param>
-        public void TrackTrace(string message, SeverityLevel severityLevel)
-        {
-            this.TrackTrace(new TraceTelemetry(message, severityLevel));
-        }
+        void TrackTrace(string message, SeverityLevel severityLevel);
 
         /// <summary>
         /// Send a trace message for display in Diagnostic Search.
@@ -180,17 +93,7 @@
         /// </remarks>
         /// <param name="message">Message to display.</param>
         /// <param name="properties">Named string values you can use to search and classify events.</param>
-        public void TrackTrace(string message, IDictionary<string, string> properties)
-        {
-            TraceTelemetry telemetry = new TraceTelemetry(message);
-
-            if (properties != null && properties.Count > 0)
-            {
-                Utils.CopyDictionary(properties, telemetry.Properties);
-            }
-
-            this.TrackTrace(telemetry);
-        }
+        void TrackTrace(string message, IDictionary<string, string> properties);
 
         /// <summary>
         /// Send a trace message for display in Diagnostic Search.
@@ -201,17 +104,7 @@
         /// <param name="message">Message to display.</param>
         /// <param name="severityLevel">Trace severity level.</param>
         /// <param name="properties">Named string values you can use to search and classify events.</param>
-        public void TrackTrace(string message, SeverityLevel severityLevel, IDictionary<string, string> properties)
-        {
-            TraceTelemetry telemetry = new TraceTelemetry(message, severityLevel);
-
-            if (properties != null && properties.Count > 0)
-            {
-                Utils.CopyDictionary(properties, telemetry.Properties);
-            }
-
-            this.TrackTrace(telemetry);
-        }
+        void TrackTrace(string message, SeverityLevel severityLevel, IDictionary<string, string> properties);
 
         /// <summary>
         /// Send a trace message for display in Diagnostic Search.
@@ -221,11 +114,7 @@
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#tracktrace">Learn more</a>
         /// </remarks>
         /// <param name="telemetry">Message with optional properties.</param>
-        public void TrackTrace(TraceTelemetry telemetry)
-        {
-            telemetry = telemetry ?? new TraceTelemetry();
-            this.Track(telemetry);
-        }
+        void TrackTrace(TraceTelemetry telemetry);
 
         /// <summary>
         /// This method is not the preferred method for sending metrics.
@@ -238,16 +127,7 @@
         /// <param name="name">Metric name.</param>
         /// <param name="value">Metric value.</param>
         /// <param name="properties">Named string values you can use to classify and filter metrics.</param>        
-        public void TrackMetric(string name, double value, IDictionary<string, string> properties = null)
-        {
-            var telemetry = new MetricTelemetry(name, value);
-            if (properties != null && properties.Count > 0)
-            {
-                Utils.CopyDictionary(properties, telemetry.Properties);
-            }
-
-            this.TrackMetric(telemetry);
-        }
+        void TrackMetric(string name, double value, IDictionary<string, string> properties = null);
 
         /// <summary>
         /// This method is not the preferred method for sending metrics.
@@ -258,15 +138,7 @@
         /// you likely have a use case for event telemetry; see <see cref="TrackEvent(EventTelemetry)"/>.
         /// </summary>
         /// <param name="telemetry">The metric telemetry item.</param>        
-        public void TrackMetric(MetricTelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                telemetry = new MetricTelemetry();
-            }
-
-            this.Track(telemetry);
-        }
+        void TrackMetric(MetricTelemetry telemetry);
 
         /// <summary>
         /// Send an <see cref="ExceptionTelemetry"/> for display in Diagnostic Search.
@@ -277,27 +149,8 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackexception">Learn more</a>
         /// </remarks>
-        public void TrackException(Exception exception, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
-        {
-            if (exception == null)
-            {
-                exception = new Exception(Utils.PopulateRequiredStringValue(null, "message", typeof(ExceptionTelemetry).FullName));
-            }
-
-            var telemetry = new ExceptionTelemetry(exception);
-
-            if (properties != null && properties.Count > 0)
-            {
-                Utils.CopyDictionary(properties, telemetry.Properties);
-            }
-
-            if (metrics != null && metrics.Count > 0)
-            {
-                Utils.CopyDictionary(metrics, telemetry.Metrics);
-            }
-
-            this.TrackException(telemetry);
-        }
+        void TrackException(Exception exception, IDictionary<string, string> properties = null,
+            IDictionary<string, double> metrics = null);
 
         /// <summary>
         /// Send an <see cref="ExceptionTelemetry"/> for display in Diagnostic Search.
@@ -306,16 +159,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackexception">Learn more</a>
         /// </remarks>
-        public void TrackException(ExceptionTelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                var exception = new Exception(Utils.PopulateRequiredStringValue(null, "message", typeof(ExceptionTelemetry).FullName));
-                telemetry = new ExceptionTelemetry(exception);
-            }
-
-            this.Track(telemetry);
-        }
+        void TrackException(ExceptionTelemetry telemetry);
 
         /// <summary>
         /// Send information about an external dependency (outgoing call) in the application.
@@ -329,12 +173,8 @@
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackdependency">Learn more</a>
         /// </remarks>
         [Obsolete("Please use a different overload of TrackDependency")]
-        public void TrackDependency(string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success)
-        {
-#pragma warning disable 618
-            this.TrackDependency(new DependencyTelemetry(dependencyName, data, startTime, duration, success));
-#pragma warning restore 618
-        }
+        void TrackDependency(string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration,
+            bool success);
 
         /// <summary>
         /// Send information about an external dependency (outgoing call) in the application.
@@ -348,10 +188,8 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackdependency">Learn more</a>
         /// </remarks>
-        public void TrackDependency(string dependencyTypeName, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, bool success)
-        {
-            this.TrackDependency(new DependencyTelemetry(dependencyTypeName, null, dependencyName, data, startTime, duration, null, success));
-        }
+        void TrackDependency(string dependencyTypeName, string dependencyName, string data, DateTimeOffset startTime,
+            TimeSpan duration, bool success);
 
         /// <summary>
         /// Send information about an external dependency (outgoing call) in the application.
@@ -367,10 +205,8 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackdependency">Learn more</a>
         /// </remarks>
-        public void TrackDependency(string dependencyTypeName, string target, string dependencyName, string data, DateTimeOffset startTime, TimeSpan duration, string resultCode, bool success)
-        {
-            this.TrackDependency(new DependencyTelemetry(dependencyTypeName, target, dependencyName, data, startTime, duration, resultCode, success));
-        }
+        void TrackDependency(string dependencyTypeName, string target, string dependencyName, string data,
+            DateTimeOffset startTime, TimeSpan duration, string resultCode, bool success);
 
         /// <summary>
         /// Send information about external dependency call in the application.
@@ -379,15 +215,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackdependency">Learn more</a>
         /// </remarks>
-        public void TrackDependency(DependencyTelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                telemetry = new DependencyTelemetry();
-            }
-
-            this.Track(telemetry);
-        }
+        void TrackDependency(DependencyTelemetry telemetry);
 
         /// <summary>
         /// Send information about availability of an application.
@@ -403,22 +231,9 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=517889">Learn more</a>
         /// </remarks>
-        public void TrackAvailability(string name, DateTimeOffset timeStamp, TimeSpan duration, string runLocation, bool success, string message = null, IDictionary<string, string> properties = null, IDictionary<string, double> metrics = null)
-        {
-            var availabilityTelemetry = new AvailabilityTelemetry(name, timeStamp, duration, runLocation, success, message);
-
-            if (properties != null && properties.Count > 0)
-            {
-                Utils.CopyDictionary(properties, availabilityTelemetry.Properties);
-            }
-
-            if (metrics != null && metrics.Count > 0)
-            {
-                Utils.CopyDictionary(metrics, availabilityTelemetry.Metrics);
-            }
-
-            this.TrackAvailability(availabilityTelemetry);
-        }
+        void TrackAvailability(string name, DateTimeOffset timeStamp, TimeSpan duration, string runLocation,
+            bool success, string message = null, IDictionary<string, string> properties = null,
+            IDictionary<string, double> metrics = null);
 
         /// <summary>
         /// Send information about availability of an application.
@@ -427,170 +242,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=517889">Learn more</a>
         /// </remarks>
-        public void TrackAvailability(AvailabilityTelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                telemetry = new AvailabilityTelemetry();
-            }
-
-            this.Track(telemetry);
-        }
-
-        /// <summary>
-        /// This method is an internal part of Application Insights infrastructure. Do not call.
-        /// </summary>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Track(ITelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                throw new ArgumentNullException(nameof(telemetry));
-            }
-
-            // TALK TO YOUR TEAM MATES BEFORE CHANGING THIS.
-            // This method needs to be public so that we can build and ship new telemetry types without having to ship core.
-            // It is hidden from intellisense to prevent customer confusion.
-            if (this.IsEnabled())
-            {
-                this.Initialize(telemetry);
-
-                telemetry.Context.ClearTempRawObjects();
-
-                // invokes the Process in the first processor in the chain
-                this.configuration.TelemetryProcessorChain.Process(telemetry);
-
-                // logs rich payload ETW event for any partners to process it
-                RichPayloadEventSource.Log.Process(telemetry);
-            }
-        }
-
-        /// <summary>
-        /// This method is an internal part of Application Insights infrastructure. Do not call.
-        /// </summary>
-        /// <param name="telemetry">Telemetry item to initialize instrumentation key.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void InitializeInstrumentationKey(ITelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                throw new ArgumentNullException(nameof(telemetry));
-            }
-
-            string instrumentationKey = this.Context.InstrumentationKey;
-
-            if (string.IsNullOrEmpty(instrumentationKey))
-            {
-                instrumentationKey = this.configuration.InstrumentationKey;
-            }
-
-            telemetry.Context.InitializeInstrumentationkey(instrumentationKey);
-        }
-
-        /// <summary>
-        /// This method is an internal part of Application Insights infrastructure. Do not call.
-        /// </summary>
-        /// <param name="telemetry">Telemetry item to initialize.</param>
-        [EditorBrowsable(EditorBrowsableState.Never)]
-        public void Initialize(ITelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                throw new ArgumentNullException(nameof(telemetry));
-            }
-
-            ISupportAdvancedSampling telemetryWithSampling = telemetry as ISupportAdvancedSampling;
-
-            // Telemetry can be already sampled out if that decision was made before calling Track()
-            bool sampledOut = false;
-            if (telemetryWithSampling != null)
-            {
-                sampledOut = telemetryWithSampling.ProactiveSamplingDecision == SamplingDecision.SampledOut;
-            }
-
-            if (!sampledOut)
-            {
-                if (telemetry is ISupportProperties telemetryWithProperties)
-                {
-                    if (this.configuration.TelemetryChannel?.DeveloperMode != null && this.configuration.TelemetryChannel.DeveloperMode.Value)
-                    {
-                        if (!telemetryWithProperties.Properties.ContainsKey("DeveloperMode"))
-                        {
-                            telemetryWithProperties.Properties.Add("DeveloperMode", "true");
-                        }
-                    }
-                }
-
-                // Properties set of TelemetryClient's Context are copied over to that of ITelemetry's Context
-#pragma warning disable CS0618 // Type or member is obsolete
-                if (this.Context.PropertiesValue != null)
-                {
-                    Utils.CopyDictionary(this.Context.Properties, telemetry.Context.Properties);
-                }
-
-#pragma warning restore CS0618 // Type or member is obsolete
-
-                // This check avoids accessing the public accessor GlobalProperties
-                // unless needed, to avoid the penalty of ConcurrentDictionary instantiation.
-                if (this.Context.GlobalPropertiesValue != null)
-                {
-                    Utils.CopyDictionary(this.Context.GlobalProperties, telemetry.Context.GlobalProperties);
-                }
-
-                string instrumentationKey = this.Context.InstrumentationKey;
-
-                if (string.IsNullOrEmpty(instrumentationKey))
-                {
-                    instrumentationKey = this.configuration.InstrumentationKey;
-                }
-
-                telemetry.Context.Initialize(this.Context, instrumentationKey);
-
-                for (int index = 0; index < this.configuration.TelemetryInitializers.Count; index++)
-                {
-                    try
-                    {
-                        this.configuration.TelemetryInitializers[index].Initialize(telemetry);
-                    }
-                    catch (Exception exception)
-                    {
-                        CoreEventSource.Log.LogError(string.Format(
-                                                        CultureInfo.InvariantCulture,
-                                                        "Exception while initializing {0}, exception message - {1}",
-                                                        this.configuration.TelemetryInitializers[index].GetType().FullName,
-                                                        exception));
-                    }
-                }
-
-                if (telemetry.Timestamp == default(DateTimeOffset))
-                {
-                    telemetry.Timestamp = PreciseTimestamp.GetUtcNow();
-                }
-
-                // Currently backend requires SDK version to comply "name: version"
-                if (string.IsNullOrEmpty(telemetry.Context.Internal.SdkVersion))
-                {
-                    var version = this.sdkVersion ?? (this.sdkVersion = SdkVersionUtils.GetSdkVersion(VersionPrefix));
-                    telemetry.Context.Internal.SdkVersion = version;
-                }
-
-                // set NodeName to the machine name if it's not initialized yet, if RoleInstance is also not set then we send only RoleInstance
-                if (string.IsNullOrEmpty(telemetry.Context.Internal.NodeName) && !string.IsNullOrEmpty(telemetry.Context.Cloud.RoleInstance))
-                {
-                    telemetry.Context.Internal.NodeName = PlatformSingleton.Current.GetMachineName();
-                }
-
-                // set RoleInstance to the machine name if it's not initialized yet
-                if (string.IsNullOrEmpty(telemetry.Context.Cloud.RoleInstance))
-                {
-                    telemetry.Context.Cloud.RoleInstance = PlatformSingleton.Current.GetMachineName();
-                }
-            }
-            else
-            {
-                CoreEventSource.Log.InitializationIsSkippedForSampledItem();
-            }
-        }
+        void TrackAvailability(AvailabilityTelemetry telemetry);
 
         /// <summary>
         /// Send information about the page viewed in the application.
@@ -599,10 +251,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#page-views">Learn more</a>
         /// </remarks>
-        public void TrackPageView(string name)
-        {
-            this.Track(new PageViewTelemetry(name));
-        }
+        void TrackPageView(string name);
 
         /// <summary>
         /// Send information about the page viewed in the application.
@@ -611,15 +260,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#page-views">Learn more</a>
         /// </remarks>
-        public void TrackPageView(PageViewTelemetry telemetry)
-        {
-            if (telemetry == null)
-            {
-                telemetry = new PageViewTelemetry();
-            }
-
-            this.Track(telemetry);
-        }
+        void TrackPageView(PageViewTelemetry telemetry);
 
         /// <summary>
         /// Send information about a request handled by the application.
@@ -632,10 +273,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackrequest">Learn more</a>
         /// </remarks>
-        public void TrackRequest(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success)
-        {
-            this.Track(new RequestTelemetry(name, startTime, duration, responseCode, success));
-        }
+        void TrackRequest(string name, DateTimeOffset startTime, TimeSpan duration, string responseCode, bool success);
 
         /// <summary>
         /// Send information about a request handled by the application.
@@ -644,15 +282,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#trackrequest">Learn more</a>
         /// </remarks>
-        public void TrackRequest(RequestTelemetry request)
-        {
-            if (request == null)
-            {
-                request = new RequestTelemetry();
-            }
-
-            this.Track(request);
-        }
+        void TrackRequest(RequestTelemetry request);
 
         /// <summary>
         /// Flushes the in-memory buffer and any metrics being pre-aggregated.
@@ -660,25 +290,7 @@
         /// <remarks>
         /// <a href="https://go.microsoft.com/fwlink/?linkid=525722#flushing-data">Learn more</a>
         /// </remarks>
-        public void Flush()
-        {
-            CoreEventSource.Log.TelemetlyClientFlush();
-
-            if (this.TryGetMetricManager(out MetricManager privateMetricManager))
-            {
-                privateMetricManager.Flush(flushDownstreamPipeline: false);
-            }
-
-            TelemetryConfiguration pipeline = this.configuration;
-            if (pipeline != null)
-            {
-                MetricManager sharedMetricManager = pipeline.GetMetricManager(createIfNotExists: false);
-                sharedMetricManager?.Flush(flushDownstreamPipeline: false);
-
-                ITelemetryChannel channel = pipeline.TelemetryChannel;
-                channel?.Flush();
-            }
-        }
+        void Flush();
 
         /// <summary>
         /// Asynchronously Flushes the in-memory buffer and any metrics being pre-aggregated.
@@ -691,30 +303,7 @@
         /// Returns false when transfer of telemetry data to server has failed with non-retriable http status.
         /// FlushAsync on InMemoryChannel always returns true, as the channel offers minimal reliability guarantees and doesn't retry sending telemetry after a failure.
         /// </returns>
-        /// TODO: Metrics flush to respect CancellationToken.
-        public Task<bool> FlushAsync(CancellationToken cancellationToken)
-        {
-            if (this.TryGetMetricManager(out MetricManager privateMetricManager))
-            {
-                privateMetricManager.Flush(flushDownstreamPipeline: false);
-            }
-
-            TelemetryConfiguration pipeline = this.configuration;
-            if (pipeline != null)
-            {
-                MetricManager sharedMetricManager = pipeline.GetMetricManager(createIfNotExists: false);
-                sharedMetricManager?.Flush(flushDownstreamPipeline: false);
-
-                ITelemetryChannel channel = pipeline.TelemetryChannel;
-
-                if (channel is IAsyncFlushable asyncFlushableChannel && !cancellationToken.IsCancellationRequested)
-                {
-                    return asyncFlushableChannel.FlushAsync(cancellationToken);
-                }
-            }
-
-            return cancellationToken.IsCancellationRequested ? TaskEx.FromCanceled<bool>(cancellationToken) : Task.FromResult(false);
-        }
+        Task<bool> FlushAsync(CancellationToken cancellationToken);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -735,14 +324,7 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            string metricId)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(metricId),
-                        metricConfiguration: null);
-        }
+        Metric GetMetric(string metricId);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -765,15 +347,7 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            string metricId,
-                            MetricConfiguration metricConfiguration)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(metricId),
-                        metricConfiguration: metricConfiguration);
-        }
+        Metric GetMetric(string metricId, MetricConfiguration metricConfiguration);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -794,16 +368,10 @@
         /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
         /// <returns>A <see cref="Metric"/> instance that you can use to automatically aggregate and then sent metric data value.</returns>
-        public Metric GetMetric(
-                            string metricId,
-                            MetricConfiguration metricConfiguration,
-                            MetricAggregationScope aggregationScope)
-        {
-            return this.GetOrCreateMetric(
-                        aggregationScope,
-                        new MetricIdentifier(metricId),
-                        metricConfiguration: metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -823,15 +391,9 @@
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
         /// <returns>A <see cref="Metric"/> instance that you can use to automatically aggregate and then sent metric data value.</returns>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name),
-                        metricConfiguration: null);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -855,16 +417,10 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            MetricConfiguration metricConfiguration)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name),
-                        metricConfiguration: metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            MetricConfiguration metricConfiguration);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -885,17 +441,11 @@
         /// configuration used earlier.</exception>
         /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            MetricConfiguration metricConfiguration,
-                            MetricAggregationScope aggregationScope)
-        {
-            return this.GetOrCreateMetric(
-                        aggregationScope,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name),
-                        metricConfiguration: metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -916,16 +466,10 @@
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
         /// <returns>A <see cref="Metric"/> instance that you can use to automatically aggregate and then sent metric data value.</returns>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name),
-                        metricConfiguration: null);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -950,17 +494,11 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            MetricConfiguration metricConfiguration)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name),
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            MetricConfiguration metricConfiguration);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -982,18 +520,12 @@
         /// configuration used earlier.</exception>
         /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            MetricConfiguration metricConfiguration,
-                            MetricAggregationScope aggregationScope)
-        {
-            return this.GetOrCreateMetric(
-                        aggregationScope,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name),
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1015,17 +547,11 @@
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
         /// <returns>A <see cref="Metric"/> instance that you can use to automatically aggregate and then sent metric data value.</returns>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            string dimension3Name)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name),
-                        metricConfiguration: null);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            string dimension3Name);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1051,18 +577,12 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            string dimension3Name,
-                            MetricConfiguration metricConfiguration)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name),
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            string dimension3Name,
+            MetricConfiguration metricConfiguration);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1085,19 +605,13 @@
         /// configuration used earlier.</exception>
         /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            string dimension3Name,
-                            MetricConfiguration metricConfiguration,
-                            MetricAggregationScope aggregationScope)
-        {
-            return this.GetOrCreateMetric(
-                        aggregationScope,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name),
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            string dimension3Name,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1120,18 +634,12 @@
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
         /// <returns>A <see cref="Metric"/> instance that you can use to automatically aggregate and then sent metric data value.</returns>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            string dimension3Name,
-                            string dimension4Name)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name, dimension4Name),
-                        metricConfiguration: null);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            string dimension3Name,
+            string dimension4Name);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1158,19 +666,13 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            string dimension3Name,
-                            string dimension4Name,
-                            MetricConfiguration metricConfiguration)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name, dimension4Name),
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            string dimension3Name,
+            string dimension4Name,
+            MetricConfiguration metricConfiguration);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1194,20 +696,14 @@
         /// configuration used earlier.</exception>
         /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
-        public Metric GetMetric(
-                            string metricId,
-                            string dimension1Name,
-                            string dimension2Name,
-                            string dimension3Name,
-                            string dimension4Name,
-                            MetricConfiguration metricConfiguration,
-                            MetricAggregationScope aggregationScope)
-        {
-            return this.GetOrCreateMetric(
-                        aggregationScope,
-                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name, dimension4Name),
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            string metricId,
+            string dimension1Name,
+            string dimension2Name,
+            string dimension3Name,
+            string dimension4Name,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1224,14 +720,8 @@
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
         /// <returns>A <see cref="Metric"/> instance that you can use to automatically aggregate and then sent metric data value.</returns>
-        public Metric GetMetric(
-                            MetricIdentifier metricIdentifier)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        metricIdentifier,
-                        metricConfiguration: null);
-        }
+        Metric GetMetric(
+            MetricIdentifier metricIdentifier);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1252,15 +742,9 @@
         /// and aggregation scope, but with a different configuration. When calling this method to get a previously
         /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
         /// configuration used earlier.</exception>
-        public Metric GetMetric(
-                            MetricIdentifier metricIdentifier,
-                            MetricConfiguration metricConfiguration)
-        {
-            return this.GetOrCreateMetric(
-                        MetricAggregationScope.TelemetryConfiguration,
-                        metricIdentifier,
-                        metricConfiguration);
-        }
+        Metric GetMetric(
+            MetricIdentifier metricIdentifier,
+            MetricConfiguration metricConfiguration);
 
         /// <summary>
         /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
@@ -1278,25 +762,9 @@
         /// configuration used earlier.</exception>
         /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
-        public Metric GetMetric(
-                            MetricIdentifier metricIdentifier,
-                            MetricConfiguration metricConfiguration,
-                            MetricAggregationScope aggregationScope)
-        {
-            return this.GetOrCreateMetric(
-                        aggregationScope,
-                        metricIdentifier,
-                        metricConfiguration);
-        }
-
-        private Metric GetOrCreateMetric(
-                                    MetricAggregationScope aggregationScope,
-                                    MetricIdentifier metricIdentifier,
-                                    MetricConfiguration metricConfiguration)
-        {
-            MetricManager metricManager = this.GetMetricManager(aggregationScope);
-            Metric metric = metricManager.Metrics.GetOrCreate(metricIdentifier, metricConfiguration);
-            return metric;
-        }
+        Metric GetMetric(
+            MetricIdentifier metricIdentifier,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope);
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VNext
+- Add ITelemetryClient interface to TelemetryClient. Fixes ([#342](https://github.com/microsoft/ApplicationInsights-dotnet/issues/342))
 
 ## Version 2.22.0-beta2
 - [Upgrade System.Diagnostics.PerformanceCounter to version 6.0.0 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -363,6 +363,7 @@
             services.AddSingleton<TelemetryConfiguration>(provider =>
                 provider.GetService<IOptions<TelemetryConfiguration>>().Value);
             services.AddSingleton<TelemetryClient>();
+            services.AddSingleton<ITelemetryClient>(provider => provider.GetRequiredService<TelemetryClient>());
         }
 
         private static void AddAndConfigureDependencyTracking(IServiceCollection services)


### PR DESCRIPTION
Fix Issue #342 .

## Changes
An interface of ITelemetryClient, containing all the public methods/properties available on TelemetryClient.
This allows consumers to inject an interface, rather than a concrete implementation, into their classes, which makes mocking and testing easier for consumers.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.

### Notes for reviewers:

- We support [comment build triggers](https://docs.microsoft.com/azure/devops/pipelines/repos/github?view=azure-devops&tabs=yaml#comment-triggers)
  - `/AzurePipelines run` will queue all builds
  - `/AzurePipelines run <pipeline-name>` will queue a specific build
