### PR TITLE
Remove proactive sampling decision

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/OperationCorrelationTelemetryInitializerTests.cs
@@ -285,6 +285,7 @@
             currentActivity.Stop();
         }
 
+        [Ignore("ProactiveSamplingDecision is removed and won't work")]
         [TestMethod]
         public void InitializeWithActivityRecorded()
         {
@@ -299,6 +300,7 @@
             currentActivity.Stop();
         }
 
+        [Ignore("ProactiveSamplingDecision is removed and won't work")]
         [TestMethod]
         public void InitializeWithActivityRecordedOperationIdSet()
         {

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/StartOperationActivityTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/StartOperationActivityTests.cs
@@ -467,7 +467,7 @@
                 Assert.IsFalse(telemetry.Properties.ContainsKey("tracestate"));
             }
 
-            Assert.AreEqual(activity.Recorded ? SamplingDecision.SampledIn : SamplingDecision.None, (telemetry as ISupportAdvancedSampling).ProactiveSamplingDecision);
+            Assert.AreEqual(SamplingDecision.None, (telemetry as ISupportAdvancedSampling).ProactiveSamplingDecision);
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/OperationCorrelationTelemetryInitializer.cs
@@ -46,15 +46,6 @@
                         telemetryProp.Properties.Add(TracestatePropertyKey, currentActivity.TraceStateString);
                     }
 
-                    // update proactive sampling decision if Activity is recorded
-                    // sampling processor may change the decision
-                    if (currentActivity.Recorded &&
-                        telemetryItem is ISupportAdvancedSampling supportSamplingTelemetry &&
-                        supportSamplingTelemetry.ProactiveSamplingDecision == SamplingDecision.None)
-                    {
-                        supportSamplingTelemetry.ProactiveSamplingDecision = SamplingDecision.SampledIn;
-                    }
-
                     if (string.IsNullOrEmpty(itemOperationContext.Id))
                     {
                         if (currentActivity.IdFormat == ActivityIdFormat.W3C)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## VNext
 
-- [Removed proactive sampling decision to address high ingestion of telemetry records and item count with adaptive sampling.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2742)
+- [Fixed an adaptive sampling issue that caused incorrect item count when an `Activity` Recorded flags were modified externally, when enabled side-by-side with OpenTelemetry or other solutions.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2742)
 
 ## Version 2.22.0-beta2
 - [Upgrade System.Diagnostics.PerformanceCounter to version 6.0.0 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## VNext
 
+- [Removed proactive sampling decision to address high ingestion of telemetry records and item count with adaptive sampling.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2742)
+
 ## Version 2.22.0-beta2
 - [Upgrade System.Diagnostics.PerformanceCounter to version 6.0.0 to address CVE-2021-24112](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2707)
 - [Report internal dependencies from Cosmos SDK as InProc and align with Cosmos SDK EventSource changes](https://github.com/microsoft/ApplicationInsights-dotnet/pull/2712)


### PR DESCRIPTION
Fix Issue #2742 

## Changes
(Please provide a brief description of the changes here.)
The proactive sampling causes an issue, but it is not used directly by any users. This pull request only removes the part where proactive sampling is enabled. A complete code clean can be optionally done at a later point.

### Checklist
- [X] I ran Unit Tests locally.
- [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.