### PR TITLE
Added support to read diagnostics config from the path defined in environment variable.

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigParser.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/SelfDiagnostics/SelfDiagnosticsConfigParser.cs
@@ -1,5 +1,6 @@
 ﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.SelfDiagnostics
 {
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.Platform;
     using System;
     using System.Diagnostics.Tracing;
     using System.IO;
@@ -11,6 +12,8 @@
         public const string ConfigFileName = "ApplicationInsightsDiagnostics.json";
         private const int FileSizeLowerLimit = 1024;  // Lower limit for log file size in KB: 1MB
         private const int FileSizeUpperLimit = 128 * 1024;  // Upper limit for log file size in KB: 128MB
+
+        private const string LogDiagnosticsEnviornmentVariable = "APPLICATIONINSIGHTS_LOG_DIAGNOSTICS";
 
         /// <summary>
         /// ConfigBufferSize is the maximum bytes of config file that will be read.
@@ -40,8 +43,13 @@
             {
                 var configFilePath = ConfigFileName;
 
+                if (PlatformSingleton.Current.TryGetEnvironmentVariable(LogDiagnosticsEnviornmentVariable, out string logDiagnosticsPath))
+                {
+                    configFilePath = Path.Combine(logDiagnosticsPath, ConfigFileName);
+                }
+
                 // First check using current working directory
-                if (!File.Exists(configFilePath))
+                else if (!File.Exists(configFilePath))
                 {
 #if NET452
                     configFilePath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, ConfigFileName);


### PR DESCRIPTION
Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
