### PR TITLE
Fix a typo in a comment in the ApplicationInsights.config file

### DIFF
--- a/WEB/Src/WindowsServer/WindowsServer/ApplicationInsights.config.install.xdt
+++ b/WEB/Src/WindowsServer/WindowsServer/ApplicationInsights.config.install.xdt
@@ -9,7 +9,7 @@
     <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.WindowsServer.AppServicesHeartbeatTelemetryModule, Microsoft.AI.WindowsServer" />
     <Add xdt:Transform="InsertIfMissing" xdt:Locator="Match(Type)" Type="Microsoft.ApplicationInsights.WindowsServer.AzureInstanceMetadataTelemetryModule, Microsoft.AI.WindowsServer">
       <!--
-      Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider 
+      Remove individual fields collected here by adding them to the ApplicationInsights.HeartbeatProvider 
       with the following syntax:
       
       <Add Type="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule, Microsoft.ApplicationInsights">

--- a/examples/.NET Config File/2.10.0_ApplicationInsights.config
+++ b/examples/.NET Config File/2.10.0_ApplicationInsights.config
@@ -61,7 +61,7 @@
 		<Add Type="Microsoft.ApplicationInsights.WindowsServer.AppServicesHeartbeatTelemetryModule, Microsoft.AI.WindowsServer"/>
 		<Add Type="Microsoft.ApplicationInsights.WindowsServer.AzureInstanceMetadataTelemetryModule, Microsoft.AI.WindowsServer">
 			<!--
-      Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider 
+      Remove individual fields collected here by adding them to the ApplicationInsights.HeartbeatProvider 
       with the following syntax:
       
       <Add Type="Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.DiagnosticsTelemetryModule, Microsoft.ApplicationInsights">


### PR DESCRIPTION
This is a very minor change which fixes a typo in a comment in the ApplicationInsights.config file installed in a project when adding/updating the Microsot.ApplicationInsights.Web NuGet package

Changes
`Remove individual fields collected here by adding them to the ApplicationInsighs.HeartbeatProvider`
to
`Remove individual fields collected here by adding them to the ApplicationInsights.HeartbeatProvider`