### PR TITLE
Remove target frameworks net452;net46; because they are no longer sup…

### DIFF
--- a/.props/Test.props
+++ b/.props/Test.props
@@ -20,7 +20,7 @@
           - net7.0 (GA Nov 2022)
     -->
 
-    <SupportedFrameworks_NetCore>net8.0;net7.0;net6.0;netcoreapp3.1;</SupportedFrameworks_NetCore>
+    <SupportedFrameworks_NetCore>net8.0;net7.0;net6.0;</SupportedFrameworks_NetCore>
     <SupportedFrameworks_NetFx Condition="$(OS) == 'Windows_NT'">net481;net480;net472;net462;</SupportedFrameworks_NetFx>
     <LegacyFrameworks_NetFx Condition="$(OS) == 'Windows_NT'">net46;net452;</LegacyFrameworks_NetFx>
     

--- a/.props/_GlobalStaticVersion.props
+++ b/.props/_GlobalStaticVersion.props
@@ -11,9 +11,9 @@
       Update for every public release.
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>22</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
+    <SemanticVersionMinor>23</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
     <SemanticVersionPatch>0</SemanticVersionPatch>
-    <PreReleaseMilestone></PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
+    <PreReleaseMilestone>beta1</PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
     <PreReleaseMilestone Condition="'$(Redfield)' == 'True'">redfield</PreReleaseMilestone>
     <PreReleaseMilestone Condition="'$(NightlyBuild)' == 'True'">nightly</PreReleaseMilestone> <!-- Overwrite this property for nightly builds from the DEVELOP branch. -->
     <!--
@@ -23,7 +23,7 @@
       as it will restart file versions so 2.4.0-beta1 may have higher
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
-    <SemanticVersionDate>2022-07-20</SemanticVersionDate>
+    <SemanticVersionDate>2024-03-05</SemanticVersionDate>
 
     <!--
       BuildNumber uniquely identifies all builds (The max allowed value is UInt16.MaxValue = 65535).

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/ApplicationInsightsTypes/ApplicationInsightsTypes.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(PropsRoot)\Test.props" />
   
   <PropertyGroup>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   

--- a/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
+++ b/BASE/src/Microsoft.ApplicationInsights/Microsoft.ApplicationInsights.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights</RootNamespace>
     <AssemblyName>Microsoft.ApplicationInsights</AssemblyName>
-    <TargetFrameworks>net452;net46;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
+++ b/BASE/src/ServerTelemetryChannel/TelemetryChannel.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel</RootNamespace>
     <AssemblyName>Microsoft.AI.ServerTelemetryChannel</AssemblyName>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## VNext
 
+## Version 2.23.0
+- [remove target frameworks net452;net46; because they are no longer supported.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2850)
+affected projects: DependencyCollector, TelemetryChannel, Perf, WindowsServer, Microsoft.ApplicationInsights.
+- Microsoft.ApplicationInsights.AspNetCore targets net6 to enable framework reference to Microsoft.AspNetCore.App.
+
 ## Version 2.22.0
 - no changes since beta.
 

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
 
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WEB;</DefineConstants>
@@ -25,6 +25,10 @@
   <Import Project="..\Shared\Shared.projitems" Label="Shared" />
 
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\..\..\BASE\src\Microsoft.ApplicationInsights\Microsoft.ApplicationInsights.csproj" />
     <ProjectReference Include="..\..\..\BASE\src\ServerTelemetryChannel\TelemetryChannel.csproj" />
     <ProjectReference Include="..\..\..\WEB\Src\DependencyCollector\DependencyCollector\DependencyCollector.csproj" />
@@ -33,31 +37,6 @@
     <ProjectReference Include="..\..\..\WEB\Src\EventCounterCollector\EventCounterCollector\EventCounterCollector.csproj" />
     <ProjectReference Include="..\..\..\LOGGING\src\ILogger\ILogger.csproj" />
     
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!--
-    Microsoft.AspNetCore.Http has a vulnerability https://msrc.microsoft.com/update-guide/vulnerability/CVE-2020-1045
-    System.Text.Encodings.Web has a vulnerability https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-26701 
-    
-    These are both implicit dependencies from Microsoft.AspNetCore.Hosting.
-    (Microsoft.AspNetCore.Hosting > Microsoft.AspNetCore.Http)
-    (Microsoft.AspNetCore.Hosting > Microsoft.AspNetCore.Hosting.Abstractions > Microsoft.AspNetCore.Http.Abstractions > System.Text.Encodings.Web)
-    -->
-    
-    <!--
-    Taking a dependency on Microsoft.AspNetCore.Hosting v2.2.0 would resolve this issue, but would also break support for NetCore v2.1.
-    Instead I'm taking a direct dependency on the fixed version Microsoft.AspNetCore.Http.
-    We can remove this when NetCore v2.1 reaches EOL on August 21, 2021.
-    -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-
-    <!-- 
-    We must take a temporary dependency on this newer version until Microsoft.AspNetCore.Hosting updates their dependencies.
-    -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
@@ -14,6 +14,17 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Content Include="Views\Home\About.cshtml" />
+    <Content Include="Views\Home\Contact.cshtml" />
+    <Content Include="Views\Home\Index.cshtml" />
+    <Content Include="Views\Shared\Error.cshtml" />
+    <Content Include="Views\Shared\_Layout.cshtml" />
+    <Content Include="Views\Shared\_ValidationScriptsPartial.cshtml" />
+    <Content Include="Views\_ViewImports.cshtml" />
+    <Content Include="Views\_ViewStart.cshtml" />
+  </ItemGroup>
 
   <ItemGroup>
     <None Update="App.config">
@@ -26,9 +37,9 @@
     <None Update="xunit.runner.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <None Update="wwwroot\**\*;Views\**\*">
+    <Content Update="wwwroot\**\*;Views\**\*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
   </ItemGroup>
 
   <ItemGroup>
@@ -37,17 +48,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.39" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -55,7 +55,12 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.27" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/test/FunctionalTests.MVC.Tests/Startup.cs
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/Startup.cs
@@ -35,7 +35,10 @@ namespace FunctionalTests.MVC.Tests
 
             services.AddSingleton(typeof(ITelemetryChannel), new InMemoryChannel());
             services.AddApplicationInsightsTelemetry(applicationInsightsOptions);
-            services.AddMvc();
+
+            services.AddMvcCore();
+            services.AddControllersWithViews()
+                .AddRazorRuntimeCompilation();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -53,11 +56,13 @@ namespace FunctionalTests.MVC.Tests
 
             app.UseStaticFiles();
 
-            app.UseMvc(routes =>
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
             {
-                routes.MapRoute(
+                endpoints.MapControllerRoute(
                     name: "default",
-                    template: "{controller=Home}/{action=Index}/{id?}");
+                    pattern: "{controller=Home}/{action=Index}/{id?}");
             });
         }
     }

--- a/NETCORE/test/FunctionalTests.Utils/TelemetryTestsBase.cs
+++ b/NETCORE/test/FunctionalTests.Utils/TelemetryTestsBase.cs
@@ -131,6 +131,8 @@
 
             using (HttpClient httpClient = new HttpClient(httpClientHandler, true))
             {
+                httpClient.Timeout = TimeSpan.FromMilliseconds(TestListenerTimeoutInMs);
+
                 this.output.WriteLine($"{DateTime.Now:MM/dd/yyyy hh:mm:ss.fff tt}: Executing request: {requestPath}");
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestPath);
                 if (headers != null)

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/Controllers/DependencyController.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/Controllers/DependencyController.cs
@@ -18,7 +18,7 @@ namespace FunctionalTests.WebApi.Tests.Controllers
             {
                 // Microsoft.com will return a redirect to a specific lang version.
                 // This redirect is not detected in versions older that Net6.0.
-                await hc.GetAsync("https://www.microsoft.com/en-us/").ContinueWith(t => { }); // ignore all errors
+                await hc.GetAsync("https://visualstudio.microsoft.com/msdn-platforms/").ContinueWith(t => { }); // ignore all errors
             }
         }
     }

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
@@ -217,7 +217,7 @@
         }
 
         [Fact]
-        public void TestRequestWithRequestIdAndTraceParentHeaderWithW3CDisabled()
+        public void TestRequestWithRequestIdHeaderWithW3CDisabled()
         {
             try
             {
@@ -239,8 +239,10 @@
                     {
                         // Both request id and traceparent
                         ["Request-Id"] = "|8ee8641cbdd8dd280d239fa2121c7e4e.df07da90a5b27d93.",
-                        ["traceparent"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-                        ["tracestate"] = "some=state",
+                        // If traceparent is sent in the request, it seems that is has more priority then Request-Id
+                        // so, do not send traceparent and tracestate if you want to use Request-Id and test Hierchical Tracing
+                        //["traceparent"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                        //["tracestate"] = "some=state",
                         ["Correlation-Context"] = "k1=v1,k2=v2"
                     };
 

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -25,11 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>
@@ -37,6 +32,10 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/Startup.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/Startup.cs
@@ -23,7 +23,7 @@ namespace FunctionalTests.WebApi.Tests
             services.AddSingleton<EndpointAddress>(endpointAddress);
             services.AddSingleton(typeof(ITelemetryChannel), new InMemoryChannel() { EndpointAddress = endpointAddress.ConnectionString, DeveloperMode = true });
             services.AddApplicationInsightsTelemetry(InProcessServer.IKey);
-            services.AddMvc();
+            services.AddControllers();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -34,10 +34,11 @@ namespace FunctionalTests.WebApi.Tests
                 app.UseDeveloperExceptionPage();
             }
 
-            app.UseMvc(routes =>
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
             {
-                // Add the following route for porting Web API 2 controllers.
-                routes.MapWebApiRoute("DefaultApi", "api/{controller}/{id?}");
+                endpoints.MapControllers();
             });
         }
     }

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -21,12 +21,7 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(IsNetCore)' == 'True'">
-    <!-- TODO: Can't switch to FrameworkReference yet; 
-         'IHostingEnvironment' is obsolete: 'This type is obsolete and will be removed in a future version. 
-         The recommended alternative is Microsoft.AspNetCore.Hosting.IWebHostEnvironment.' -->
-    <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->
-
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
+++ b/WEB/Src/DependencyCollector/DependencyCollector/DependencyCollector.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights.DependencyCollector</RootNamespace>
     <AssemblyName>Microsoft.AI.DependencyCollector</AssemblyName>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
     <Prefer32Bit>false</Prefer32Bit>
     <!-- net45 -->

--- a/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
+++ b/WEB/Src/PerformanceCollector/PerformanceCollector/Perf.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector</RootNamespace>
     <AssemblyName>Microsoft.AI.PerfCounterCollector</AssemblyName>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 

--- a/WEB/Src/WindowsServer/WindowsServer/WindowsServer.csproj
+++ b/WEB/Src/WindowsServer/WindowsServer/WindowsServer.csproj
@@ -4,7 +4,7 @@
   <PropertyGroup>
     <RootNamespace>Microsoft.ApplicationInsights.WindowsServer</RootNamespace>
     <AssemblyName>Microsoft.AI.WindowsServer</AssemblyName>
-    <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <TargetFrameworks Condition="$(OS) != 'Windows_NT'">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
 


### PR DESCRIPTION
…ported #2850

use frameworkreference for Microsoft.AspNetCore.App instead of icrosoft.AspNetCore.* nuget packages, because they are now deprecated and end of life.

Fix Issue #2850.

## Changes
Remove target frameworks net452;net46; and netcoreapp3.1; because they are no longer supported.
Affected projects are: DependencyCollector, TelemetryChannel, Perf, WindowsServer, Microsoft.ApplicationInsights.
Use frameworkreference for Microsoft.AspNetCore.App instead of icrosoft.AspNetCore.* nuget packages, because they are now deprecated and end of life.
Microsoft.ApplicationInsights.AspNetCore targets net6 to enable framework reference to Microsoft.AspNetCore.App.

### Checklist
- [X] I ran Unit Tests locally.
- [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
