### PR TITLE
Populate required field Message with n/a if it is empty

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
@@ -191,7 +191,7 @@
         [DataRow(" ")]
         public void ProvidesDefaultMessage(string message)
         {
-            var exp = new Exception(string.Empty);
+            var exp = new ExceptionWithMessageOverride(message);
 
             ExceptionDetails expDetails = ExceptionConverter.ConvertToExceptionDetails(exp, null);
 
@@ -224,6 +224,21 @@
             }
 
             throw new AggregateException("exception message");
+        }
+        
+        /// <summary>
+        /// Overrides the Message property of the base exception, so that null messages are
+        /// returned as null, rather than a default, e.g. "Exception of type 'System.Exception' was thrown".
+        /// </summary>
+        private class ExceptionWithMessageOverride : Exception
+        {
+            public ExceptionWithMessageOverride(string message)
+                : base(message)
+            {
+                Message = message;
+            }
+            
+            public override string Message { get; }
         }
     }
 }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/ExceptionConverterTest.cs
@@ -185,6 +185,19 @@
             Assert.AreEqual(5, expDetails.message.Length);
         }
 
+        [TestMethod]
+        [DataRow(null)]
+        [DataRow("")]
+        [DataRow(" ")]
+        public void ProvidesDefaultMessage(string message)
+        {
+            var exp = new Exception(string.Empty);
+
+            ExceptionDetails expDetails = ExceptionConverter.ConvertToExceptionDetails(exp, null);
+
+            Assert.AreEqual("n/a", expDetails.message);
+        }
+
         [MethodImplAttribute(MethodImplOptions.NoInlining)]
         private Exception CreateException(int numberOfStackpoints)
         {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
@@ -1,8 +1,7 @@
-﻿using Microsoft.ApplicationInsights.DataContracts;
-
-namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
+﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
     using System;
+    using Microsoft.ApplicationInsights.DataContracts;
 
     /// <summary>
     /// Additional implementation for ExceptionDetails.

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
@@ -22,7 +22,7 @@
             {
                 id = exception.GetHashCode(),
                 typeName = exception.GetType().FullName,
-                message = Utils.PopulateRequiredStringValue(exception.Message, "message", typeof(ExceptionTelemetry).FullName),
+                message = Utils.PopulateRequiredNonWhitespaceStringValue(exception.Message, "message", typeof(ExceptionTelemetry).FullName),
             };
 
             if (parentExceptionDetails != null)

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/External/ExceptionDetailsImplementation.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
+﻿using Microsoft.ApplicationInsights.DataContracts;
+
+namespace Microsoft.ApplicationInsights.Extensibility.Implementation.External
 {
     using System;
 
@@ -21,7 +23,7 @@
             {
                 id = exception.GetHashCode(),
                 typeName = exception.GetType().FullName,
-                message = exception.Message,
+                message = Utils.PopulateRequiredStringValue(exception.Message, "message", typeof(ExceptionTelemetry).FullName),
             };
 
             if (parentExceptionDetails != null)

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Utils.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Utils.cs
@@ -53,6 +53,20 @@
         }
 
         /// <summary>
+        /// Validates the string and if null or empty populates it with '$parameterName is a required field for $telemetryType' value.
+        /// </summary>
+        public static string PopulateRequiredNonWhitespaceStringValue(string value, string parameterName, string telemetryType)
+        {
+            if (value.IsNullOrWhiteSpace())
+            {
+                CoreEventSource.Log.PopulateRequiredStringWithValue(parameterName, telemetryType);
+                return "n/a";
+            }
+
+            return value;
+        }
+
+        /// <summary>
         /// Returns default Timespan value if not a valid Timespan.
         /// </summary>
         public static TimeSpan ValidateDuration(string value)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VNext
+- [Populate required field Message with "n/a" if it is empty](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1066)
 
 ## Version 2.22.0
 - no changes since beta.


### PR DESCRIPTION
Fix Issue #1066.

## Changes
Application Insights rejects exceptions that have empty messages. This means that some exceptions are lost, making investigation of runtime issues difficult. I noticed this when investigating an issue in a .NET 8 API, where a `CosmosException` for a conflict occurred, was logged on the console but wasn't logged in App Insights.

There was previously a PR #2697 that never got merged due to lack of tests.

Original example from the other PR:
```csharp
var configuration = TelemetryConfiguration.CreateDefault();
configuration.ConnectionString = "InstrumentationKey=...";
var telemetryClient = new TelemetryClient(configuration);
telemetryClient.TrackException(new Exception("")); // ignored
telemetryClient.TrackException(new Exception("foo")); // logged
telemetryClient.Flush();
```

Original response from the other PR:
```json
{
    "itemsReceived": 1,
    "itemsAccepted": 0,
    "errors":
    [
        {
            "index": 0,
            "statusCode": 400,
            "message": "109: Field 'message' on type 'ExceptionDetails' is required but missing or empty. Expected: string, Actual: undefined"
        }
    ]
}
```

### Checklist
- [✅] I ran Unit Tests locally.*
- [✅] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

* I had some test failures on a fresh clone, but the tests for the relevant part of the code were passing, so I'm hoping it's just an issue with some dependencies on my machine.

For significant contributions please make sure you have completed the following items:

- [N/A] Design discussion issue #
- [N/A] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
