### PR TITLE
Add support for connection string to Microsoft.ApplicationInsights.NLogTarget 

### DIFF
--- a/.publicApi/Microsoft.ApplicationInsights.NLogTarget.dll/net452/PublicAPI.Shipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.NLogTarget.dll/net452/PublicAPI.Shipped.txt
@@ -3,6 +3,8 @@ Microsoft.ApplicationInsights.NLogTarget.ApplicationInsightsTarget.ApplicationIn
 Microsoft.ApplicationInsights.NLogTarget.ApplicationInsightsTarget.ContextProperties.get -> System.Collections.Generic.IList<Microsoft.ApplicationInsights.NLogTarget.TargetPropertyWithContext>
 Microsoft.ApplicationInsights.NLogTarget.ApplicationInsightsTarget.InstrumentationKey.get -> string
 Microsoft.ApplicationInsights.NLogTarget.ApplicationInsightsTarget.InstrumentationKey.set -> void
+Microsoft.ApplicationInsights.NLogTarget.ApplicationInsightsTarget.ConnectionString.get -> string
+Microsoft.ApplicationInsights.NLogTarget.ApplicationInsightsTarget.ConnectionString.set -> void
 Microsoft.ApplicationInsights.NLogTarget.TargetPropertyWithContext
 Microsoft.ApplicationInsights.NLogTarget.TargetPropertyWithContext.Layout.get -> NLog.Layouts.Layout
 Microsoft.ApplicationInsights.NLogTarget.TargetPropertyWithContext.Layout.set -> void

--- a/LOGGING/README.md
+++ b/LOGGING/README.md
@@ -37,7 +37,26 @@ Application Insights NLog Target nuget package adds ApplicationInsights target i
 
 If your application does not have web.config then it can also be configured manually.
 
- * **Configure ApplicationInsightsTarget using NLog.config** :
+* **Configure ApplicationInsightsTarget with ConnectionString using NLog.config** :
+ConnectionString is the preferred approach to write logs into Application Insights. If the NLog Application Insights target has connectionString in the config file then TelemetryClient will use it, otherwise it will use the instrumentationKey.
+
+```xml
+<nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <extensions>
+		<add assembly="Microsoft.ApplicationInsights.NLogTarget" />
+    </extensions>
+	<targets>
+		<target xsi:type="ApplicationInsightsTarget" name="aiTarget">
+			<connectionString>Your_ApplicationInsights_ConnectionString</connectionString>	<!-- Only required if not using ApplicationInsights.config -->
+			<contextproperty name="threadid" layout="${threadid}" />	<!-- Can be repeated with more context -->
+		</target>
+	</targets>
+	<rules>
+		<logger name="*" minlevel="Trace" writeTo="aiTarget" />
+	</rules>
+</nlog>
+```
+  * **Configure ApplicationInsightsTarget using NLog.config** :
 
 ```xml
 <nlog xmlns="http://www.nlog-project.org/schemas/NLog.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
@@ -70,6 +89,10 @@ For more information see:
 
 
 ```csharp
+// You need this only if you did not define ConnectionString or InstrumentationKey in ApplicationInsights.config (Or in the NLog.config)
+TelemetryConfiguration.Active.ConnectionString = "Your_ApplicationInsights_ConnectionString";
+
+or 
 // You need this only if you did not define InstrumentationKey in ApplicationInsights.config (Or in the NLog.config)
 TelemetryConfiguration.Active.InstrumentationKey = "Your_Resource_Key";
 
@@ -85,6 +108,9 @@ If you configure NLog programmatically with the [NLog Config API](https://github
 var config = new LoggingConfiguration();
 
 ApplicationInsightsTarget target = new ApplicationInsightsTarget();
+// You need this only if you did not define Application Insights ConnectionString in ApplicationInsights.config or want to use different connectionstring
+target.ConnectionString = "Your_ApplicationInsights_ConnectionString";
+or
 // You need this only if you did not define InstrumentationKey in ApplicationInsights.config or want to use different instrumentation key
 target.InstrumentationKey = "Your_Resource_Key";
 

--- a/LOGGING/src/NLogTarget/ApplicationInsightsTarget.cs
+++ b/LOGGING/src/NLogTarget/ApplicationInsightsTarget.cs
@@ -13,6 +13,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
 
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Implementation;
 
@@ -31,6 +32,7 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         private TelemetryClient telemetryClient;
         private DateTime lastLogEventTime;
         private NLog.Layouts.Layout instrumentationKeyLayout = string.Empty;
+        private NLog.Layouts.Layout connectionStringLayout = string.Empty;
 
         /// <summary>
         /// Initializers a new instance of ApplicationInsightsTarget type.
@@ -48,6 +50,15 @@ namespace Microsoft.ApplicationInsights.NLogTarget
         {
             get => (this.instrumentationKeyLayout as NLog.Layouts.SimpleLayout)?.Text ?? null;
             set => this.instrumentationKeyLayout = value ?? string.Empty;
+        }
+
+        /// <summary>
+        /// Gets or sets the Application Insights connectionstring for your application.
+        /// </summary>
+        public string ConnectionString
+        {
+            get => (this.connectionStringLayout as NLog.Layouts.SimpleLayout)?.Text ?? null;
+            set => this.connectionStringLayout = value ?? string.Empty;
         }
 
         /// <summary>
@@ -118,10 +129,21 @@ namespace Microsoft.ApplicationInsights.NLogTarget
             this.telemetryClient = new TelemetryClient();
 #pragma warning restore CS0618 // Type or member is obsolete
 
-            string instrumentationKey = this.instrumentationKeyLayout.Render(LogEventInfo.CreateNullEvent());
-            if (!string.IsNullOrWhiteSpace(instrumentationKey))
+            string connectionString = this.connectionStringLayout.Render(LogEventInfo.CreateNullEvent());
+
+            // Check if nlog application insights target has connectionstring in config file then
+            // configure telemetryclient with the connectionstring otherwise using instrumentationkey.
+            if (!string.IsNullOrWhiteSpace(connectionString))
             {
-                this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
+                this.telemetryClient.TelemetryConfiguration.ConnectionString = connectionString;
+            }
+            else
+            {
+                string instrumentationKey = this.instrumentationKeyLayout.Render(LogEventInfo.CreateNullEvent());
+                if (!string.IsNullOrWhiteSpace(instrumentationKey))
+                {
+                    this.telemetryClient.Context.InstrumentationKey = instrumentationKey;
+                }
             }
 
             this.telemetryClient.Context.GetInternalContext().SdkVersion = SdkVersionUtils.GetSdkVersion("nlog:");

--- a/LOGGING/test/NLogTarget.Tests/NLogTargetTests.cs
+++ b/LOGGING/test/NLogTarget.Tests/NLogTargetTests.cs
@@ -230,7 +230,7 @@
         }
 
 
-    [TestMethod]
+        [TestMethod]
         [TestCategory("NLogTarget")]
         public void GlobalDiagnosticContextPropertiesAreAddedToProperties()
         {
@@ -459,6 +459,62 @@
             Assert.AreEqual("Flush called", flushException.Message);
         }
 
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogInfoIsSentAsInformationTraceItemWithAIConnectionString()
+        {
+            var aiLogger = this.CreateTargetWithGivenConnectionString("Your_ApplicationInsights_ConnectionString");
+            aiLogger.Info("Info message");
+
+            var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.First();
+            Assert.AreEqual($"Info message", telemetry.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogTraceIsSentAsVerboseTraceItemWithAIConnectionString()
+        {
+            var aiLogger = this.CreateTargetWithGivenConnectionString("Your_ApplicationInsights_ConnectionString");
+            aiLogger.Trace("Trace message");
+
+            var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
+            Assert.AreEqual("Trace message", telemetry.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogDebugIsSentAsVerboseTraceItemWithAIConnectionString()
+        {
+            var aiLogger = this.CreateTargetWithGivenConnectionString("Your_ApplicationInsights_ConnectionString");
+            aiLogger.Debug("Debug Message");
+
+            var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
+            Assert.AreEqual("Debug Message", telemetry.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogWarnIsSentAsWarningTraceItemWithAIConnectionString()
+        {
+            var aiLogger = this.CreateTargetWithGivenConnectionString("Your_ApplicationInsights_ConnectionString");
+
+            aiLogger.Warn("Warn message");
+
+            var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
+            Assert.AreEqual("Warn message", telemetry.Message);
+        }
+
+        [TestMethod]
+        [TestCategory("NLogTarget")]
+        public void NLogErrorIsSentAsVerboseTraceItemWithAIConnectionString()
+        {
+            var aiLogger = this.CreateTargetWithGivenConnectionString("InstrumentationKey=b91a8f48-c77c-4f12-80e2-f96bc1abb126;IngestionEndpoint=https://centralus-2.in.applicationinsights.azure.com/;LiveEndpoint=https://centralus.livediagnostics.monitor.azure.com/");
+            aiLogger.Error("Error Message");
+
+            var telemetry = (TraceTelemetry)this.adapterHelper.Channel.SentItems.FirstOrDefault();
+            Assert.AreEqual("Error Message", telemetry.Message);
+        }
+
         private void VerifyMessagesInMockChannel(Logger aiLogger, string instrumentationKey)
         {
             aiLogger.Trace("Sample trace message");
@@ -487,6 +543,38 @@
             }
 
             target.InstrumentationKey = instrumentationKey;
+            LoggingRule rule = new LoggingRule("*", LogLevel.Trace, target);
+            LoggingConfiguration config = new LoggingConfiguration();
+            config.AddTarget("AITarget", target);
+            config.LoggingRules.Add(rule);
+
+            LogManager.Configuration = config;
+            Logger aiLogger = LogManager.GetLogger("AITarget");
+
+            if (loggerAction != null)
+            {
+                loggerAction(aiLogger);
+                target.Dispose();
+                return null;
+            }
+
+            return aiLogger;
+        }
+
+        private Logger CreateTargetWithGivenConnectionString(
+            string connectionString = "Your_ApplicationInsights_ConnectionString",
+            Action<Logger> loggerAction = null)
+        {
+            // Mock channel to validate that our appender is trying to send logs
+#pragma warning disable CS0618 // Type or member is obsolete
+            TelemetryConfiguration.Active.TelemetryChannel = this.adapterHelper.Channel;
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            ApplicationInsightsTarget target = new ApplicationInsightsTarget
+            {
+                ConnectionString = connectionString
+            };
+
             LoggingRule rule = new LoggingRule("*", LogLevel.Trace, target);
             LoggingConfiguration config = new LoggingConfiguration();
             config.AddTarget("AITarget", target);

--- a/LOGGING/test/Shared/AdapterHelper.cs
+++ b/LOGGING/test/Shared/AdapterHelper.cs
@@ -19,6 +19,8 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
     {
         public string InstrumentationKey { get; }
 
+        public string ConnectionString { get; }
+
 #if NET452 || NET46
         private static readonly string ApplicationInsightsConfigFilePath =
             Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "ApplicationInsights.config");
@@ -27,16 +29,19 @@ namespace Microsoft.ApplicationInsights.Tracing.Tests
             Path.Combine(Path.GetDirectoryName(typeof(AdapterHelper).GetTypeInfo().Assembly.Location), "ApplicationInsights.config");
 #endif
 
-        public AdapterHelper(string instrumentationKey = "F8474271-D231-45B6-8DD4-D344C309AE69")
+        public AdapterHelper(string instrumentationKey = "F8474271-D231-45B6-8DD4-D344C309AE69"
+            , string connectionString = "Your_ApplicationInsights_ConnectionString")
         {
             this.InstrumentationKey = instrumentationKey;
+            this.ConnectionString = connectionString;
 
             string configuration = string.Format(InvariantCulture,
                                     @"<?xml version=""1.0"" encoding=""utf-8"" ?>
                                      <ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
                                         <InstrumentationKey>{0}</InstrumentationKey>
                                      </ApplicationInsights>",
-                                     instrumentationKey);
+                                     instrumentationKey,
+                                     connectionString);
 
             File.WriteAllText(ApplicationInsightsConfigFilePath, configuration);
             this.Channel = new CustomTelemetryChannel();


### PR DESCRIPTION
Add support for connection string to Microsoft.ApplicationInsights.NLogTarget https://github.com/microsoft/ApplicationInsights-dotnet/issues/2714 

Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
