### PR TITLE
Target Microsoft.ApplicationInsights.AspNetCore to netcoreapp3.1 and remove package references to deprecated nugets Microsoft.AspNetCore.*

### DIFF
--- a/.props/_GlobalStaticVersion.props
+++ b/.props/_GlobalStaticVersion.props
@@ -11,7 +11,7 @@
       Update for every public release.
     -->
     <SemanticVersionMajor>2</SemanticVersionMajor>
-    <SemanticVersionMinor>22</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
+    <SemanticVersionMinor>23</SemanticVersionMinor> <!-- If changing the Minor version, also update the Date value. -->
     <SemanticVersionPatch>0</SemanticVersionPatch>
     <PreReleaseMilestone></PreReleaseMilestone> <!--Valid values: beta1, beta2, EMPTY for stable -->
     <PreReleaseMilestone Condition="'$(Redfield)' == 'True'">redfield</PreReleaseMilestone>
@@ -23,7 +23,7 @@
       as it will restart file versions so 2.4.0-beta1 may have higher
       file version (like 2.4.0.2222) than 2.4.0-beta2 (like 2.4.0.1111)
     -->
-    <SemanticVersionDate>2022-07-20</SemanticVersionDate>
+    <SemanticVersionDate>2024-03-28</SemanticVersionDate>
 
     <!--
       BuildNumber uniquely identifies all builds (The max allowed value is UInt16.MaxValue = 65535).

--- a/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
+++ b/BASE/src/ServerTelemetryChannel/Implementation/ApplicationFolderProvider.cs
@@ -119,7 +119,7 @@
 
         internal static bool IsWindowsOperatingSystem()
         {
-#if NET452
+#if NETFRAMEWORK
             return true;
 #else
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 ## VNext
 - [Populate required field Message with "n/a" if it is empty](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1066)
 
+## Version 2.23.0
+- [Microsoft.ApplicationInsights.AspNetCore used deprecated NuGet packages](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2811)
+- Target Microsoft.ApplicationInsights.AspNetCore to netcoreapp3.1
+- Remove package references to nugets Microsoft.AspNetCore.*
+- For AspNetCore use framework reference to Microsoft.AspNetCore.App
+
 ## Version 2.22.0
 - no changes since beta.
 

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Microsoft.ApplicationInsights.AspNetCore.csproj
@@ -3,9 +3,9 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.AspNetCore</AssemblyName>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
 
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp3.1</TargetFrameworks>
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WEB;</DefineConstants>
   </PropertyGroup>
 
@@ -32,32 +32,10 @@
     <ProjectReference Include="..\..\..\WEB\Src\WindowsServer\WindowsServer\WindowsServer.csproj" />
     <ProjectReference Include="..\..\..\WEB\Src\EventCounterCollector\EventCounterCollector\EventCounterCollector.csproj" />
     <ProjectReference Include="..\..\..\LOGGING\src\ILogger\ILogger.csproj" />
-    
-    <PackageReference Include="Microsoft.AspNetCore.Hosting" Version="2.1.1" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.1.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <!--
-    Microsoft.AspNetCore.Http has a vulnerability https://msrc.microsoft.com/update-guide/vulnerability/CVE-2020-1045
-    System.Text.Encodings.Web has a vulnerability https://msrc.microsoft.com/update-guide/vulnerability/CVE-2021-26701 
-    
-    These are both implicit dependencies from Microsoft.AspNetCore.Hosting.
-    (Microsoft.AspNetCore.Hosting > Microsoft.AspNetCore.Http)
-    (Microsoft.AspNetCore.Hosting > Microsoft.AspNetCore.Hosting.Abstractions > Microsoft.AspNetCore.Http.Abstractions > System.Text.Encodings.Web)
-    -->
-    
-    <!--
-    Taking a dependency on Microsoft.AspNetCore.Hosting v2.2.0 would resolve this issue, but would also break support for NetCore v2.1.
-    Instead I'm taking a direct dependency on the fixed version Microsoft.AspNetCore.Http.
-    We can remove this when NetCore v2.1 reaches EOL on August 21, 2021.
-    -->
-    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.1.22" />
-
-    <!-- 
-    We must take a temporary dependency on this newer version until Microsoft.AspNetCore.Hosting updates their dependencies.
-    -->
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
+++ b/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/Microsoft.ApplicationInsights.WorkerService.csproj
@@ -3,7 +3,7 @@
 
   <PropertyGroup>
     <AssemblyName>Microsoft.ApplicationInsights.WorkerService</AssemblyName>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
     <DefineConstants>$(DefineConstants);AI_ASPNETCORE_WORKER;</DefineConstants>
   </PropertyGroup>
 

--- a/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/FunctionalTests.MVC.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$(PropsRoot)\Test.props" />
 
   
@@ -37,17 +37,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.1.39" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.2.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.0.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
@@ -56,6 +45,14 @@
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
     <DotNetCliToolReference Include="dotnet-xunit" Version="2.3.1" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="3.1.32" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' != 'netcoreapp3.1' ">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor.RuntimeCompilation" Version="6.0.27" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/test/FunctionalTests.MVC.Tests/Startup.cs
+++ b/NETCORE/test/FunctionalTests.MVC.Tests/Startup.cs
@@ -35,7 +35,10 @@ namespace FunctionalTests.MVC.Tests
 
             services.AddSingleton(typeof(ITelemetryChannel), new InMemoryChannel());
             services.AddApplicationInsightsTelemetry(applicationInsightsOptions);
-            services.AddMvc();
+            services.AddMvcCore(options => options.EnableEndpointRouting = false);
+
+            services.AddControllersWithViews()
+                .AddRazorRuntimeCompilation();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/NETCORE/test/FunctionalTests.Utils/TelemetryTestsBase.cs
+++ b/NETCORE/test/FunctionalTests.Utils/TelemetryTestsBase.cs
@@ -131,6 +131,8 @@
 
             using (HttpClient httpClient = new HttpClient(httpClientHandler, true))
             {
+                httpClient.Timeout = TimeSpan.FromMilliseconds(TestListenerTimeoutInMs);
+
                 this.output.WriteLine($"{DateTime.Now:MM/dd/yyyy hh:mm:ss.fff tt}: Executing request: {requestPath}");
                 HttpRequestMessage request = new HttpRequestMessage(HttpMethod.Get, requestPath);
                 if (headers != null)

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/Controllers/DependencyController.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/Controllers/DependencyController.cs
@@ -18,7 +18,7 @@ namespace FunctionalTests.WebApi.Tests.Controllers
             {
                 // Microsoft.com will return a redirect to a specific lang version.
                 // This redirect is not detected in versions older that Net6.0.
-                await hc.GetAsync("https://www.microsoft.com/en-us/").ContinueWith(t => { }); // ignore all errors
+                await hc.GetAsync("https://visualstudio.microsoft.com/msdn-platforms/").ContinueWith(t => { }); // ignore all errors
             }
         }
     }

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
@@ -217,7 +217,7 @@
         }
 
         [Fact]
-        public void TestRequestWithRequestIdAndTraceParentHeaderWithW3CDisabled()
+        public void TestRequestWithRequestIdHeaderWithW3CDisabled()
         {
             try
             {
@@ -239,8 +239,10 @@
                     {
                         // Both request id and traceparent
                         ["Request-Id"] = "|8ee8641cbdd8dd280d239fa2121c7e4e.df07da90a5b27d93.",
-                        ["traceparent"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
-                        ["tracestate"] = "some=state",
+                        // If traceparent is sent in the request, it seems that is has more priority then Request-Id
+                        // so, do not send traceparent and tracestate if you want to use Request-Id and test Hierchical Tracing
+                        //["traceparent"] = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+                        //["tracestate"] = "some=state",
                         ["Correlation-Context"] = "k1=v1,k2=v2"
                     };
 

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTests.WebApi.Tests.csproj
@@ -25,11 +25,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.WebApiCompatShim" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Diagnostics" Version="2.1.1" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.11.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
       <PrivateAssets>all</PrivateAssets>

--- a/NETCORE/test/FunctionalTests.WebApi.Tests/Startup.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/Startup.cs
@@ -23,7 +23,7 @@ namespace FunctionalTests.WebApi.Tests
             services.AddSingleton<EndpointAddress>(endpointAddress);
             services.AddSingleton(typeof(ITelemetryChannel), new InMemoryChannel() { EndpointAddress = endpointAddress.ConnectionString, DeveloperMode = true });
             services.AddApplicationInsightsTelemetry(InProcessServer.IKey);
-            services.AddMvc();
+            services.AddMvcCore(options => options.EnableEndpointRouting = false);
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -37,7 +37,7 @@ namespace FunctionalTests.WebApi.Tests
             app.UseMvc(routes =>
             {
                 // Add the following route for porting Web API 2 controllers.
-                routes.MapWebApiRoute("DefaultApi", "api/{controller}/{id?}");
+                routes.MapRoute("DefaultApi", "api/{controller}/{id?}");
             });
         }
     }

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/BaseTestClass.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsExtensionsTests/BaseTestClass.cs
@@ -12,7 +12,6 @@ namespace Microsoft.Extensions.DependencyInjection.Test
     using Microsoft.ApplicationInsights.AspNetCore.Tests;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.AspNetCore.Hosting;
-    using Microsoft.AspNetCore.Hosting.Internal;
     using Microsoft.Extensions.Configuration;
 
     public abstract class BaseTestClass

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsServiceOptionsTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Extensions/ApplicationInsightsServiceOptionsTests.cs
@@ -15,7 +15,6 @@ using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector;
 using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.ApplicationInsights.WindowsServer;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.Hosting.Internal;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Test;

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/Microsoft.ApplicationInsights.AspNetCore.Tests.csproj
@@ -20,15 +20,6 @@
     <PackageReference Include="Moq" Version="4.16.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(IsNetCore)' == 'True'">
-    <!-- TODO: Can't switch to FrameworkReference yet; 
-         'IHostingEnvironment' is obsolete: 'This type is obsolete and will be removed in a future version. 
-         The recommended alternative is Microsoft.AspNetCore.Hosting.IWebHostEnvironment.' -->
-    <!--<FrameworkReference Include="Microsoft.AspNetCore.App" />-->
-
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.2.5" />
-  </ItemGroup>
-
   <ItemGroup>
     <None Update="App.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/AspNetCoreEnvironmentTelemetryInitializerTests.cs
@@ -2,7 +2,6 @@
 {
     using Microsoft.ApplicationInsights.AspNetCore.TelemetryInitializers;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.AspNetCore.Hosting.Internal;
     using Xunit;
 
     public class AspNetCoreEnvironmentTelemetryInitializerTests


### PR DESCRIPTION
Fix Issue #2811 .

## Changes
- Target Microsoft.ApplicationInsights.AspNetCore to netcoreapp3.1
- Remove package references to nugets Microsoft.AspNetCore.*
- For AspNetCore use framework reference to Microsoft.AspNetCore.App

### Checklist
- [ X ] I ran Unit Tests locally.
- [ X ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.
