### PR TITLE
Fix Typos

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ For significant contributions please make sure you have completed the following 
 The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.
 
 ### Notes for authors:
-- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
+- FxCop and other analyzers will fail the build. To see these errors yourself, compile locally using the Release configuration.

--- a/.scripts/release_GenerateReleaseMetadata.ps1
+++ b/.scripts/release_GenerateReleaseMetadata.ps1
@@ -45,7 +45,7 @@ class ReleaseInfo {
 }
 
 Function Get-GitChangeset() {
-    # if running localy, use git command. for VSTS, probably better to use Build.SourceVersion
+    # if running locally, use git command. for VSTS, probably better to use Build.SourceVersion
     # Git command only works if this script executes in the repo's directory
     [string]$commit = ""
     try {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryConfigurationFactory.cs
@@ -174,7 +174,7 @@
                 }
                 else if (instance == null)
                 {
-                    CoreEventSource.Log.IncorrectInstanceAtributesConfigurationError(definition.Name.LocalName);
+                    CoreEventSource.Log.IncorrectInstanceAttributesConfigurationError(definition.Name.LocalName);
                 }
 
                 if (instance != null)

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/CoreEventSource.cs
@@ -97,7 +97,7 @@
             Keywords = Keywords.Diagnostics,
             Message = "Scheduler timer dispose failure: {0}",
             Level = EventLevel.Warning)]
-        public void DiagnoisticsEventThrottlingSchedulerDisposeTimerFailure(
+        public void DiagnosticsEventThrottlingSchedulerDisposeTimerFailure(
             string exception,
             string appDomainName = "Incorrect")
         {
@@ -112,7 +112,7 @@
             Keywords = Keywords.Diagnostics,
             Message = "A scheduler timer was created for the interval: {0}",
             Level = EventLevel.Verbose)]
-        public void DiagnoisticsEventThrottlingSchedulerTimerWasCreated(
+        public void DiagnosticsEventThrottlingSchedulerTimerWasCreated(
             string intervalInMilliseconds,
             string appDomainName = "Incorrect")
         {
@@ -124,7 +124,7 @@
             Keywords = Keywords.Diagnostics,
             Message = "A scheduler timer was removed",
             Level = EventLevel.Verbose)]
-        public void DiagnoisticsEventThrottlingSchedulerTimerWasRemoved(string appDomainName = "Incorrect")
+        public void DiagnosticsEventThrottlingSchedulerTimerWasRemoved(string appDomainName = "Incorrect")
         {
             this.WriteEvent(8, this.nameProvider.Name);
         }
@@ -237,7 +237,7 @@
             Keywords = Keywords.UserActionable,
             Message = "ApplicationInsights configuration file loading failed. Element '{0}' element does not have a Type attribute, does not specify a value and is not a valid collection type. Type initialization was skipped. Monitoring will continue.",
             Level = EventLevel.Error)]
-        public void IncorrectInstanceAtributesConfigurationError(string definition, string appDomainName = "Incorrect")
+        public void IncorrectInstanceAttributesConfigurationError(string definition, string appDomainName = "Incorrect")
         {
             this.WriteEvent(
                 18,
@@ -604,7 +604,7 @@
         public void TelemetryChannelNoInstrumentationKey(string appDomainName = "Incorrect") => this.WriteEvent(57, this.nameProvider.Name);
 
         [Event(58, Message = "TelemetryClient.Flush was invoked.", Level = EventLevel.Verbose)]
-        public void TelemetlyClientFlush(string appDomainName = "Incorrect") => this.WriteEvent(58, this.nameProvider.Name);
+        public void TelemetryClientFlush(string appDomainName = "Incorrect") => this.WriteEvent(58, this.nameProvider.Name);
 
         [Event(59, Message = "MetricManager.Flush was invoked.", Level = EventLevel.Verbose)]
         public void MetricManagerFlush(string appDomainName = "Incorrect") => this.WriteEvent(59, this.nameProvider.Name);

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnoisticsEventThrottlingScheduler.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/DiagnosticsModule/DiagnoisticsEventThrottlingScheduler.cs
@@ -45,7 +45,7 @@
             var token = InternalCreateAndStartTimer(interval, actionToExecute);
             this.timers.Add(token);
 
-            CoreEventSource.Log.DiagnoisticsEventThrottlingSchedulerTimerWasCreated(interval.ToString(CultureInfo.InvariantCulture));
+            CoreEventSource.Log.DiagnosticsEventThrottlingSchedulerTimerWasCreated(interval.ToString(CultureInfo.InvariantCulture));
 
             return token;
         }
@@ -67,7 +67,7 @@
             {
                 DisposeTimer(timer);
 
-                CoreEventSource.Log.DiagnoisticsEventThrottlingSchedulerTimerWasRemoved();
+                CoreEventSource.Log.DiagnosticsEventThrottlingSchedulerTimerWasRemoved();
             }
         }
 
@@ -85,7 +85,7 @@
             }
             catch (Exception exc)
             {
-                CoreEventSource.Log.DiagnoisticsEventThrottlingSchedulerDisposeTimerFailure(exc.ToInvariantString());
+                CoreEventSource.Log.DiagnosticsEventThrottlingSchedulerDisposeTimerFailure(exc.ToInvariantString());
             }
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -662,7 +662,7 @@
         /// </remarks>
         public void Flush()
         {
-            CoreEventSource.Log.TelemetlyClientFlush();
+            CoreEventSource.Log.TelemetryClientFlush();
 
             if (this.TryGetMetricManager(out MetricManager privateMetricManager))
             {


### PR DESCRIPTION
## Changes

I spotted a typo in `CoreEventSource`. Turns out there were a few others. And then when I created this PR there was another typo in the PR template.

This change is not substantial, so I am omitting to complete CHANGELOG.md unless you would like me to.

There may be other typos left elsewhere; I only set out to fix `TelemetlyClientFlush`

### Checklist

- [x] I ran Unit Tests locally.

- [ ] ~~CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.~~

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
