### PR TITLE
Feature: Improve metric dimensions API by accepting a collection of dimensions

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/MetricTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/MetricTests.cs
@@ -1587,6 +1587,158 @@ namespace Microsoft.ApplicationInsights
                     }
                 }
             }
+            telemetryCollector.Clear();
+            {
+                MetricConfiguration config = new MetricConfiguration(
+                    seriesCountLimit: 10,
+                    valuesPerDimensionLimits: new[] { 3, 1, 2 },
+                    seriesConfig: new MetricSeriesConfigurationForMeasurement(restrictToUInt32Values: false));
+                Metric metric = InvokeMetricCtor(
+                    metricManager,
+                    metricNamespace: "nsx",
+                    metricId: "Foo20",
+                    configuration: config,
+                    "D1",
+                    "D2",
+                    "D3",
+                    "D4");
+
+                Assert.AreEqual(1, metric.SeriesCount);
+
+                metric.TrackValue(42);
+                Assert.AreEqual(1, metric.SeriesCount);
+
+                Assert.ThrowsException<ArgumentException>(() => metric.TrackValue(42, "D1.A", "D2.A", "D3.A", "D4.A", "D5.A"));
+                Assert.ThrowsException<ArgumentException>(() => metric.TrackValue(42, "D1.A", "D2.A", "D3.A"));
+
+                Assert.IsTrue(metric.TrackValue(1111, "D1.A", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(2, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1111, "D1.A", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(2, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1112, "D1.A", "D2.A", "D3.A", "D4.B"));
+                Assert.AreEqual(3, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1112, "D1.A", "D2.A", "D3.A", "D4.B"));
+                Assert.AreEqual(3, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(1113, "D1.A", "D2.A", "D3.A", "D4.C"));
+                Assert.AreEqual(3, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1121, "D1.A", "D2.A", "D3.B", "D4.A"));
+                Assert.AreEqual(4, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1121, "D1.A", "D2.A", "D3.B", "D4.A"));
+                Assert.AreEqual(4, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1122, "D1.A", "D2.A", "D3.B", "D4.B"));
+                Assert.AreEqual(5, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(1122, "D1.A", "D2.A", "D3.B", "D4.B"));
+                Assert.AreEqual(5, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(1123, "D1.A", "D2.A", "D3.B", "D4.C"));
+                Assert.AreEqual(5, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(1132, "D1.A", "D2.A", "D3.C", "D4.B"));
+                Assert.AreEqual(5, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(1133, "D1.A", "D2.A", "D3.C", "D4.C"));
+                Assert.AreEqual(5, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(1211, "D1.A", "D2.B", "D3.A", "D4.A"));
+                Assert.AreEqual(5, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2111, "D1.B", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(6, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2111, "D1.B", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(6, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(2111, "D1.B", "D2.B", "D3.A", "D4.A"));
+                Assert.AreEqual(6, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2112, "D1.B", "D2.A", "D3.A", "D4.B"));
+                Assert.AreEqual(7, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2112, "D1.B", "D2.A", "D3.A", "D4.B"));
+                Assert.AreEqual(7, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(2113, "D1.B", "D2.A", "D3.A", "D4.C"));
+                Assert.AreEqual(7, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2121, "D1.B", "D2.A", "D3.B", "D4.A"));
+                Assert.AreEqual(8, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2121, "D1.B", "D2.A", "D3.B", "D4.A"));
+                Assert.AreEqual(8, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2122, "D1.B", "D2.A", "D3.B", "D4.B"));
+                Assert.AreEqual(9, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(2122, "D1.B", "D2.A", "D3.B", "D4.B"));
+                Assert.AreEqual(9, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(2123, "D1.B", "D2.A", "D3.B", "D4.C"));
+                Assert.AreEqual(9, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(2132, "D1.B", "D2.A", "D3.C", "D4.B"));
+                Assert.AreEqual(9, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(2133, "D1.B", "D2.A", "D3.C", "D4.C"));
+                Assert.AreEqual(9, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(2222, "D1.B", "D2.B", "D3.B", "D4.B"));
+                Assert.AreEqual(9, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(3111, "D1.C", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(10, metric.SeriesCount);
+
+                Assert.IsTrue(metric.TrackValue(3111, "D1.C", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(10, metric.SeriesCount);
+
+                Assert.IsFalse(metric.TrackValue(4111, "D1.D", "D2.A", "D3.A", "D4.A"));
+                Assert.AreEqual(10, metric.SeriesCount);
+
+                metricManager.Flush();
+
+                Assert.AreEqual(10, telemetryCollector.Count);
+                Assert.AreEqual(1, telemetryCollector.Where((a) => a.Dimensions.Count == 0).Count());
+                Assert.AreEqual(9, telemetryCollector.Where((a) => a.Dimensions.Count == 4).Count());
+
+                for (int i = 0; i < telemetryCollector.Count; i++)
+                {
+                    Assert.IsNotNull(telemetryCollector[i]);
+                    MetricAggregate aggregate = telemetryCollector[i];
+
+                    Assert.AreEqual("Foo20", aggregate.MetricId);
+                    Assert.AreEqual("nsx", aggregate.MetricNamespace);
+
+                    if (aggregate.Dimensions.Count == 0)
+                    {
+                        Assert.AreEqual(1, aggregate.Data["Count"]);
+                        Assert.AreEqual(42.0, aggregate.Data["Sum"]);
+                    }
+                    else if (aggregate.Dimensions.Count == 4)
+                    {
+                        Assert.AreEqual(2, aggregate.Data["Count"]);
+                        Assert.AreEqual(4, aggregate.Dimensions.Count);
+
+                        int expVal = 1000 * (1 + (int)(aggregate.Dimensions["D1"][3] - 'A'));
+                        expVal += 100 * (1 + (int)(aggregate.Dimensions["D2"][3] - 'A'));
+                        expVal += 10 * (1 + (int)(aggregate.Dimensions["D3"][3] - 'A'));
+                        expVal += 1 * (1 + (int)(aggregate.Dimensions["D4"][3] - 'A'));
+                        expVal *= 2;
+
+                        Assert.AreEqual((double)expVal, aggregate.Data["Sum"]);
+                    }
+                    else
+                    {
+                        Assert.Fail($"Unexpected number of dimensions: {aggregate.Dimensions.Count}.");
+                    }
+                }
+            }
 
             TestUtil.CompleteDefaultAggregationCycle(metricManager);
         }
@@ -1860,6 +2012,22 @@ namespace Microsoft.ApplicationInsights
                                     metricManager,
                                     new MetricIdentifier(metricNamespace, metricId, dimension1Name, dimension2Name, dimension3Name, dimension4Name),
                                     configuration);
+            return metric;
+        }
+        
+        private static Metric InvokeMetricCtor(
+            MetricManager metricManager,
+            string metricNamespace,
+            string metricId,
+            MetricConfiguration configuration,
+            params string[] dimensions)
+        {
+            // Metric ctor is private..
+
+            Metric metric = new Metric(
+                metricManager,
+                new MetricIdentifier(metricNamespace, metricId, dimensions),
+                configuration);
             return metric;
         }
     }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
@@ -1505,6 +1505,106 @@
 
                 sentTelemetry.Clear();
             }
+            
+                        {
+                Metric metric = client.GetMetric(
+                            new MetricIdentifier(
+                                        "Test MetricNamespace", 
+                                        "Test MetricId", 
+                                        ["Dim 1", 
+                                        "Dim 2", 
+                                        "Dim 3", 
+                                        "Dim 4", 
+                                        "Dim 5", 
+                                        "Dim 6", 
+                                        "Dim 7", 
+                                        "Dim 8", 
+                                        "Dim 9", 
+                                        "Dim 10"]),
+                            MetricConfigurations.Common.Measurement());
+                Assert.IsNotNull(metric);
+                Assert.AreEqual(10, metric.Identifier.DimensionsCount);
+                Assert.AreEqual("Test MetricNamespace", metric.Identifier.MetricNamespace);
+                Assert.AreEqual("Test MetricId", metric.Identifier.MetricId);
+                Assert.AreEqual(MetricConfigurations.Common.Measurement(), metric.GetConfiguration());
+                Assert.AreEqual("Dim 1", metric.Identifier.GetDimensionName(1));
+                Assert.AreEqual("Dim 2", metric.Identifier.GetDimensionName(2));
+                Assert.AreEqual("Dim 3", metric.Identifier.GetDimensionName(3));
+                Assert.AreEqual("Dim 4", metric.Identifier.GetDimensionName(4));
+                Assert.AreEqual("Dim 5", metric.Identifier.GetDimensionName(5));
+                Assert.AreEqual("Dim 6", metric.Identifier.GetDimensionName(6));
+                Assert.AreEqual("Dim 7", metric.Identifier.GetDimensionName(7));
+                Assert.AreEqual("Dim 8", metric.Identifier.GetDimensionName(8));
+                Assert.AreEqual("Dim 9", metric.Identifier.GetDimensionName(9));
+                Assert.AreEqual("Dim 10", metric.Identifier.GetDimensionName(10));
+
+                metric.TrackValue(0.5, true, ["DV1", "DV2", "DV3", "DV4", "DV5", "DV6", "DV7", "DV8", "DV9", "DV10"]);
+                metric.TrackValue(0.6, true, ["DV1", "DV2", "DV3", "DV4", "DV5", "DV6", "DV7", "DV8", "DV9", "DV10"]);
+
+                telemetryPipeline.GetMetricManager().Flush();
+                Assert.AreEqual(1, sentTelemetry.Count);
+
+                MetricTelemetry[] orderedTelemetry = sentTelemetry
+                                        .OrderByDescending( (t) => ((MetricTelemetry) t).Count * 10000 + ((MetricTelemetry) t).Sum )
+                                        .Select( (t) => (MetricTelemetry) t )
+                                        .ToArray();
+
+                TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], "Test MetricNamespace", "Test MetricId", 2, 1.1, 0.6, 0.5, 0.05);
+                Assert.AreEqual(11, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("DV1", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 1"]);
+                Assert.AreEqual("DV2", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 2"]);
+                Assert.AreEqual("DV3", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 3"]);
+                Assert.AreEqual("DV4", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 4"]);
+                Assert.AreEqual("DV5", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 5"]);
+                Assert.AreEqual("DV6", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 6"]);
+                Assert.AreEqual("DV7", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 7"]);
+                Assert.AreEqual("DV8", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 8"]);
+                Assert.AreEqual("DV9", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 9"]);
+                Assert.AreEqual("DV10", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 10"]);
+                sentTelemetry.Clear();
+
+                metric.TrackValue(0.7, true, ["DV1", "DV2", "DV3", "DV4", "DV5", "DV6", "DV7", "DV8", "DV9", "DV10"]);
+                metric.TrackValue(0.8, true, ["DV1", "DV2", "DV3", "DV4", "DV5", "DV6a", "DV7", "DV8", "DV9", "DV10"]);
+
+                telemetryPipeline.GetMetricManager().Flush();
+                Assert.AreEqual(2, sentTelemetry.Count);
+
+                orderedTelemetry = sentTelemetry
+                                        .OrderByDescending( (t) => ((MetricTelemetry) t).Count * 10000 + ((MetricTelemetry) t).Sum )
+                                        .Select( (t) => (MetricTelemetry) t )
+                                        .ToArray();
+
+                TestUtil.ValidateNumericAggregateValues(orderedTelemetry[0], "Test MetricNamespace", "Test MetricId", 1, 0.8, 0.8, 0.8, 0);
+                Assert.AreEqual(11, ((MetricTelemetry)orderedTelemetry[0]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[0]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("DV1", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 1"]);
+                Assert.AreEqual("DV2", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 2"]);
+                Assert.AreEqual("DV3", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 3"]);
+                Assert.AreEqual("DV4", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 4"]);
+                Assert.AreEqual("DV5", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 5"]);
+                Assert.AreEqual("DV6a", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 6"]);
+                Assert.AreEqual("DV7", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 7"]);
+                Assert.AreEqual("DV8", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 8"]);
+                Assert.AreEqual("DV9", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 9"]);
+                Assert.AreEqual("DV10", ((MetricTelemetry)orderedTelemetry[0]).Properties["Dim 10"]);
+
+                TestUtil.ValidateNumericAggregateValues(orderedTelemetry[1], "Test MetricNamespace", "Test MetricId", 1, 0.7, 0.7, 0.7, 0);
+                Assert.AreEqual(11, ((MetricTelemetry)orderedTelemetry[1]).Properties.Count);
+                Assert.IsTrue(((MetricTelemetry)orderedTelemetry[1]).Properties.ContainsKey(TestUtil.AggregationIntervalMonikerPropertyKey));
+                Assert.AreEqual("DV1", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 1"]);
+                Assert.AreEqual("DV2", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 2"]);
+                Assert.AreEqual("DV3", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 3"]);
+                Assert.AreEqual("DV4", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 4"]);
+                Assert.AreEqual("DV5", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 5"]);
+                Assert.AreEqual("DV6", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 6"]);
+                Assert.AreEqual("DV7", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 7"]);
+                Assert.AreEqual("DV8", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 8"]);
+                Assert.AreEqual("DV9", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 9"]);
+                Assert.AreEqual("DV10", ((MetricTelemetry)orderedTelemetry[1]).Properties["Dim 10"]);
+
+                sentTelemetry.Clear();
+            }
 
             TestUtil.CompleteDefaultAggregationCycle(telemetryPipeline.GetMetricManager());
             telemetryPipeline.Dispose();

--- a/BASE/src/Microsoft.ApplicationInsights/Metric.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metric.cs
@@ -1225,13 +1225,14 @@ namespace Microsoft.ApplicationInsights
         /// </summary>
         /// <param name="metricValue">The value to be aggregated.</param>
         /// <param name="dimensionValues">The dimension values for this metric.</param>
+        /// <param name="createIfNotExists">Whether to attempt creating a metric series for the specified dimension values if it does not exist.</param>
         /// <returns><c>True</c> if the specified value was added to the <c>MetricSeries</c> indicated by the specified dimension name;
         /// <c>False</c> if the indicated series could not be created because a dimension cap or a metric series cap was reached.</returns>
         /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
-        public bool TrackValue(double metricValue, params string[] dimensionValues)
+        public bool TrackValue(double metricValue, bool createIfNotExists, params string[] dimensionValues)
         {
             MetricSeries series;
-            bool canTrack = this.TryGetDataSeries(out series, true, dimensionValues);
+            bool canTrack = this.TryGetDataSeries(out series, createIfNotExists, dimensionValues);
             if (canTrack)
             {
                 series.TrackValue(metricValue);
@@ -1247,13 +1248,14 @@ namespace Microsoft.ApplicationInsights
         /// </summary>
         /// <param name="metricValue">The value to be aggregated.</param>
         /// <param name="dimensionValues">The dimension values for this metric.</param>
+        /// <param name="createIfNotExists">Whether to attempt creating a metric series for the specified dimension values if it does not exist.</param>
         /// <returns><c>True</c> if the specified value was added to the <c>MetricSeries</c> indicated by the specified dimension name;
         /// <c>False</c> if the indicated series could not be created because a dimension cap or a metric series cap was reached.</returns>
         /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
-        public bool TrackValue(object metricValue, params string[] dimensionValues)
+        public bool TrackValue(object metricValue, bool createIfNotExists, params string[] dimensionValues)
         {
             MetricSeries series;
-            if (this.TryGetDataSeries(out series, true, dimensionValues))
+            if (this.TryGetDataSeries(out series, createIfNotExists, dimensionValues))
             {
                 series.TrackValue(metricValue);
                 return true;

--- a/BASE/src/Microsoft.ApplicationInsights/Metric.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metric.cs
@@ -1229,7 +1229,7 @@ namespace Microsoft.ApplicationInsights
         /// <returns><c>True</c> if the specified value was added to the <c>MetricSeries</c> indicated by the specified dimension name;
         /// <c>False</c> if the indicated series could not be created because a dimension cap or a metric series cap was reached.</returns>
         /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
-        public bool TrackValue(double metricValue, bool createIfNotExists, params string[] dimensionValues)
+        public bool TrackValue(double metricValue, bool createIfNotExists, string[] dimensionValues)
         {
             MetricSeries series;
             bool canTrack = this.TryGetDataSeries(out series, createIfNotExists, dimensionValues);
@@ -1252,7 +1252,7 @@ namespace Microsoft.ApplicationInsights
         /// <returns><c>True</c> if the specified value was added to the <c>MetricSeries</c> indicated by the specified dimension name;
         /// <c>False</c> if the indicated series could not be created because a dimension cap or a metric series cap was reached.</returns>
         /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
-        public bool TrackValue(object metricValue, bool createIfNotExists, params string[] dimensionValues)
+        public bool TrackValue(object metricValue, bool createIfNotExists, string[] dimensionValues)
         {
             MetricSeries series;
             if (this.TryGetDataSeries(out series, createIfNotExists, dimensionValues))

--- a/BASE/src/Microsoft.ApplicationInsights/Metric.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metric.cs
@@ -1,4 +1,6 @@
-﻿namespace Microsoft.ApplicationInsights
+﻿using System.Linq;
+
+namespace Microsoft.ApplicationInsights
 {
     using System;
     using System.Collections.Generic;
@@ -1208,6 +1210,50 @@
                             dimension8Value,
                             dimension9Value,
                             dimension10Value))
+            {
+                series.TrackValue(metricValue);
+                return true;
+            }
+
+            return false;
+        }
+        
+        /// <summary>
+        /// Tracks the specified value using the <c>MetricSeries</c> associated with the specified dimension value.<br />
+        /// An aggregate representing tracked values will be automatically sent to the cloud ingestion endpoint at the end of each aggregation period.
+        /// This overload accepts n dimension values, up to 10. The amount of dimension values needs to match the dimensionality of this Metric.
+        /// </summary>
+        /// <param name="metricValue">The value to be aggregated.</param>
+        /// <param name="dimensionValues">The dimension values for this metric.</param>
+        /// <returns><c>True</c> if the specified value was added to the <c>MetricSeries</c> indicated by the specified dimension name;
+        /// <c>False</c> if the indicated series could not be created because a dimension cap or a metric series cap was reached.</returns>
+        /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
+        public bool TrackValue(double metricValue, params string[] dimensionValues)
+        {
+            MetricSeries series;
+            bool canTrack = this.TryGetDataSeries(out series, true, dimensionValues);
+            if (canTrack)
+            {
+                series.TrackValue(metricValue);
+            }
+
+            return canTrack;
+        }
+
+        /// <summary>
+        /// Tracks the specified value using the <c>MetricSeries</c> associated with the specified dimension value.<br />
+        /// An aggregate representing tracked values will be automatically sent to the cloud ingestion endpoint at the end of each aggregation period.
+        /// This overload accepts n dimension values, up to 10. The amount of dimension values needs to match the dimensionality of this Metric.
+        /// </summary>
+        /// <param name="metricValue">The value to be aggregated.</param>
+        /// <param name="dimensionValues">The dimension values for this metric.</param>
+        /// <returns><c>True</c> if the specified value was added to the <c>MetricSeries</c> indicated by the specified dimension name;
+        /// <c>False</c> if the indicated series could not be created because a dimension cap or a metric series cap was reached.</returns>
+        /// <exception cref="ArgumentException">If the number of specified dimension names does not match the dimensionality of this <c>Metric</c>.</exception>
+        public bool TrackValue(object metricValue, params string[] dimensionValues)
+        {
+            MetricSeries series;
+            if (this.TryGetDataSeries(out series, true, dimensionValues))
             {
                 series.TrackValue(metricValue);
                 return true;

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -1339,15 +1339,15 @@
         /// See <see cref="MetricAggregationScope" /> for more info.</param>
         /// <param name="dimensions">Up to 10 custom dimensions for this metric.</param>
         public Metric GetMetric(
-            string metricId,
-            MetricConfiguration metricConfiguration,
-            MetricAggregationScope aggregationScope,
-            params string[] dimensions)
+                            string metricId,
+                            MetricConfiguration metricConfiguration,
+                            MetricAggregationScope aggregationScope,
+                            params string[] dimensions)
         {
             return this.GetOrCreateMetric(
-                aggregationScope,
-                new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimensions),
-                metricConfiguration);
+                        aggregationScope,
+                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimensions),
+                        metricConfiguration);
         }
 
         private Metric GetOrCreateMetric(

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -1289,6 +1289,67 @@
                         metricConfiguration);
         }
 
+        /// <summary>
+        /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
+        /// Optionally specify a metric configuration to control how the tracked values are aggregated.
+        /// This overload can contain up to 10 custom dimensions.
+        /// </summary>
+        /// <param name="metricId">The ID (name) of the metric.
+        ///   (The namespace specified in <see cref="MetricIdentifier.DefaultMetricNamespace"/> will be used.
+        ///   To specify another namespace, use an overload that takes a <c>MetricIdentifier</c> parameter instead.)</param>
+        /// <param name="metricConfiguration">Determines how tracked values will be aggregated. <br />
+        /// Use presets in <see cref="MetricConfigurations.Common"/> or specify your own settings. </param>
+        /// <returns>A <c>Metric</c> with the specified ID and dimensions. If you call this method several times
+        /// with the same metric ID and dimensions for a given aggregation scope, you will receive the same
+        /// instance of <c>Metric</c>.</returns>
+        /// <exception cref="ArgumentException">If you previously created a metric with the same namespace, ID, dimensions
+        /// and aggregation scope, but with a different configuration. When calling this method to get a previously
+        /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
+        /// configuration used earlier.</exception>
+        /// <param name="dimensions">Up to 10 custom dimensions for this metric.</param>
+        public Metric GetMetric(
+                            string metricId,
+                            MetricConfiguration metricConfiguration,
+                            params string[] dimensions)
+        {
+            return this.GetOrCreateMetric(
+                        MetricAggregationScope.TelemetryConfiguration,
+                        new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimensions),
+                        metricConfiguration);
+        }
+        
+        /// <summary>
+        /// Gets or creates a metric container that you can use to track, aggregate and send metric values.<br />
+        /// Optionally specify a metric configuration to control how the tracked values are aggregated.
+        /// This overload can contain up to 10 custom dimensions.
+        /// </summary>
+        /// <param name="metricId">The ID (name) of the metric.
+        ///   (The namespace specified in <see cref="MetricIdentifier.DefaultMetricNamespace"/> will be used.
+        ///   To specify another namespace, use an overload that takes a <c>MetricIdentifier</c> parameter instead.)</param>
+        /// <param name="metricConfiguration">Determines how tracked values will be aggregated. <br />
+        /// Use presets in <see cref="MetricConfigurations.Common"/> or specify your own settings. </param>
+        /// <returns>A <c>Metric</c> with the specified ID and dimensions. If you call this method several times
+        /// with the same metric ID and dimensions for a given aggregation scope, you will receive the same
+        /// instance of <c>Metric</c>.</returns>
+        /// <exception cref="ArgumentException">If you previously created a metric with the same namespace, ID, dimensions
+        /// and aggregation scope, but with a different configuration. When calling this method to get a previously
+        /// created metric, you can simply avoid specifying any configuration (or specify null) to imply the
+        /// configuration used earlier.</exception>
+        /// <param name="aggregationScope">The scope across which the values for the metric are to be aggregated in memory.
+        /// See <see cref="MetricAggregationScope" /> for more info.</param>
+        /// <param name="dimensions">Up to 10 custom dimensions for this metric.</param>
+        public Metric GetMetric(
+            string metricId,
+            MetricConfiguration metricConfiguration,
+            MetricAggregationScope aggregationScope,
+            params string[] dimensions)
+        {
+            return this.GetOrCreateMetric(
+                aggregationScope,
+                new MetricIdentifier(MetricIdentifier.DefaultMetricNamespace, metricId, dimensions),
+                metricConfiguration);
+        }
+
         private Metric GetOrCreateMetric(
                                     MetricAggregationScope aggregationScope,
                                     MetricIdentifier metricIdentifier,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## VNext
 - [Populate required field Message with "n/a" if it is empty](https://github.com/microsoft/ApplicationInsights-dotnet/issues/1066)
+- [Improve API for handling custom metric dimensions](https://github.com/microsoft/ApplicationInsights-dotnet/issues/2906)
 
 ## Version 2.22.0
 - no changes since beta.


### PR DESCRIPTION
Fix Issue #2906.

## Changes
- Add `TelemetryClient.GetMetric` overload that accepts `n` number of dimensions;
- Add `Metric.TrackValue` overload that accepts `n` number of dimension values.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

~~For significant contributions please make sure you have completed the following items:~~

~~- [ ] Design discussion issue #~~
~~- [ ] Changes in public surface reviewed~~

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
