### PR TITLE
remove redundant null check for dispose of telemetryProcessors

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/TelemetryProcessorChain.cs
@@ -70,16 +70,11 @@
         {
             if (disposing)
             {
-                SnapshottingList<ITelemetryProcessor> processors = this.telemetryProcessors;
-
-                if (processors != null)
+                foreach (ITelemetryProcessor processor in this.telemetryProcessors)
                 {
-                    foreach (ITelemetryProcessor processor in processors)
+                    if (processor is IDisposable disposableProcessor)
                     {
-                        if (processor is IDisposable disposableProcessor)
-                        {
-                            disposableProcessor.Dispose();
-                        }
+                        disposableProcessor.Dispose();
                     }
                 }
             }


### PR DESCRIPTION
Fix Issue # .

## Changes

remove some code that is redundant


### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

no change log required

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
