### PR TITLE
missing usings for DiagnosticListener instances

### DIFF
--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/TelemetryInitializers/OperationNameTelemetryInitializerTests.cs
@@ -97,7 +97,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var telemetryListener = new DiagnosticListener(TestListenerName);
+            using var telemetryListener = new DiagnosticListener(TestListenerName);
             using (var listener = CreateHostingListener(AspNetCoreMajorVersion.One))
             {
                 telemetryListener.Subscribe(listener);
@@ -119,7 +119,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var telemetryListener = new DiagnosticListener(TestListenerName);
+            using var telemetryListener = new DiagnosticListener(TestListenerName);
             using (var listener = CreateHostingListener(AspNetCoreMajorVersion.One))
             {
                 telemetryListener.Subscribe(listener);
@@ -140,7 +140,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var telemetryListener = new DiagnosticListener(TestListenerName);
+            using var telemetryListener = new DiagnosticListener(TestListenerName);
             using (var listener = CreateHostingListener(AspNetCoreMajorVersion.One))
             {
                 telemetryListener.Subscribe(listener);
@@ -163,7 +163,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var telemetryListener = new DiagnosticListener(TestListenerName);
+            using var telemetryListener = new DiagnosticListener(TestListenerName);
             using (var listener = CreateHostingListener(AspNetCoreMajorVersion.One))
             {
                 telemetryListener.Subscribe(listener);
@@ -189,7 +189,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
 
-            var telemetryListener = new DiagnosticListener(TestListenerName);
+            using var telemetryListener = new DiagnosticListener(TestListenerName);
             using (var listener = CreateHostingListener(AspNetCoreMajorVersion.One))
             {
                 telemetryListener.Subscribe(listener);
@@ -211,7 +211,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Tests.TelemetryInitializers
             actionContext.RouteData.Values.Add(TreeRouter.RouteGroupKey, "RouteGroupKey");
 
             var contextAccessor = HttpContextAccessorHelper.CreateHttpContextAccessor(new RequestTelemetry(), actionContext);
-            var telemetryListener = new DiagnosticListener(TestListenerName);
+            using var telemetryListener = new DiagnosticListener(TestListenerName);
             using (var listener = CreateHostingListener(AspNetCoreMajorVersion.One))
             {
                 telemetryListener.Subscribe(listener);

--- a/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
+++ b/WEB/Src/DependencyCollector/DependencyCollector.Tests/Implementation/AzureSdkDiagnosticListenerTest.cs
@@ -69,8 +69,8 @@
                 listener.StartActivity(sendActivity, null);
                 listener.StopActivity(sendActivity, null);
 
-                var listenerAnother = new DiagnosticListener("Azure.AnotherClient");
-                var listenerYetAnother = new DiagnosticListener("Azure.YetAnotherClient");
+                using var listenerAnother = new DiagnosticListener("Azure.AnotherClient");
+                using var listenerYetAnother = new DiagnosticListener("Azure.YetAnotherClient");
 
                 Assert.AreEqual(0, this.sentItems.Count);
             }


### PR DESCRIPTION
Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
