### PR TITLE
remove un-used stringwriter from SerializeWritesHasFullStackPropertyA…

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/DataContracts/ExceptionTelemetryTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/DataContracts/ExceptionTelemetryTest.cs
@@ -485,15 +485,12 @@
         [TestMethod]
         public void SerializeWritesHasFullStackPropertyAsItIsExpectedByEndpoint()
         {
-            using (var stringWriter = new StringWriter(CultureInfo.InvariantCulture))
-            {
-                var exception = CreateExceptionWithStackTrace();
-                ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
+            var exception = CreateExceptionWithStackTrace();
+            ExceptionTelemetry expected = CreateExceptionTelemetry(exception);
 
-                var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
+            var item = TelemetryItemTestHelper.SerializeDeserializeTelemetryItem<AI.ExceptionData>(expected);
 
-                Assert.IsTrue(item.data.baseData.exceptions[0].hasFullStack);
-            }
+            Assert.IsTrue(item.data.baseData.exceptions[0].hasFullStack);
         }
 
         [TestMethod]


### PR DESCRIPTION
…sItIsExpectedByEndpoint

Fix Issue # .

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
