### PR TITLE
make SerializeWritesRootExceptionWithoutOuterId fail

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/DataContracts/ExceptionTelemetryTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/DataContracts/ExceptionTelemetryTest.cs
@@ -424,15 +424,13 @@
         [TestMethod]
         public void SerializeWritesRootExceptionWithoutOuterId()
         {
-            using (var stringWriter = new StringWriter(CultureInfo.InvariantCulture))
-            {
-                var exception = new Exception();
-                ExceptionTelemetry original = CreateExceptionTelemetry(exception);
-                byte[] serializedTelemetryAsBytes = JsonSerializer.Serialize(original, compress: false);
-                string serializedTelemetry = Encoding.UTF8.GetString(serializedTelemetryAsBytes, 0, serializedTelemetryAsBytes.Length);
+            var exception = new Exception();
+            ExceptionTelemetry original = CreateExceptionTelemetry(exception);
+            byte[] serializedTelemetryAsBytes = JsonSerializer.Serialize(original, compress: false);
+            string serializedTelemetry =
+                Encoding.UTF8.GetString(serializedTelemetryAsBytes, 0, serializedTelemetryAsBytes.Length);
 
-                AssertEx.DoesNotContain("\"outerId\":", stringWriter.ToString(), StringComparison.OrdinalIgnoreCase);
-            }
+            AssertEx.DoesNotContain("\"outerId\":", serializedTelemetry, StringComparison.OrdinalIgnoreCase);
         }
 
         [TestMethod]


### PR DESCRIPTION
Fix Issue # .

I think SerializeWritesRootExceptionWithoutOuterId  is problematic. it creates a new StringWriter, then does nothing to it, then asserts it does not contain a string. which obviously it doesnt because it will be empty

so i changed the test to assert on the output of JsonSerializer.Serialize. now it fails. but now i dont know what the correct behavior should be??

## Changes
(Please provide a brief description of the changes here.)

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
