### PR TITLE
pass headers in TestRequestWithNoCorrelationHeaders

### DIFF
--- a/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
+++ b/NETCORE/test/FunctionalTests.WebApi.Tests/FunctionalTest/RequestCorrelationTests.cs
@@ -43,7 +43,7 @@
                     { "Request-Context", "appId=value"},
                 };
 
-                var item = this.ValidateBasicRequest(server, RequestPath, expectedRequestTelemetry);
+                var item = this.ValidateRequestWithHeaders(server, RequestPath, requestHeaders, expectedRequestTelemetry);
 
                 Assert.Equal(32, item.tags["ai.operation.id"].Length);
                 Assert.True(Regex.Match(item.tags["ai.operation.id"], @"[a-z][0-9]").Success);


### PR DESCRIPTION
Fix Issue # .

## Changes

I cant tell if the headers should be passed, or the variable should be burned?

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
