### PR TITLE
remove stopwatch that is checking if a Thread.Sleep is working

### DIFF
--- a/WEB/Src/PerformanceCollector/Perf.Tests/WebAppPerformanceCollector/NormalizedCPUPercenageGaugeTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/WebAppPerformanceCollector/NormalizedCPUPercenageGaugeTests.cs
@@ -28,9 +28,7 @@
             Assert.IsTrue(Math.Abs(value1) < 0.000001);
             Assert.IsTrue(Math.Abs(normalizedValue1) < 0.000001);
 
-            Stopwatch sw = Stopwatch.StartNew();
             Thread.Sleep(TimeSpan.FromSeconds(10));
-            long actualSleepTimeTicks = sw.Elapsed.Ticks;
 
             double value2 = gauge.Collect();
             double normalizedValue2 = normalizedGauge.Collect();


### PR DESCRIPTION
Fix Issue # .

## Changes

i assume someone didnt trust Thread.Sleep and was double checking

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
