### PR TITLE
fix compiler issue re: `Reverse()` method in Test project.

### DIFF
--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
@@ -643,7 +643,7 @@
             telemetryProcessor.Process(trace);
 
             // ASSERT
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().Reverse().ToArray();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray();
 
             var expectedProperties =
                 new Dictionary<string, string>()
@@ -766,7 +766,7 @@
 
             // ASSERT
             // even though Success is set to false, since ResponseCode is empty the special case logic must have turned it into true
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().Reverse().ToArray().Single();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray().Single();
             double metricValue = accumulatorManager.CurrentDataAccumulator.CollectionConfigurationAccumulator.MetricAccumulators["Metric1"].CalculateAggregation(out long count);
 
             Assert.AreEqual(1, count);
@@ -822,7 +822,7 @@
             telemetryProcessor.Process(dependency);
             
             // ASSERT
-            Assert.AreEqual(TelemetryDocumentType.RemoteDependency.ToString(), accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().Reverse().ToArray().Single().DocumentType);
+            Assert.AreEqual(TelemetryDocumentType.RemoteDependency.ToString(), accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray().Single().DocumentType);
         }
 
         [TestMethod]
@@ -911,7 +911,7 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<RequestTelemetryDocument>()
                     .ToArray();
 
@@ -919,7 +919,7 @@
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<RequestTelemetryDocument>()
                     .ToArray();
 
@@ -1038,7 +1038,7 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<DependencyTelemetryDocument>()
                     .ToArray();
 
@@ -1046,7 +1046,7 @@
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<DependencyTelemetryDocument>()
                     .ToArray();
 
@@ -1166,7 +1166,7 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<ExceptionTelemetryDocument>()
                     .ToArray();
 
@@ -1174,7 +1174,7 @@
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<ExceptionTelemetryDocument>()
                     .ToArray();
 
@@ -1292,13 +1292,13 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<EventTelemetryDocument>()
                     .ToArray();
 
             var collectedTelemetryStreamSuccessOnly =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
-                    document => document.DocumentStreamIds.Contains("StreamSuccessOnly")).ToArray().Reverse().Cast<EventTelemetryDocument>().ToArray();
+                    document => document.DocumentStreamIds.Contains("StreamSuccessOnly")).ToArray().Cast<EventTelemetryDocument>().ToArray();
 
             // the quota is 3 initially, then 0.5 every second (but not more than 30)
 
@@ -1413,7 +1413,7 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<TraceTelemetryDocument>()
                     .ToArray();
 
@@ -1421,7 +1421,7 @@
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    .Reverse()
+                    //.Reverse()
                     .Cast<TraceTelemetryDocument>()
                     .ToArray();
 
@@ -1520,7 +1520,7 @@
                 var collectedTelemetryForStream =
                     accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains(streamId))
                         .ToArray()
-                        .Reverse()
+                        //.Reverse()
                         .Cast<RequestTelemetryDocument>()
                         .ToArray();
 
@@ -3154,7 +3154,7 @@
             // ASSERT
             Assert.IsFalse(accumulatorManager.CurrentDataAccumulator.GlobalDocumentQuotaReached);
             Assert.AreEqual(1, accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Count);
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().Reverse().ToArray();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray();
 
             Assert.AreEqual(TelemetryDocumentType.Request, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[0].DocumentType));
             var requestTelemetryDocument = (RequestTelemetryDocument)collectedTelemetry[0];
@@ -3198,7 +3198,7 @@
             // ASSERT
             Assert.IsFalse(accumulatorManager.CurrentDataAccumulator.GlobalDocumentQuotaReached);
             Assert.AreEqual(1, accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Count);
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().Reverse().ToArray();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray();
 
             Assert.AreEqual(TelemetryDocumentType.Request, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[0].DocumentType));
             var requestTelemetryDocument = (RequestTelemetryDocument)collectedTelemetry[0];

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
@@ -766,7 +766,7 @@
 
             // ASSERT
             // even though Success is set to false, since ResponseCode is empty the special case logic must have turned it into true
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Reverse().ToArray().Single();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Single();
             double metricValue = accumulatorManager.CurrentDataAccumulator.CollectionConfigurationAccumulator.MetricAccumulators["Metric1"].CalculateAggregation(out long count);
 
             Assert.AreEqual(1, count);
@@ -822,7 +822,7 @@
             telemetryProcessor.Process(dependency);
             
             // ASSERT
-            Assert.AreEqual(TelemetryDocumentType.RemoteDependency.ToString(), accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Reverse().ToArray().Single().DocumentType);
+            Assert.AreEqual(TelemetryDocumentType.RemoteDependency.ToString(), accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Single().DocumentType);
         }
 
         [TestMethod]
@@ -3154,7 +3154,7 @@
             // ASSERT
             Assert.IsFalse(accumulatorManager.CurrentDataAccumulator.GlobalDocumentQuotaReached);
             Assert.AreEqual(1, accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Count);
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray();
 
             Assert.AreEqual(TelemetryDocumentType.Request, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[0].DocumentType));
             var requestTelemetryDocument = (RequestTelemetryDocument)collectedTelemetry[0];
@@ -3198,7 +3198,7 @@
             // ASSERT
             Assert.IsFalse(accumulatorManager.CurrentDataAccumulator.GlobalDocumentQuotaReached);
             Assert.AreEqual(1, accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Count);
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray();
 
             Assert.AreEqual(TelemetryDocumentType.Request, Enum.Parse(typeof(TelemetryDocumentType), collectedTelemetry[0].DocumentType));
             var requestTelemetryDocument = (RequestTelemetryDocument)collectedTelemetry[0];

--- a/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
+++ b/WEB/Src/PerformanceCollector/Perf.Tests/QuickPulse/QuickPulseTelemetryProcessorTests.cs
@@ -643,7 +643,7 @@
             telemetryProcessor.Process(trace);
 
             // ASSERT
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Reverse().ToArray();
 
             var expectedProperties =
                 new Dictionary<string, string>()
@@ -766,7 +766,7 @@
 
             // ASSERT
             // even though Success is set to false, since ResponseCode is empty the special case logic must have turned it into true
-            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray().Single();
+            var collectedTelemetry = accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Reverse().ToArray().Single();
             double metricValue = accumulatorManager.CurrentDataAccumulator.CollectionConfigurationAccumulator.MetricAccumulators["Metric1"].CalculateAggregation(out long count);
 
             Assert.AreEqual(1, count);
@@ -822,7 +822,7 @@
             telemetryProcessor.Process(dependency);
             
             // ASSERT
-            Assert.AreEqual(TelemetryDocumentType.RemoteDependency.ToString(), accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.ToArray().ToArray().Single().DocumentType);
+            Assert.AreEqual(TelemetryDocumentType.RemoteDependency.ToString(), accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Reverse().ToArray().Single().DocumentType);
         }
 
         [TestMethod]
@@ -911,16 +911,16 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<RequestTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             var collectedTelemetryStreamSuccessOnly =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<RequestTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             // the quota is 3 initially, then 0.5 every second (but not more than 30)
@@ -1038,16 +1038,16 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<DependencyTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             var collectedTelemetryStreamSuccessOnly =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<DependencyTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             // the quota is 3 initially, then 0.5 every second (but not more than 30)
@@ -1166,16 +1166,16 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<ExceptionTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             var collectedTelemetryStreamSuccessOnly =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<ExceptionTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             // the quota is 3 initially, then 0.5 every second (but not more than 30)
@@ -1292,13 +1292,13 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<EventTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             var collectedTelemetryStreamSuccessOnly =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
-                    document => document.DocumentStreamIds.Contains("StreamSuccessOnly")).ToArray().Cast<EventTelemetryDocument>().ToArray();
+                    document => document.DocumentStreamIds.Contains("StreamSuccessOnly")).ToArray().Cast<EventTelemetryDocument>().Reverse().ToArray();
 
             // the quota is 3 initially, then 0.5 every second (but not more than 30)
 
@@ -1413,16 +1413,16 @@
             var collectedTelemetryStreamAll =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains("StreamAll"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<TraceTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             var collectedTelemetryStreamSuccessOnly =
                 accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(
                     document => document.DocumentStreamIds.Contains("StreamSuccessOnly"))
                     .ToArray()
-                    //.Reverse()
                     .Cast<TraceTelemetryDocument>()
+                    .Reverse()
                     .ToArray();
 
             // the quota is 3 initially, then 0.5 every second (but not more than 30)
@@ -1520,8 +1520,8 @@
                 var collectedTelemetryForStream =
                     accumulatorManager.CurrentDataAccumulator.TelemetryDocuments.Where(document => document.DocumentStreamIds.Contains(streamId))
                         .ToArray()
-                        //.Reverse()
                         .Cast<RequestTelemetryDocument>()
+                        .Reverse()
                         .ToArray();
 
                 Assert.AreEqual(maxGlobalTelemetryQuota, collectedTelemetryForStream.Length);


### PR DESCRIPTION
Discovered a new issue affecting test projects today. 

> CS0023	Operator '.' cannot be applied to operand of type 'void'

The problems appears to be with the use of the `Reverse()` method.
In each of the use cases, the `Reverse()` method is being called on an array of `TelemetryDocument` objects.
Each of the use cases are expecting to use the [Linq Reverse method](https://learn.microsoft.com/en-us/dotnet/api/system.linq.enumerable.reverse?view=net-9.0), which returns an IEnumerable and can be used to chain multiple methods.
Instead, the compiler has started selecting the [Array Reverse method](https://learn.microsoft.com/en-us/dotnet/api/system.array.reverse?view=net-9.0) which returns a void which causes the above error.

I don't know what has caused the sudden breaking change. The last successful build was 2 weeks ago and was using .NET 8.0.12. Today's CI is using 8.0.13.

This PR fixes the issue by changing the order in which Reverse() is called to ensure it's being called on an Enumerable instead of on the Array type.
