### PR TITLE
Use AADAudience connection string value wjhen present

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
@@ -159,6 +159,54 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         }
 
         [TestMethod]
+        public void VerifyAudience_AddsTrailingSlash()
+        {
+            var expectedAudience = "https://monitor.azure.com/";
+            var mockCredential = new MockCredential();
+
+            var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
+            reflectionCredentialEnvelope.Audience = "https://monitor.azure.com";
+
+            Assert.AreEqual(expectedAudience, reflectionCredentialEnvelope.Audience);
+        }
+
+        [TestMethod]
+        public void VerifyAudience_DefaultsToProduction()
+        {
+            var expectedAudience = "https://monitor.azure.com/";
+            var mockCredential = new MockCredential();
+
+            var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
+
+            Assert.AreEqual(expectedAudience, reflectionCredentialEnvelope.Audience);
+        }
+
+        [TestMethod]
+        public void VerifyScopes_AddsDotDefault()
+        {
+            var expectedScope = "https://monitor.azure.us/.default";
+            var mockCredential = new MockCredential();
+
+            var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
+            reflectionCredentialEnvelope.Audience = "https://monitor.azure.us";
+
+            Assert.AreEqual(1, reflectionCredentialEnvelope.Scopes.Length);
+            Assert.AreEqual(expectedScope, reflectionCredentialEnvelope.Scopes[0]);
+        }
+
+        [TestMethod]
+        public void VerifyScopes_DefaultsToProduction()
+        {
+            var expectedScope = "https://monitor.azure.com/.default";
+            var mockCredential = new MockCredential();
+
+            var reflectionCredentialEnvelope = new ReflectionCredentialEnvelope(mockCredential);
+
+            Assert.AreEqual(1, reflectionCredentialEnvelope.Scopes.Length);
+            Assert.AreEqual(expectedScope, reflectionCredentialEnvelope.Scopes[0]);
+        }
+
+        [TestMethod]
         public void VerifyGetToken_IfCredentialThrowsException_EnvelopeReturnsNull()
         {
             Mock<TokenCredential> mockTokenCredential = new Mock<TokenCredential>();

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelopeTests.cs
@@ -29,6 +29,8 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
     [TestCategory("AAD")]
     public class ReflectionCredentialEnvelopeTests
     {
+        private readonly string[] defaultScope = new string[] { "https://monitor.azure.com/.default" };
+
         [TestMethod]
         public void VerifyCanIdentifyValidClass()
         {
@@ -130,7 +132,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         [TestMethod]
         public void VerifyGetToken_ReturnsValidToken()
         {
-            var requestContext = new TokenRequestContext(scopes: AuthConstants.GetScopes());
+            var requestContext = new TokenRequestContext(scopes: defaultScope);
             var mockCredential = new MockCredential();
             var tokenFromCredential = mockCredential.GetToken(requestContext, CancellationToken.None);
 
@@ -147,7 +149,7 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
         [TestMethod]
         public async Task VerifyGetTokenAsync_ReturnsValidToken()
         {
-            var requestContext = new TokenRequestContext(scopes: AuthConstants.GetScopes());
+            var requestContext = new TokenRequestContext(scopes: defaultScope);
             var mockCredential = new MockCredential();
             var tokenFromCredential = await mockCredential.GetTokenAsync(requestContext, CancellationToken.None);
 

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TelemetryConfigurationCredentialEnvelopeTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Extensibility/Implementation/Authentication/TelemetryConfigurationCredentialEnvelopeTests.cs
@@ -92,6 +92,60 @@ namespace Microsoft.ApplicationInsights.TestFramework.Extensibility.Implementati
             tc.SetAzureTokenCredential(new MockCredential());
             Assert.IsTrue(tc.TelemetryChannel.EndpointAddress.Contains("v2.1")); // api switch
         }
+
+        [TestMethod]
+        public void VerifySetCredential_CorrectlyUsesDefaultAudience()
+        {
+            // SETUP
+            var tc = TelemetryConfiguration.CreateDefault();
+
+            // ACT
+            // set credential second
+            tc.SetAzureTokenCredential(new MockCredential());
+            Assert.AreEqual("https://monitor.azure.com/", tc.CredentialEnvelope.Audience); // default audience
+        }
+
+        [TestMethod]
+        public void VerifySetCredential_CorrectlyUsesConnectionStringAudience_ConnectionStringSetFirst()
+        {
+            // SETUP
+            var tc = TelemetryConfiguration.CreateDefault();
+            tc.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=applicationinsights.us;IngestionEndpoint=https://usgovvirginia-1.in.applicationinsights.azure.us/;LiveEndpoint=https://usgovvirginia.livediagnostics.monitor.azure.us/;AADAudience=https://monitor.azure.us/;ApplicationId=00000000-0000-0000-0000-000000000000";
+
+            // ACT
+            // set credential second
+            tc.SetAzureTokenCredential(new MockCredential());
+            Assert.AreEqual("https://monitor.azure.us/", tc.CredentialEnvelope.Audience); // Connection String audience
+        }
+
+        [TestMethod]
+        public void VerifySetCredential_CorrectlyUsesConnectionStringAudience_TokenSetFirst()
+        {
+            // SETUP
+            var tc = TelemetryConfiguration.CreateDefault();
+
+            // ACT
+            // set credential second
+            tc.SetAzureTokenCredential(new MockCredential());
+            Assert.AreEqual("https://monitor.azure.com/", tc.CredentialEnvelope.Audience); // default audience
+
+            tc.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=applicationinsights.us;IngestionEndpoint=https://usgovvirginia-1.in.applicationinsights.azure.us/;LiveEndpoint=https://usgovvirginia.livediagnostics.monitor.azure.us/;AADAudience=https://monitor.azure.us/;ApplicationId=00000000-0000-0000-0000-000000000000";
+            tc.SetAzureTokenCredential(new MockCredential());
+            Assert.AreEqual("https://monitor.azure.us/", tc.CredentialEnvelope.Audience); // Connection String audience
+        }
+
+        [TestMethod]
+        public void VerifySetCredential_CorrectlyDefaultsAudience_ConnectionStringNoAudience()
+        {
+            // SETUP
+            var tc = TelemetryConfiguration.CreateDefault();
+            tc.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000;EndpointSuffix=applicationinsights.us;IngestionEndpoint=https://usgovvirginia-1.in.applicationinsights.azure.us/;LiveEndpoint=https://usgovvirginia.livediagnostics.monitor.azure.us/;ApplicationId=00000000-0000-0000-0000-000000000000";
+
+            // ACT
+            // set credential second
+            tc.SetAzureTokenCredential(new MockCredential());
+            Assert.AreEqual("https://monitor.azure.com/", tc.CredentialEnvelope.Audience); // default audience
+        }
     }
 }
 #endif

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthConstants.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/AuthConstants.cs
@@ -5,18 +5,5 @@
         public const string AuthorizationHeaderName = "Authorization";
 
         public const string AuthorizationTokenPrefix = "Bearer ";
-
-        /// <summary>
-        /// Source: 
-        /// (https://docs.microsoft.com/azure/active-directory/develop/msal-acquire-cache-tokens#scopes-when-acquiring-tokens).
-        /// (https://docs.microsoft.com/azure/active-directory/develop/v2-permissions-and-consent#the-default-scope).
-        /// </summary>
-        private const string AzureMonitorScope = "https://monitor.azure.com//.default";
-
-        /// <summary>
-        /// Get scopes for Azure Monitor as an array.
-        /// </summary>
-        /// <returns>An array of scopes.</returns>
-        public static string[] GetScopes() => new string[] { AzureMonitorScope };
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/CredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/CredentialEnvelope.cs
@@ -15,6 +15,11 @@
         internal abstract object Credential { get; }
 
         /// <summary>
+        /// Gets or sets the audience to retrieve a token for.
+        /// </summary>
+        internal abstract string Audience { get; set; }
+
+        /// <summary>
         /// Gets an Azure.Core.AccessToken.
         /// </summary>
         /// <remarks>

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -27,6 +27,7 @@
 
         private readonly object tokenCredential;
         private readonly object tokenRequestContext;
+        private string audience = "https://monitor.azure.com/";
 
         /// <summary>
         /// Create an instance of <see cref="ReflectionCredentialEnvelope"/>.
@@ -38,7 +39,7 @@
 
             if (IsValidType(tokenCredential))
             {
-                this.tokenRequestContext = AzureCore.MakeTokenRequestContext(scopes: AuthConstants.GetScopes());
+                this.tokenRequestContext = AzureCore.MakeTokenRequestContext(scopes: this.Scopes);
             }
             else
             {
@@ -50,6 +51,53 @@
         /// Gets the TokenCredential instance held by this class.
         /// </summary>
         internal override object Credential => this.tokenCredential;
+
+        internal override string Audience
+        {
+            get
+            {
+                return this.audience;
+            }
+
+            set
+            {
+                if (string.IsNullOrEmpty(value))
+                {
+                    this.audience = "https://monitor.azure.com/";
+                }
+                else
+                {
+                    var normalizedAudience = value;
+                    if (!normalizedAudience.EndsWith("/"))
+                    {
+                        normalizedAudience += "/";
+                    }
+
+                    this.audience = normalizedAudience;
+                }
+            }
+        }
+
+        internal string[] Scopes
+        {
+            get
+            {
+                if (string.IsNullOrEmpty(this.Audience))
+                {
+                    return new string[] { "https://monitor.azure.com/.default" };
+                }
+                else
+                {
+                    var normalizedScope = this.Audience;
+                    if (!normalizedScope.EndsWith("/.default"))
+                    {
+                        normalizedScope += ".default";
+                    }
+
+                    return new string[] { normalizedScope };
+                }
+            }
+        }
 
         /// <summary>
         /// Gets an Azure.Core.AccessToken.

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Authentication/ReflectionCredentialEnvelope.cs
@@ -82,20 +82,13 @@
         {
             get
             {
-                if (string.IsNullOrEmpty(this.Audience))
+                var normalizedScope = this.Audience;
+                if (!normalizedScope.EndsWith(".default"))
                 {
-                    return new string[] { "https://monitor.azure.com/.default" };
+                    normalizedScope += ".default";
                 }
-                else
-                {
-                    var normalizedScope = this.Audience;
-                    if (!normalizedScope.EndsWith("/.default"))
-                    {
-                        normalizedScope += ".default";
-                    }
 
-                    return new string[] { normalizedScope };
-                }
+                return new string[] { normalizedScope };
             }
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -13,6 +13,7 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Authentication;
+    using Microsoft.ApplicationInsights.Extensibility.Implementation.ConfigString;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Endpoints;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Sampling;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
@@ -313,6 +314,14 @@
 
                     // UPDATE APPLICATION ID PROVIDER
                     SetApplicationIdEndpoint(this.ApplicationIdProvider, this.EndpointContainer.FormattedApplicationIdEndpoint, force: true);
+
+                    // UPDATE AAD AUDIENCE
+                    if (this.CredentialEnvelope != null)
+                    {
+                        var parsed = ConfigStringParser.Parse(this.ConnectionString);
+                        parsed.TryGetValue("AADAudience", out var audience);
+                        this.CredentialEnvelope.Audience = audience;
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -432,6 +441,14 @@
             // Update Ingestion Endpoint.
             var ingestionEndpoint = this.EndpointContainer.GetFormattedIngestionEndpoint(enableAAD: true);
             this.SetTelemetryChannelEndpoint(ingestionEndpoint);
+
+            // Update AAD audience if we can
+            if (!string.IsNullOrEmpty(this.ConnectionString))
+            {
+                var parsed = ConfigStringParser.Parse(this.ConnectionString);
+                parsed.TryGetValue("AADAudience", out var audience);
+                this.CredentialEnvelope.Audience = audience;
+            }
         }
 
         internal MetricManager GetMetricManager(bool createIfNotExists)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## VNext
+- Parse AADAudience from ConnectionString to build scope for token requests
 
 ## Version 2.23.0
 - no changes since beta.


### PR DESCRIPTION
Fix Issue # .

## Changes
When a connection string is provided, and it includes an AADAudience component, use that value to build a scope used when fetching tokens. If no AADAudience is available, default to the commercial value to maintain current behavior in commercial/public cloud.

### Checklist
- [x] I ran Unit Tests locally.
- [x] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.

For significant contributions please make sure you have completed the following items:

- [ ] Design discussion issue #
- [ ] Changes in public surface reviewed

The PR will trigger build, unit tests, and functional tests automatically. Please follow [these](https://github.com/Microsoft/ApplicationInsights-dotnet/blob/develop/.github/CONTRIBUTING.md) instructions to build and test locally.

### Notes for authors:
- FxCop and other analyzers will fail the build. To see these errors yourself, compile localy using the Release configuration.
