### PR TITLE
NLog ApplicationInsightsTarget InitializeTarget requires ConnectionString

### DIFF
--- a/LOGGING/test/NLogTarget.Tests/NLogTargetTests.cs
+++ b/LOGGING/test/NLogTarget.Tests/NLogTargetTests.cs
@@ -61,10 +61,12 @@
             config.AddTarget("AITarget", target);
             config.LoggingRules.Add(rule);
 
-            LogManager.Configuration = config;
-            var logger = LogManager.GetLogger("AITarget");
-
-            Assert.ThrowsException<NLogConfigurationException>(() => logger.Info("trigger"));
+            Assert.ThrowsException<NLogConfigurationException>(() =>
+            {
+                LogManager.Configuration = config;
+                var logger = LogManager.GetLogger("AITarget");
+                logger.Info("trigger");
+            });
         }
 
         [TestMethod]
@@ -81,10 +83,12 @@
             config.AddTarget("AITarget", target);
             config.LoggingRules.Add(rule);
 
-            LogManager.Configuration = config;
-            var logger = LogManager.GetLogger("AITarget");
-
-            Assert.ThrowsException<NLogConfigurationException>(() => logger.Info("trigger"));
+            Assert.ThrowsException<NLogConfigurationException>(() =>
+            {
+                LogManager.Configuration = config;
+                var logger = LogManager.GetLogger("AITarget");
+                logger.Info("trigger");
+            });
         }
 
         [TestMethod]

--- a/examples/NLogConsoleApp/Program.cs
+++ b/examples/NLogConsoleApp/Program.cs
@@ -3,6 +3,9 @@
 Console.WriteLine("NLog Console App - Application Insights Example");
 Console.WriteLine("================================================\n");
 
+NLog.Common.InternalLogger.LogToConsole = true;
+NLog.Common.InternalLogger.LogLevel = NLog.LogLevel.Warn;
+
 // Get NLog logger - the ApplicationInsightsTarget will handle telemetry
 var logger = LogManager.GetCurrentClassLogger();
 


### PR DESCRIPTION
NLog automatically deactivates targets that fails to initialize, so no need to keep track of `initializationFailed` introduced with #3009

Same as #3013 but excluding the use of the non-working `FlushAsync`.