### PR TITLE
Simplify TrackRequest/TrackDependency to use override attributes only

### DIFF
--- a/.github/workflows/codeql-csharp.yml
+++ b/.github/workflows/codeql-csharp.yml
@@ -68,6 +68,7 @@ jobs:
         dotnet-version: |
             8.0.x
             9.0.x
+            10.0.x
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net10.0/PublicAPI.Shipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net10.0/PublicAPI.Shipped.txt
@@ -147,7 +147,6 @@ Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.TraceTelemetry(string
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.OperationTelemetry() -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Sanitize() -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>.Telemetry.get -> T
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
@@ -269,7 +268,6 @@ override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Timestamp.
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(object otherObj) -> bool
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.GetHashCode() -> int
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.ToString() -> string
-static Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions.ToInvariantString(this System.Exception exception) -> string
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateDefault() -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateFromConfiguration(string config) -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DefaultMetricNamespace.get -> string

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net462/PublicAPI.Shipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net462/PublicAPI.Shipped.txt
@@ -147,7 +147,6 @@ Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.TraceTelemetry(string
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.OperationTelemetry() -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Sanitize() -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>.Telemetry.get -> T
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
@@ -269,7 +268,6 @@ override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Timestamp.
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(object otherObj) -> bool
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.GetHashCode() -> int
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.ToString() -> string
-static Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions.ToInvariantString(this System.Exception exception) -> string
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateDefault() -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateFromConfiguration(string config) -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DefaultMetricNamespace.get -> string

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net8.0/PublicAPI.Shipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net8.0/PublicAPI.Shipped.txt
@@ -147,7 +147,6 @@ Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.TraceTelemetry(string
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.OperationTelemetry() -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Sanitize() -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>.Telemetry.get -> T
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
@@ -269,7 +268,6 @@ override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Timestamp.
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(object otherObj) -> bool
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.GetHashCode() -> int
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.ToString() -> string
-static Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions.ToInvariantString(this System.Exception exception) -> string
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateDefault() -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateFromConfiguration(string config) -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DefaultMetricNamespace.get -> string

--- a/.publicApi/Microsoft.ApplicationInsights.dll/net9.0/PublicAPI.Shipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/net9.0/PublicAPI.Shipped.txt
@@ -147,7 +147,6 @@ Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.TraceTelemetry(string
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.OperationTelemetry() -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Sanitize() -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>.Telemetry.get -> T
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
@@ -269,7 +268,6 @@ override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Timestamp.
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(object otherObj) -> bool
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.GetHashCode() -> int
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.ToString() -> string
-static Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions.ToInvariantString(this System.Exception exception) -> string
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateDefault() -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateFromConfiguration(string config) -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DefaultMetricNamespace.get -> string

--- a/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Shipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.dll/netstandard2.0/PublicAPI.Shipped.txt
@@ -147,7 +147,6 @@ Microsoft.ApplicationInsights.DataContracts.TraceTelemetry.TraceTelemetry(string
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.OperationTelemetry() -> void
 Microsoft.ApplicationInsights.Extensibility.Implementation.OperationTelemetry.Sanitize() -> void
-Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>
 Microsoft.ApplicationInsights.Extensibility.IOperationHolder<T>.Telemetry.get -> T
 Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
@@ -269,7 +268,6 @@ override Microsoft.ApplicationInsights.DataContracts.RequestTelemetry.Timestamp.
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.Equals(object otherObj) -> bool
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.GetHashCode() -> int
 override Microsoft.ApplicationInsights.Metrics.MetricIdentifier.ToString() -> string
-static Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.Extensions.ToInvariantString(this System.Exception exception) -> string
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateDefault() -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration.CreateFromConfiguration(string config) -> Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration
 static Microsoft.ApplicationInsights.Metrics.MetricIdentifier.DefaultMetricNamespace.get -> string

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/Extensions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/Implementation/Tracing/Extensions.cs
@@ -9,7 +9,7 @@
     /// Provides a set of extension methods for tracing.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
-    public static class Extensions
+    internal static class Extensions
     {
         /// <summary>
         /// Returns a culture-independent string representation of the given <paramref name="exception"/> object, 

--- a/BASE/src/Microsoft.ApplicationInsights/Internal/SemanticConventions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Internal/SemanticConventions.cs
@@ -160,5 +160,69 @@
         // Messaging v1.21.0 https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/messaging.md
         public const string AttributeMessagingDestinationName = "messaging.destination.name";
         public const string AttributeNetworkProtocolName = "network.protocol.name";
+
+        // Microsoft Application Insights Override Attributes
+        // These attributes allow explicit mapping from Application Insights fields to OpenTelemetry attributes
+        // Used by both the shim layer and Azure Monitor Exporter for consistent behavior
+        
+        /// <summary>
+        /// Override attribute for dependency data field.
+        /// When present, takes precedence over computed data from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftDependencyData = "microsoft.dependency.data";
+
+        /// <summary>
+        /// Override attribute for dependency name field.
+        /// When present, takes precedence over computed name from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftDependencyName = "microsoft.dependency.name";
+
+        /// <summary>
+        /// Override attribute for operation name field.
+        /// When present, takes precedence over computed operation name.
+        /// </summary>
+        public const string AttributeMicrosoftOperationName = "microsoft.operation_name";
+
+        /// <summary>
+        /// Override attribute for dependency result code field.
+        /// When present, takes precedence over computed result code from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftDependencyResultCode = "microsoft.dependency.resultCode";
+
+        /// <summary>
+        /// Override attribute for dependency target field.
+        /// When present, takes precedence over computed target from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftDependencyTarget = "microsoft.dependency.target";
+
+        /// <summary>
+        /// Override attribute for dependency type field.
+        /// When present, takes precedence over computed type from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftDependencyType = "microsoft.dependency.type";
+
+        /// <summary>
+        /// Override attribute for request name field.
+        /// When present, takes precedence over Activity.DisplayName.
+        /// </summary>
+        public const string AttributeMicrosoftRequestName = "microsoft.request.name";
+
+        /// <summary>
+        /// Override attribute for request URL field.
+        /// When present, takes precedence over computed URL from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftRequestUrl = "microsoft.request.url";
+
+        /// <summary>
+        /// Override attribute for request source field.
+        /// When present, takes precedence over computed source from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftRequestSource = "microsoft.request.source";
+
+        /// <summary>
+        /// Override attribute for request result code field.
+        /// When present, takes precedence over computed result code from semantic conventions.
+        /// </summary>
+        public const string AttributeMicrosoftRequestResultCode = "microsoft.request.resultCode";
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricIdentifier.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Metrics/MetricIdentifier.cs
@@ -399,7 +399,7 @@
             this.dimension10Name = dimension10Name;
 
             this.identifierString = this.GetIdentifierString();
-            this.hashCode = this.identifierString.GetHashCode();
+            this.hashCode = StringComparer.Ordinal.GetHashCode(this.identifierString);
         }
 
         /// <summary>Initializes a new metric identifier.</summary>

--- a/WEB/Src/Web/Web/Web.csproj
+++ b/WEB/Src/Web/Web/Web.csproj
@@ -48,5 +48,9 @@
     <AdditionalFiles Include="$(PublicApiRoot)\$(AssemblyName).dll\$(TargetFramework)\PublicAPI.Unshipped.txt" />
   </ItemGroup>
 
+  <ItemGroup>
+    <Compile Include="..\..\..\..\BASE\src\Microsoft.ApplicationInsights\Extensibility\Implementation\Tracing\Extensions.cs" Link="Extensions.cs" />
+  </ItemGroup>
+
   <Import Project="..\..\Common\Common.projitems" Label="Shared" />
 </Project>


### PR DESCRIPTION
## Summary
Simplified `TrackRequest` and `TrackDependency` implementations to only set Microsoft override attributes (`microsoft.request.*`, `microsoft.dependency.*`) and determine correct `ActivityKind`, removing all semantic convention mapping logic.

## Changes

### Core Implementation
- **TelemetryClient.cs**
  - `TrackRequest`: Only sets override attributes (name, url, source, resultCode, operation_name) and determines ActivityKind (Server vs Consumer)
  - `TrackDependency`: Only sets override attributes (type, data, name, target, resultCode) and determines ActivityKind (Client, Producer, Internal)
  - Both methods now set `enduser.id` from `Context.User.Id`
  - Custom properties added as-is (without `custom.` prefix)

### Helper Classes
- **DependencyTelemetryMapper.cs**: Reduced to single method `GetActivityKindForDependency()` that determines correct ActivityKind based on dependency type
  - Returns `ActivityKind.Internal` for "InProc" calls
  - Returns `ActivityKind.Producer` for messaging (Queue Message, Azure Service Bus, Azure Event Hubs)
  - Returns `ActivityKind.Client` for HTTP, SQL, and other outgoing calls

- **RequestTelemetryMapper.cs**: Reduced to single method `GetActivityKindForRequest()` that determines correct ActivityKind
  - Returns `ActivityKind.Consumer` for messaging requests (servicebus, eventhub, queue, topic)
  - Returns `ActivityKind.Server` for HTTP requests

### Testing
- Added15 tests (7 TrackRequest + 8 TrackDependency) that verify:
  - Override attributes are correctly set
  - ActivityKind is determined correctly
  - Custom properties are preserved
  - Error status is set correctly
  - Null handling works properly

## Architecture Rationale
The shim layer's responsibility is to preserve Application Insights semantics via override attributes. The Azure Monitor Exporter will:
- Use override attributes (`microsoft.request.*`, `microsoft.dependency.*`) to populate RequestData/RemoteDependencyData fields
- Map semantic conventions from real OpenTelemetry instrumentation (not shim-created Activities)

This separation ensures:
1. Manual telemetry created via shim preserves exact AI semantics
2. Auto-instrumented telemetry gets proper semantic convention mapping
3. No double-mapping or conflicts between systems

## Misc

* Removed one public API by marking internal and fixed one hashcode warning