### PR TITLE
Remove unused `EnableDebugLogger` API and make `Resources` class internal

### DIFF
--- a/.publicApi/Microsoft.ApplicationInsights.AspNetCore.dll/Stable/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.AspNetCore.dll/Stable/PublicAPI.Unshipped.txt
@@ -12,8 +12,6 @@ Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOp
 Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableAdaptiveSampling.set -> void
 Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableAuthenticationTrackingJavaScript.get -> bool
 Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableAuthenticationTrackingJavaScript.set -> void
-Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableDebugLogger.get -> bool
-Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableDebugLogger.set -> void
 Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableDependencyTrackingTelemetryModule.get -> bool
 Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnableDependencyTrackingTelemetryModule.set -> void
 Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions.EnablePerformanceCounterCollectionModule.get -> bool
@@ -28,13 +26,7 @@ Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet
 Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet.FullScript.get -> string
 Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet.JavaScriptSnippet(Microsoft.ApplicationInsights.Extensibility.TelemetryConfiguration telemetryConfiguration, Microsoft.Extensions.Options.IOptions<Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions> serviceOptions, Microsoft.AspNetCore.Http.IHttpContextAccessor httpContextAccessor = null, System.Text.Encodings.Web.JavaScriptEncoder encoder = null) -> void
 Microsoft.ApplicationInsights.AspNetCore.JavaScriptSnippet.ScriptBody.get -> string
-Microsoft.ApplicationInsights.AspNetCore.Resources
 Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions
-static Microsoft.ApplicationInsights.AspNetCore.Resources.Culture.get -> System.Globalization.CultureInfo
-static Microsoft.ApplicationInsights.AspNetCore.Resources.Culture.set -> void
-static Microsoft.ApplicationInsights.AspNetCore.Resources.JavaScriptAuthSnippet.get -> string
-static Microsoft.ApplicationInsights.AspNetCore.Resources.JavaScriptSnippet.get -> string
-static Microsoft.ApplicationInsights.AspNetCore.Resources.ResourceManager.get -> System.Resources.ResourceManager
 static Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.AddApplicationInsightsTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.AddApplicationInsightsTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.ApplicationInsights.AspNetCore.Extensions.ApplicationInsightsServiceOptions options) -> Microsoft.Extensions.DependencyInjection.IServiceCollection
 static Microsoft.Extensions.DependencyInjection.ApplicationInsightsExtensions.AddApplicationInsightsTelemetry(this Microsoft.Extensions.DependencyInjection.IServiceCollection services, Microsoft.Extensions.Configuration.IConfiguration configuration) -> Microsoft.Extensions.DependencyInjection.IServiceCollection

--- a/.publicApi/Microsoft.ApplicationInsights.WorkerService.dll/Stable/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.ApplicationInsights.WorkerService.dll/Stable/PublicAPI.Unshipped.txt
@@ -10,8 +10,6 @@ Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.Cr
 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.Credential.set -> void
 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnableAdaptiveSampling.get -> bool
 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnableAdaptiveSampling.set -> void
-Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnableDebugLogger.get -> bool
-Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnableDebugLogger.set -> void
 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnableDependencyTrackingTelemetryModule.get -> bool
 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnableDependencyTrackingTelemetryModule.set -> void
 Microsoft.ApplicationInsights.WorkerService.ApplicationInsightsServiceOptions.EnablePerformanceCounterCollectionModule.get -> bool

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Resources.Designer.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Resources.Designer.cs
@@ -22,7 +22,7 @@ namespace Microsoft.ApplicationInsights.AspNetCore {
     // with the /str option, or rebuild your VS project.
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    public class Resources {
+    internal class Resources {
         
         private static global::System.Resources.ResourceManager resourceMan;
         

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsServiceOptions.cs
@@ -56,11 +56,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
         public string ApplicationVersion { get; set; } = Assembly.GetEntryAssembly()?.GetName().Version.ToString();
 
         /// <summary>
-        /// Gets or sets a value indicating whether a logger would be registered automatically in debug mode.
-        /// </summary>
-        public bool EnableDebugLogger { get; set; } = true;
-
-        /// <summary>
         /// Gets or sets a value indicating whether AutoCollectedMetricExtractors are added or not.
         /// Defaults to <value>true</value>.
         /// </summary>
@@ -98,7 +93,6 @@ namespace Microsoft.ApplicationInsights.AspNetCore.Extensions
 
             target.ApplicationVersion = this.ApplicationVersion;
             target.EnableAdaptiveSampling = this.EnableAdaptiveSampling;
-            target.EnableDebugLogger = this.EnableDebugLogger;
             target.EnableQuickPulseMetricStream = this.EnableQuickPulseMetricStream;
             target.AddAutoCollectedMetricExtractor = this.AddAutoCollectedMetricExtractor;
             target.EnablePerformanceCounterCollectionModule = this.EnablePerformanceCounterCollectionModule;

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/content/config-all-default.json
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/content/config-all-default.json
@@ -11,7 +11,6 @@
     "EnableEventCounterCollectionModule": true,
     "AddAutoCollectedMetricExtractor": true,
     "EnableQuickPulseMetricStream": true,
-    "EnableDebugLogger": true,
     "EnableHeartbeat": true,
     "EnableAuthenticationTrackingJavaScript": false,
     "ApplicationVersion": "Version",

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/content/config-all-settings-false.json
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/content/config-all-settings-false.json
@@ -11,7 +11,6 @@
     "EnableEventCounterCollectionModule": false,
     "AddAutoCollectedMetricExtractor": false,
     "EnableQuickPulseMetricStream": false,
-    "EnableDebugLogger": true,
     "EnableHeartbeat": false,
     "EnableAuthenticationTrackingJavaScript": false,
     "EnableDiagnosticsTelemetryModule": false,

--- a/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/content/config-all-settings-true.json
+++ b/NETCORE/test/Microsoft.ApplicationInsights.AspNetCore.Tests/content/config-all-settings-true.json
@@ -11,7 +11,6 @@
     "EnableEventCounterCollectionModule": true,
     "AddAutoCollectedMetricExtractor": true,
     "EnableQuickPulseMetricStream": true,
-    "EnableDebugLogger": true,
     "EnableHeartbeat": true,
     "EnableAuthenticationTrackingJavaScript": true,
     "EnableDiagnosticsTelemetryModule": true,

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/content/config-all-default.json
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/content/config-all-default.json
@@ -11,7 +11,6 @@
     "EnableEventCounterCollectionModule": true,
     "AddAutoCollectedMetricExtractor": true,
     "EnableQuickPulseMetricStream": true,
-    "EnableDebugLogger": true,
     "EnableHeartbeat": true,
     "EnableAuthenticationTrackingJavaScript": false,
     "ApplicationVersion": "Version",

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/content/config-all-settings-false.json
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/content/config-all-settings-false.json
@@ -11,7 +11,6 @@
     "EnableEventCounterCollectionModule": false,
     "AddAutoCollectedMetricExtractor": false,
     "EnableQuickPulseMetricStream": false,
-    "EnableDebugLogger": true,
     "EnableHeartbeat": false,
     "EnableAuthenticationTrackingJavaScript": false,
     "EnableDiagnosticsTelemetryModule": false,

--- a/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/content/config-all-settings-true.json
+++ b/NETCORE/test/Microsoft.ApplicationInsights.WorkerService.Tests/content/config-all-settings-true.json
@@ -11,7 +11,6 @@
     "EnableEventCounterCollectionModule": true,
     "AddAutoCollectedMetricExtractor": true,
     "EnableQuickPulseMetricStream": true,
-    "EnableDebugLogger": true,
     "EnableHeartbeat": true,
     "EnableAuthenticationTrackingJavaScript": true,
     "EnableDiagnosticsTelemetryModule": true,


### PR DESCRIPTION
### Summary
This PR cleans up the public API surface for the 3.x release by removing APIs that are no longer functional and internalizing implementation details.

### Changes

#### 1. Removed `EnableDebugLogger` property
- **Reason**: This property has no effect in 3.x. The debug logger functionality was removed but the property was left behind.
- **Impact**: Customers setting this property were not getting any benefit. Removing it provides clarity.

#### 2. Made `Resources` class internal
- **Reason**: The `Resources` class (containing `JavaScriptSnippet`, `JavaScriptAuthSnippet`, `Culture`, `ResourceManager`) is an implementation detail used internally by `JavaScriptSnippet`.
- **Impact**: None for customers. The public API for JavaScript snippet injection remains unchanged:
  ```razor
  @inject IJavaScriptSnippet JavaScriptSnippet
  @Html.Raw(JavaScriptSnippet.FullScript)