### PR TITLE
remove unnecessary product field from features

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Internal/FeatureMetricEmissionHelperTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/Internal/FeatureMetricEmissionHelperTests.cs
@@ -57,7 +57,6 @@ namespace Microsoft.ApplicationInsights
             AssertKey("type", 0, tags); // == feature
             Assert.Contains("os", tags);
             AssertKey("language", "dotnet", tags);
-            AssertKey("product", "appinsights", tags);
             AssertKey("version", "b", tags);
         }
 

--- a/BASE/src/Microsoft.ApplicationInsights/Internal/FeatureMetricEmissionHelper.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Internal/FeatureMetricEmissionHelper.cs
@@ -83,7 +83,6 @@ namespace Microsoft.ApplicationInsights.Internal
                         new ("type", 0), // 0 = feature, 1 = instrumentation scopes
                         new ("os", this.os),
                         new ("language", "dotnet"),
-                        new ("product", "appinsights"),
                         new ("version", this.version));
             }
             catch (Exception)


### PR DESCRIPTION
## Changes
The product field is no longer used in the sdk stats feature reporting, so it can be removed.

### Checklist
- [x] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.