### PR TITLE
Improve JSON deserialization for metadata fetch

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Internal/FeatureMetricEmissionHelper.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Internal/FeatureMetricEmissionHelper.cs
@@ -123,7 +123,16 @@ namespace Microsoft.ApplicationInsights.Internal
                     {
                         httpClient.DefaultRequestHeaders.Add("Metadata", "True");
                         var responseString = httpClient.GetStringAsync(new Uri(StatsbeatConstants.AMSUrl));
-                        return JsonSerializer.Deserialize<Dictionary<string, object>>(responseString.Result);
+                        using var document = JsonDocument.Parse(responseString.Result);
+                        var result = new Dictionary<string, object>();
+                        foreach (var property in document.RootElement.EnumerateObject())
+                        {
+                            result[property.Name] = property.Value.ValueKind == JsonValueKind.String
+                                ? property.Value.GetString()
+                                : property.Value.ToString();
+                        }
+
+                        return result;
                     }
                 }
             }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Version 3.0.1-beta1
+- [Improve JSON deserialization for metadata fetch](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3120)
+- 
 ## Version 3.0.0
 - [Replaced `netstandard2.0` with `net8.0` target framework in `Microsoft.ApplicationInsights.NLogTarget` package.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3102)
 


### PR DESCRIPTION
Helps with #2786

## Changes
Replaced JsonSerializer.Deserialize with JsonDocument.Parse to improve native aot support.

For more context, with the current implementation, trying to build with native aot errors our with these:
```
/_/BASE/src/Microsoft.ApplicationInsights/Internal/FeatureMetricEmissionHelper.cs(126): Trim analysis error IL2026: Microsoft.ApplicationInsights.Internal.FeatureMetricEmissionHelper.GetVmMetadata(): Using member 'System.Text.Json.JsonSerializer.Deserialize<Dictionary`2<String,Object>>(String,JsonSerializerOptions)' which has 'RequiresUnreferencedCodeAttribute' can break functionality when trimming application code. JSON serialization and deserialization might require types that cannot be statically analyzed. Use the overload that takes a JsonTypeInfo or JsonSerializerContext, or make sure all of the required types are preserved.
/_/BASE/src/Microsoft.ApplicationInsights/Internal/FeatureMetricEmissionHelper.cs(126): AOT analysis error IL3050: Microsoft.ApplicationInsights.Internal.FeatureMetricEmissionHelper.GetVmMetadata(): Using member 'System.Text.Json.JsonSerializer.Deserialize<Dictionary`2<String,Object>>(String,JsonSerializerOptions)' which has 'RequiresDynamicCodeAttribute' can break functionality when AOT compiling. JSON serialization and deserialization might require types that cannot be statically analyzed and might need runtime code generation. Use System.Text.Json source generation for native AOT applications.
```

Moving away from JsonSerializer solves this issue. We could also move to a source generated approach, but given we want a single property, this approach is simpler.

### Checklist
- [ ] I ran Unit Tests locally.
- [ ] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.