### PR TITLE
Fix Web package initialization issues

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -14,10 +14,13 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.SelfDiagnostics;
     using Microsoft.ApplicationInsights.Internal;
     using Microsoft.ApplicationInsights.Metrics;
+    using Microsoft.ApplicationInsights.Processors;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using OpenTelemetry;
+    using OpenTelemetry.Logs;
     using OpenTelemetry.Resources;
+    using OpenTelemetry.Trace;
 
     /// <summary>
     /// Encapsulates the global telemetry configuration typically loaded from the ApplicationInsights.config file.
@@ -59,6 +62,7 @@
         private OpenTelemetrySdk openTelemetrySdk;
         private ActivitySource defaultActivitySource;
         private MetricsManager metricsManager;
+        private TelemetryContext telemetryContext;
 
         /// <summary>
         /// Initializes a new instance of the TelemetryConfiguration class.
@@ -219,7 +223,6 @@
             get => this.extensionVersion;
             set
             {
-                this.ThrowIfBuilt();
                 this.extensionVersion = value;
             }
         }
@@ -228,6 +231,28 @@
         /// Gets the default ActivitySource used by TelemetryClient.
         /// </summary>
         internal ActivitySource ApplicationInsightsActivitySource => this.defaultActivitySource;
+
+        /// <summary>
+        /// Gets a value indicating whether the configuration has been built.
+        /// </summary>
+        internal bool IsBuilt => this.isBuilt;
+
+        /// <summary>
+        /// Gets the shared TelemetryContext for this configuration.
+        /// All TelemetryClient instances sharing this configuration use the same context.
+        /// </summary>
+        internal TelemetryContext Context
+        {
+            get
+            {
+                if (this.telemetryContext == null)
+                {
+                    this.telemetryContext = new TelemetryContext();
+                }
+
+                return this.telemetryContext;
+            }
+        }
 
         /// <summary>
         /// Gets the MetricsManager used by TelemetryClient for metrics tracking.
@@ -314,23 +339,6 @@
         }
 
         /// <summary>
-        /// Prepends a configuration action so it runs before any user-registered configuration.
-        /// This ensures that enrichment processors (e.g., TelemetryContextLogProcessor) execute
-        /// before export processors, regardless of the order users call ConfigureOpenTelemetryBuilder.
-        /// </summary>
-        internal void PrependOpenTelemetryBuilderConfiguration(Action<IOpenTelemetryBuilder> configure)
-        {
-            this.ThrowIfBuilt();
-
-            var previousConfiguration = this.builderConfiguration;
-            this.builderConfiguration = builder =>
-            {
-                configure(builder);
-                previousConfiguration(builder);
-            };
-        }
-
-        /// <summary>
         /// Sets the cloud role name and role instance for telemetry.
         /// This configures the OpenTelemetry Resource with service.name, service.namespace, service.instance.id, and service.version attributes
         /// which map to Cloud.RoleName, Cloud.RoleInstance, and Application.Ver in Application Insights.
@@ -376,6 +384,15 @@
         {
             if (string.IsNullOrEmpty(this.connectionString))
             {
+                var envConnectionString = Environment.GetEnvironmentVariable("APPLICATIONINSIGHTS_CONNECTION_STRING");
+                if (!string.IsNullOrEmpty(envConnectionString))
+                {
+                    this.connectionString = envConnectionString;
+                }
+            }
+
+            if (string.IsNullOrEmpty(this.connectionString))
+            {
                 return this.FeatureReporter;
             }
 
@@ -417,6 +434,12 @@
 
                 this.openTelemetrySdk = OpenTelemetrySdk.Create(builder =>
                 {
+                    // Register context processors first so they run before exporters.
+                    // This ensures TelemetryContext properties are stamped on all
+                    // Activities and LogRecords before they are exported.
+                    builder.WithTracing(tracing => tracing.AddProcessor(new TelemetryContextActivityProcessor(this.Context)));
+                    builder.WithLogging(logging => logging.AddProcessor(new TelemetryContextLogProcessor(this.Context)));
+
                     this.builderConfiguration(builder);
                     builder.SetAzureMonitorExporter(options =>
                     {

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights
+namespace Microsoft.ApplicationInsights
 {
     using System;
     using System.Collections;
@@ -55,19 +55,10 @@
             // Use the shared ActivitySource from configuration
             this.activitySource = configuration.ApplicationInsightsActivitySource;
 
-            // For non-DI scenarios: Register context processors and build SDK eagerly
-            // For DI scenarios: SDK will be built by configuration when accessed;
-            // processors are registered via UseApplicationInsightsTelemetry() in NETCORE
+            // For non-DI scenarios: Build SDK eagerly to ensure all providers are ready.
+            // For DI scenarios: SDK is built externally by the host.
             if (!isFromDependencyInjection)
             {
-                // Prepend context processors so they run BEFORE any user-registered exporters.
-                // This ensures LogRecords/Activities are enriched with context tags before export.
-                configuration.PrependOpenTelemetryBuilderConfiguration(builder =>
-                {
-                    builder.WithTracing(tracing => tracing.AddProcessor(new TelemetryContextActivityProcessor(this.Context)));
-                    builder.WithLogging(logging => logging.AddProcessor(new TelemetryContextLogProcessor(this.Context)));
-                });
-
                 this.sdk = configuration.Build();
             }
 
@@ -101,13 +92,7 @@
         /// <summary>
         /// Gets the current context that will be used to augment telemetry you send.
         /// </summary>
-        public TelemetryContext Context
-        {
-            get;
-            internal set;
-        }
-
-        = new TelemetryContext();
+        public TelemetryContext Context => this.Configuration.Context;
 
         /// <summary>
         /// Gets the <see cref="TelemetryConfiguration"/> object associated with this telemetry client instance.
@@ -153,7 +138,7 @@
         /// <param name="properties">Named string values you can use to search and classify events.</param>
         public void TrackEvent(string eventName, IDictionary<string, string> properties = null)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackEvent);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackEvent);
             if (string.IsNullOrEmpty(eventName))
             {
                 CoreEventSource.Log.TrackEventInvalidName();
@@ -176,7 +161,7 @@
         /// <param name="telemetry">An event log item.</param>
         public void TrackEvent(EventTelemetry telemetry)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackEvent);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackEvent);
             if (telemetry == null)
             {
                 CoreEventSource.Log.TrackEventTelemetryIsNull();
@@ -208,7 +193,7 @@
         /// </remarks>
         public void TrackAvailability(string name, DateTimeOffset timeStamp, TimeSpan duration, string runLocation, bool success, string message = null, IDictionary<string, string> properties = null)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackAvailability);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackAvailability);
             var availabilityTelemetry = new AvailabilityTelemetry(name, timeStamp, duration, runLocation, success, message);
 
             if (properties != null && properties.Count > 0)
@@ -229,7 +214,7 @@
         /// <param name="telemetry">An availability telemetry item.</param>
         public void TrackAvailability(AvailabilityTelemetry telemetry)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackAvailability);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackAvailability);
             if (telemetry == null)
             {
                 CoreEventSource.Log.TrackAvailabilityTelemetryIsNull();
@@ -281,7 +266,7 @@
         /// <param name="message">Message to display.</param>
         public void TrackTrace(string message)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             var state = new DictionaryLogState(null, message);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
         }
@@ -296,7 +281,7 @@
         /// <param name="severityLevel">Trace severity level.</param>
         public void TrackTrace(string message, SeverityLevel severityLevel)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             LogLevel logLevel = GetLogLevel(severityLevel);
             var state = new DictionaryLogState(null, message);
             this.Logger.Log(logLevel, 0, state, null, (s, ex) => s.Message);
@@ -312,7 +297,7 @@
         /// <param name="properties">Named string values you can use to search and classify events.</param>
         public void TrackTrace(string message, IDictionary<string, string> properties)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             var state = new DictionaryLogState(properties, message);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
         }
@@ -328,7 +313,7 @@
         /// <param name="properties">Named string values you can use to search and classify events.</param>
         public void TrackTrace(string message, SeverityLevel severityLevel, IDictionary<string, string> properties)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             LogLevel logLevel = GetLogLevel(severityLevel);
             var state = new DictionaryLogState(properties, message);
             this.Logger.Log(logLevel, 0, state, null, (s, ex) => s.Message);
@@ -344,7 +329,7 @@
         /// <param name="telemetry">Message with optional properties.</param>
         public void TrackTrace(TraceTelemetry telemetry)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             if (telemetry == null)
             {
                 telemetry = new TraceTelemetry();
@@ -382,7 +367,7 @@
         /// <param name="properties">Named string values you can use to classify and filter metrics.</param>        
         public void TrackMetric(string name, double value, IDictionary<string, string> properties = null)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackMetric);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackMetric);
             // Get or create histogram for this metric
             var histogram = this.Configuration.MetricsManager.GetOrCreateHistogram(name, null);
 
@@ -413,7 +398,7 @@
         /// <param name="telemetry">The metric telemetry item.</param>        
         public void TrackMetric(MetricTelemetry telemetry)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackMetric);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackMetric);
             if (telemetry == null)
             {
                 CoreEventSource.Log.TrackMetricTelemetryIsNull();
@@ -451,7 +436,7 @@
         /// </remarks>
         public void TrackException(Exception exception, IDictionary<string, string> properties = null)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackException);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackException);
             if (exception == null)
             {
                 exception = new InvalidOperationException(Utils.PopulateRequiredStringValue(null, "message", typeof(ExceptionTelemetry).FullName));
@@ -470,7 +455,7 @@
         /// </remarks>
         public void TrackException(ExceptionTelemetry telemetry)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackException);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackException);
             // TODO investigate how problem id, custom message, etc should appear in portal
             if (telemetry == null)
             {
@@ -567,7 +552,7 @@
         /// </remarks>
         public void TrackDependency(DependencyTelemetry telemetry)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackDependency);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackDependency);
             if (telemetry == null)
             {
                 return;
@@ -742,7 +727,7 @@
         /// </remarks>
         public void TrackRequest(RequestTelemetry request)
         {
-            this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackRequest);
+            this.Configuration.FeatureReporter?.MarkFeatureInUse(StatsbeatFeatures.TrackRequest);
             if (request == null)
             {
                 return;

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Microsoft.ApplicationInsights
+namespace Microsoft.ApplicationInsights
 {
     using System;
     using System.ComponentModel;
@@ -62,7 +62,7 @@
             }
 #endif
 
-            telemetryClient.Configuration.FeatureReporter.MarkFeatureInUse(Internal.StatsbeatFeatures.StartOperation);
+            telemetryClient.Configuration.FeatureReporter?.MarkFeatureInUse(Internal.StatsbeatFeatures.StartOperation);
 
             var effectiveName = string.IsNullOrEmpty(operationName) ? typeof(T).Name : operationName;
             var kind = ResolveActivityKind<T>();
@@ -161,7 +161,7 @@
                 operationTelemetry.Name = typeof(T).Name;
             }
 
-            telemetryClient.Configuration.FeatureReporter.MarkFeatureInUse(Internal.StatsbeatFeatures.StartOperation);
+            telemetryClient.Configuration.FeatureReporter?.MarkFeatureInUse(Internal.StatsbeatFeatures.StartOperation);
 
             var kind = ResolveActivityKind<T>();
             var source = telemetryClient.TelemetryConfiguration.ApplicationInsightsActivitySource;
@@ -244,7 +244,7 @@
                 return null;
             }
 
-            telemetryClient.Configuration.FeatureReporter.MarkFeatureInUse(Internal.StatsbeatFeatures.StartOperation);
+            telemetryClient.Configuration.FeatureReporter?.MarkFeatureInUse(Internal.StatsbeatFeatures.StartOperation);
 
             // if already started activity, we just link it — not create a new one
             if (activity.Id == null)

--- a/WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs
+++ b/WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs
@@ -61,73 +61,78 @@
                     sharedTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
 
                     sharedTelemetryConfiguration.ExtensionVersion = VersionUtils.ExtensionLabelShimWeb + VersionUtils.GetVersion(typeof(ApplicationInsightsExtensions));
-                    
-                    // Read all configuration options from applicationinsights.config
-                    ApplicationInsightsConfigOptions configOptions = ApplicationInsightsConfigurationReader.GetConfigurationOptions();
-                    
-                    if (configOptions != null)
+
+                    // If user code (e.g., Global.asax) already built the config by creating
+                    // a TelemetryClient, skip reconfiguration — the config is sealed.
+                    if (!sharedTelemetryConfiguration.IsBuilt)
                     {
-                        // Apply Group 1: Direct TelemetryConfiguration properties (before Build)
-                        if (!string.IsNullOrEmpty(configOptions.ConnectionString))
+                        // Read all configuration options from applicationinsights.config
+                        ApplicationInsightsConfigOptions configOptions = ApplicationInsightsConfigurationReader.GetConfigurationOptions();
+                    
+                        if (configOptions != null)
                         {
-                            sharedTelemetryConfiguration.ConnectionString = configOptions.ConnectionString;
-                            WebEventSource.Log.ConnectionStringLoadedFromConfig(configOptions.ConnectionString);
+                            // Apply Group 1: Direct TelemetryConfiguration properties (before Build)
+                            if (!string.IsNullOrEmpty(configOptions.ConnectionString))
+                            {
+                                sharedTelemetryConfiguration.ConnectionString = configOptions.ConnectionString;
+                                WebEventSource.Log.ConnectionStringLoadedFromConfig(configOptions.ConnectionString);
+                            }
+                            else
+                            {
+                                WebEventSource.Log.NoConnectionStringFoundInConfig();
+                            }
+
+                            if (configOptions.DisableTelemetry.HasValue)
+                            {
+                                sharedTelemetryConfiguration.DisableTelemetry = configOptions.DisableTelemetry.Value;
+                            }
+
+                            if (configOptions.TracesPerSecond.HasValue)
+                            {
+                                sharedTelemetryConfiguration.TracesPerSecond = configOptions.TracesPerSecond.Value;
+                            }
+
+                            if (configOptions.SamplingRatio.HasValue)
+                            {
+                                sharedTelemetryConfiguration.SamplingRatio = configOptions.SamplingRatio.Value;
+                                if (!configOptions.TracesPerSecond.HasValue)
+                                {
+                                    sharedTelemetryConfiguration.TracesPerSecond = null;
+                                }
+                            }
+
+                            if (!string.IsNullOrEmpty(configOptions.StorageDirectory))
+                            {
+                                sharedTelemetryConfiguration.StorageDirectory = configOptions.StorageDirectory;
+                            }
+
+                            if (configOptions.DisableOfflineStorage.HasValue)
+                            {
+                                sharedTelemetryConfiguration.DisableOfflineStorage = configOptions.DisableOfflineStorage.Value;
+                            }
+
+                            if (configOptions.EnableTraceBasedLogsSampler.HasValue)
+                            {
+                                sharedTelemetryConfiguration.EnableTraceBasedLogsSampler = configOptions.EnableTraceBasedLogsSampler.Value;
+                            }
+
+                            // EnableQuickPulseMetricStream -> EnableLiveMetrics (TelemetryConfiguration property)
+                            if (configOptions.EnableQuickPulseMetricStream.HasValue)
+                            {
+                                sharedTelemetryConfiguration.EnableLiveMetrics = configOptions.EnableQuickPulseMetricStream.Value;
+                            }
+
+                            // Configure OpenTelemetry builder for properties that require OpenTelemetry API
+                            sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
+                                builder => ConfigureOpenTelemetryWithOptions(builder, configOptions));
                         }
                         else
                         {
                             WebEventSource.Log.NoConnectionStringFoundInConfig();
+
+                            sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
+                                builder => builder.UseApplicationInsightsAspNetTelemetry());
                         }
-
-                        if (configOptions.DisableTelemetry.HasValue)
-                        {
-                            sharedTelemetryConfiguration.DisableTelemetry = configOptions.DisableTelemetry.Value;
-                        }
-
-                        if (configOptions.TracesPerSecond.HasValue)
-                        {
-                            sharedTelemetryConfiguration.TracesPerSecond = configOptions.TracesPerSecond.Value;
-                        }
-
-                        if (configOptions.SamplingRatio.HasValue)
-                        {
-                            sharedTelemetryConfiguration.SamplingRatio = configOptions.SamplingRatio.Value;
-                            if (!configOptions.TracesPerSecond.HasValue)
-                            {
-                                sharedTelemetryConfiguration.TracesPerSecond = null;
-                            }
-                        }
-
-                        if (!string.IsNullOrEmpty(configOptions.StorageDirectory))
-                        {
-                            sharedTelemetryConfiguration.StorageDirectory = configOptions.StorageDirectory;
-                        }
-
-                        if (configOptions.DisableOfflineStorage.HasValue)
-                        {
-                            sharedTelemetryConfiguration.DisableOfflineStorage = configOptions.DisableOfflineStorage.Value;
-                        }
-
-                        if (configOptions.EnableTraceBasedLogsSampler.HasValue)
-                        {
-                            sharedTelemetryConfiguration.EnableTraceBasedLogsSampler = configOptions.EnableTraceBasedLogsSampler.Value;
-                        }
-
-                        // EnableQuickPulseMetricStream -> EnableLiveMetrics (TelemetryConfiguration property)
-                        if (configOptions.EnableQuickPulseMetricStream.HasValue)
-                        {
-                            sharedTelemetryConfiguration.EnableLiveMetrics = configOptions.EnableQuickPulseMetricStream.Value;
-                        }
-
-                        // Configure OpenTelemetry builder for properties that require OpenTelemetry API
-                        sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
-                            builder => ConfigureOpenTelemetryWithOptions(builder, configOptions));
-                    }
-                    else
-                    {
-                        WebEventSource.Log.NoConnectionStringFoundInConfig();
-
-                        sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
-                            builder => builder.UseApplicationInsightsAspNetTelemetry());
                     }
 
                     isInitialized = true;


### PR DESCRIPTION
Post the 3.1.0 release, a classic aspnet application won't start up properly due to the prepend method throwing an exception. 
This PR removes that prepend method, but also refactors code for context processors to be set in a way that the exception doesn't throw.

Side considerations - 
- Connection string is settable via env var and config
- avoid null exceptions from internal feature tracking
- Testing to ensure this doesn't cause regression in other packages.

