### PR TITLE
Update OpenTelemetry and Azure Monitor packages to address vulnerabilities

### DIFF
--- a/BASE/src/Microsoft.ApplicationInsights/Properties/AssemblyInfo.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Properties/AssemblyInfo.cs
@@ -9,6 +9,9 @@ using System.Runtime.InteropServices;
 [assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.AspNetCore, PublicKey=" + AssemblyInfo.PublicKey)]
 [assembly: InternalsVisibleTo("Microsoft.ApplicationInsights.WorkerService, PublicKey=" + AssemblyInfo.PublicKey)]
 
+// Required so Moq/Castle.DynamicProxy can subclass internal types (e.g. MemoryMappedFileHandler) for unit testing.
+[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=" + AssemblyInfo.MoqPublicKey)]
+
 internal static class AssemblyInfo
 {
 #if PUBLIC_RELEASE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## Unreleased
-- Update OpenTelemetry and Azure Monitor dependencies to address known security advisories (e.g. [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) in `OpenTelemetry.Api` 1.15.1).
+- [Update OpenTelemetry and Azure Monitor dependencies to address known security advisories (e.g. [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) in `OpenTelemetry.Api` 1.15.1).](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3174)
   - OpenTelemetry 1.15.3
   - OpenTelemetry.Exporter.Console 1.15.3
   - OpenTelemetry.Exporter.InMemory 1.15.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## Unreleased
+- Update OpenTelemetry and Azure Monitor dependencies to address known security advisories (e.g. [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) in `OpenTelemetry.Api` 1.15.1).
+  - OpenTelemetry 1.15.3
+  - OpenTelemetry.Exporter.Console 1.15.3
+  - OpenTelemetry.Exporter.InMemory 1.15.3
+  - OpenTelemetry.Extensions.Hosting 1.15.3
+  - OpenTelemetry.Instrumentation.AspNetCore 1.15.2
+  - OpenTelemetry.Instrumentation.AspNet 1.15.2
+  - OpenTelemetry.Instrumentation.Http 1.15.1
+  - OpenTelemetry.Instrumentation.SqlClient 1.15.2
+  - Azure.Monitor.OpenTelemetry.Exporter 1.8.0
+
 ## Version 3.1.0
 - [Make `TelemetryContext` properties public and propagate them via `TelemetryClient`.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3137)
 - [Add fallback to `APPLICATIONINSIGHTS_CONNECTION_STRING` environment variable for Base, Web, and NLog packages when connection string is not set via code.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3134)

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,7 +15,7 @@
   <!-- 
     ==============================================================================
     OPENTELEMETRY PACKAGES
-    Core packages using stable version 1.15.1 with some RC/Beta components
+    Core packages using stable version 1.15.3 with some RC/Beta components
     ==============================================================================
   -->
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,18 +19,18 @@
     ==============================================================================
   -->
 
-  <ItemGroup Label="OpenTelemetry - Core (Stable 1.15.1)">
-    <PackageVersion Include="OpenTelemetry" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.1" />
+  <ItemGroup Label="OpenTelemetry - Core (Stable 1.15.3)">
+    <PackageVersion Include="OpenTelemetry" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Exporter.InMemory" Version="1.15.3" />
+    <PackageVersion Include="OpenTelemetry.Extensions.Hosting" Version="1.15.3" />
   </ItemGroup>
 
   <ItemGroup Label="OpenTelemetry - Instrumentation">
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet" Version="1.15.1" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.0" />
-    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.0" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.AspNet" Version="1.15.2" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.Http" Version="1.15.1" />
+    <PackageVersion Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.15.2" />
   </ItemGroup>
 
   <!-- 
@@ -40,13 +40,13 @@
   -->
 
   <ItemGroup Label="Azure Monitor">
-    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.7.0" />
+    <PackageVersion Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.8.0" />
   </ItemGroup>
 
   <!-- 
     ==============================================================================
     MICROSOFT.EXTENSIONS PACKAGES
-    Most packages on 10.0.2; Microsoft.Extensions.Options on 10.0.3 (required by Azure Monitor Exporter 1.7.0)
+    Most packages on 10.0.2; Microsoft.Extensions.Options on 10.0.3 (required by Azure Monitor Exporter 1.8.0)
     ==============================================================================
   -->
 


### PR DESCRIPTION
## What

Bumps OpenTelemetry and Azure Monitor dependencies to address known security advisories and unblock builds.

| Package | Old | New |
|---|---|---|
| `OpenTelemetry` | 1.15.1 | **1.15.3** |
| `OpenTelemetry.Exporter.Console` | 1.15.1 | **1.15.3** |
| `OpenTelemetry.Exporter.InMemory` | 1.15.1 | **1.15.3** |
| `OpenTelemetry.Extensions.Hosting` | 1.15.1 | **1.15.3** |
| `OpenTelemetry.Instrumentation.AspNetCore` | 1.15.0 | **1.15.2** |
| `OpenTelemetry.Instrumentation.AspNet` | 1.15.1 | **1.15.2** |
| `OpenTelemetry.Instrumentation.Http` | 1.15.0 | **1.15.1** |
| `OpenTelemetry.Instrumentation.SqlClient` | 1.15.0 | **1.15.2** |
| `Azure.Monitor.OpenTelemetry.Exporter` | 1.7.0 | **1.8.0** |

## Why

Building `Everything.sln` against the previous versions fails with `NU1902` because `OpenTelemetry.Api 1.15.1` carries a moderate-severity advisory ([GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j)). All transitively-required floor versions of dependencies (e.g. `Azure.Core >= 1.54.0`) are satisfied — no further pins needed.

## Test infra fix

This PR also adds:

```csharp
[assembly: InternalsVisibleTo("DynamicProxyGenAssembly2, PublicKey=" + AssemblyInfo.MoqPublicKey)]
```

to `BASE/src/Microsoft.ApplicationInsights/Properties/AssemblyInfo.cs`. Because `Microsoft.ApplicationInsights` is strong-named, Castle.DynamicProxy (used by Moq) cannot subclass internal types like `MemoryMappedFileHandler` without it. The `MoqPublicKey` constant was already defined in the same file but unused. This fix re-enables the 14 `SelfDiagnosticsEventListenerTest.*` tests across `net462`/`net8.0`/`net9.0`/`net10.0`.

## Validation

- ✅ `dotnet restore Everything.sln` — clean
- ✅ `dotnet build Everything.sln -c Release` — 0 errors (baseline `main` fails with `NU1902`)
- ✅ `dotnet test Everything.sln -c Release` — `SelfDiagnostics` tests now passing (14/14 across all TFMs); remaining 3 failure types are pre-existing flakes on `main` (IMDS-dependent `FeatureMetricEmissionHelperTests.ReportsFeaturesSeen`, file-cleanup race in `Web.Tests`, timing race in `WorkerServiceTelemetryTests.BackgroundWorkOperationsAreExported`) — out of scope for this change.
