### PR TITLE
docs: ILogger Scope are disabled by default

### DIFF
--- a/MigrationGuidance.md
+++ b/MigrationGuidance.md
@@ -228,16 +228,9 @@ Previously, ITelemetryInitializer and the base classes provided an extensibility
 - [LogRecord Processor (enrichment)](docs/concepts.md#log-processors)
 
 #### ILogger Scopes (`BeginScope`) Are Disabled by Default
-In 2.x, properties added via `ILogger.BeginScope(...)` automatically appeared as custom dimensions on log telemetry. In 3.x, logging scopes are **disabled by default** because the underlying OpenTelemetry logger integration does not capture them unless explicitly configured. As a result, values set with `BeginScope` will be silently dropped unless the following option is added:
+In 2.x, properties added via `ILogger.BeginScope(...)` automatically appeared as custom dimensions on log telemetry. In 3.x, logging scopes are **disabled by default** because the underlying OpenTelemetry logger integration does not capture them unless explicitly configured. As a result, values set with `BeginScope` will be silently dropped unless `IncludeScopes` is enabled.
 
-```csharp
-builder.Services.Configure<OpenTelemetryLoggerOptions>(loggingOptions =>
-{
-    loggingOptions.IncludeScopes = true;
-});
-```
-
-Once enabled, scope key-value pairs will flow through as log attributes and appear in `customDimensions` in Application Insights.
+For the required configuration and the recommended scope state shapes for performance, see the existing [`IncludeScopes` guidance in `NETCORE/Readme.md`](NETCORE/Readme.md).
 
 ### TelemetryProcessors
 In 2.x, this property represent a collection of telemetry processors to apply to the configuration. The built in ones in 2.x are listed below:

--- a/MigrationGuidance.md
+++ b/MigrationGuidance.md
@@ -230,7 +230,7 @@ Previously, ITelemetryInitializer and the base classes provided an extensibility
 #### ILogger Scopes (`BeginScope`) Are Disabled by Default
 In 2.x, properties added via `ILogger.BeginScope(...)` automatically appeared as custom dimensions on log telemetry. In 3.x, logging scopes are **disabled by default** because the underlying OpenTelemetry logger integration does not capture them unless explicitly configured. As a result, values set with `BeginScope` will be silently dropped unless `IncludeScopes` is enabled.
 
-For the required configuration and the recommended scope state shapes for performance, see the existing [`IncludeScopes` guidance in `NETCORE/Readme.md`](NETCORE/Readme.md).
+For the required configuration and the recommended scope state shapes for performance, see the [`IncludeScopes` guidance in `NETCORE/Readme.md`](NETCORE/Readme.md).
 
 ### TelemetryProcessors
 In 2.x, this property represent a collection of telemetry processors to apply to the configuration. The built in ones in 2.x are listed below:

--- a/MigrationGuidance.md
+++ b/MigrationGuidance.md
@@ -227,6 +227,18 @@ Previously, ITelemetryInitializer and the base classes provided an extensibility
 - [Activity Processor (enrichment)](docs/concepts.md#enriching-telemetry-with-activity-processors)
 - [LogRecord Processor (enrichment)](docs/concepts.md#log-processors)
 
+#### ILogger Scopes (`BeginScope`) Are Disabled by Default
+In 2.x, properties added via `ILogger.BeginScope(...)` automatically appeared as custom dimensions on log telemetry. In 3.x, logging scopes are **disabled by default** because the underlying OpenTelemetry logger integration does not capture them unless explicitly configured. As a result, values set with `BeginScope` will be silently dropped unless the following option is added:
+
+```csharp
+builder.Services.Configure<OpenTelemetryLoggerOptions>(loggingOptions =>
+{
+    loggingOptions.IncludeScopes = true;
+});
+```
+
+Once enabled, scope key-value pairs will flow through as log attributes and appear in `customDimensions` in Application Insights.
+
 ### TelemetryProcessors
 In 2.x, this property represent a collection of telemetry processors to apply to the configuration. The built in ones in 2.x are listed below:
 - `SamplingTelemetryProcessor`: Please refer to the [sampling section](#sampling) to understand the replacement.

--- a/skills/applicationinsights-setup/references/custom-logging.md
+++ b/skills/applicationinsights-setup/references/custom-logging.md
@@ -129,6 +129,15 @@ using (_logger.BeginScope(new Dictionary<string, object>
 }
 ```
 
+> **Important:** Logging scopes are **disabled by default** in the 3.x SDK. Without the following configuration, `BeginScope` properties are silently dropped:
+>
+> ```csharp
+> builder.Services.Configure<OpenTelemetryLoggerOptions>(options =>
+> {
+>     options.IncludeScopes = true;
+> });
+> ```
+
 ## How Logs Map to Application Insights
 
 | ILogger | Application Insights |


### PR DESCRIPTION
Related to Issue #3123.

## Changes
Added documentation based on [this comment](https://github.com/microsoft/ApplicationInsights-dotnet/issues/3123#issuecomment-3935805018).