### PR TITLE
Fix #3163: TelemetryClient construction crash + per-client Context scoping

### DIFF
--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientPerClientScopingTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientPerClientScopingTests.cs
@@ -1,0 +1,267 @@
+namespace Microsoft.ApplicationInsights
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Internal;
+    using OpenTelemetry;
+    using OpenTelemetry.Logs;
+    using OpenTelemetry.Metrics;
+    using OpenTelemetry.Trace;
+    using Xunit;
+
+    [Collection("TelemetryClientTests")]
+    public class TelemetryClientPerClientScopingTests : IDisposable
+    {
+        private readonly TelemetryConfiguration configuration;
+        private readonly List<Activity> activityItems;
+        private readonly List<LogRecord> logItems;
+        private readonly List<OpenTelemetry.Metrics.Metric> metricItems;
+        private readonly TelemetryClient clientA;
+        private readonly TelemetryClient clientB;
+
+        public TelemetryClientPerClientScopingTests()
+        {
+            this.configuration = new TelemetryConfiguration();
+            this.configuration.SamplingRatio = 1.0f;
+            this.configuration.ConnectionString = "InstrumentationKey=" + Guid.NewGuid();
+            this.activityItems = new List<Activity>();
+            this.logItems = new List<LogRecord>();
+            this.metricItems = new List<OpenTelemetry.Metrics.Metric>();
+            this.configuration.ConfigureOpenTelemetryBuilder(builder => builder
+                .WithTracing(tracing => tracing.AddInMemoryExporter(this.activityItems))
+                .WithLogging(logging => logging.AddInMemoryExporter(this.logItems))
+                .WithMetrics(metrics => metrics.AddInMemoryExporter(this.metricItems)));
+            this.clientA = new TelemetryClient(this.configuration);
+            this.clientB = new TelemetryClient(this.configuration);
+        }
+
+        public void Dispose()
+        {
+            while (Activity.Current != null)
+            {
+                Activity.Current.Stop();
+            }
+
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", null);
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", null);
+            this.configuration.Dispose();
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackDependency()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackDependency(new DependencyTelemetry { Type = "HTTP", Name = "dep-a", Duration = TimeSpan.FromMilliseconds(1), Success = true });
+            this.clientB.TrackDependency(new DependencyTelemetry { Type = "HTTP", Name = "dep-b", Duration = TimeSpan.FromMilliseconds(1), Success = true });
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.GetActivityTagValue("dep-a", SemanticConventions.AttributeServiceName));
+            Assert.Equal("B", this.GetActivityTagValue("dep-b", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackRequest()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackRequest(new RequestTelemetry("req-a", DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(1), "200", true));
+            this.clientB.TrackRequest(new RequestTelemetry("req-b", DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(1), "200", true));
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.GetActivityTagValue("req-a", SemanticConventions.AttributeServiceName));
+            Assert.Equal("B", this.GetActivityTagValue("req-b", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackEvent()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackEvent("event-a");
+            this.clientB.TrackEvent("event-b");
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.GetLogAttributeValue("event-a", "microsoft.custom_event.name", SemanticConventions.AttributeServiceName));
+            Assert.Equal("B", this.GetLogAttributeValue("event-b", "microsoft.custom_event.name", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackTrace()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackTrace("trace-a", new Dictionary<string, string> { ["test.name"] = "trace-a" });
+            this.clientB.TrackTrace("trace-b", new Dictionary<string, string> { ["test.name"] = "trace-b" });
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.GetLogAttributeValue("trace-a", "test.name", SemanticConventions.AttributeServiceName));
+            Assert.Equal("B", this.GetLogAttributeValue("trace-b", "test.name", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackException()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackException(new ExceptionTelemetry(new InvalidOperationException("exception-a")));
+            this.clientB.TrackException(new ExceptionTelemetry(new InvalidOperationException("exception-b")));
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.logItems.Single(item => item.FormattedMessage == "exception-a").Attributes.First(attribute => attribute.Key == SemanticConventions.AttributeServiceName).Value?.ToString());
+            Assert.Equal("B", this.logItems.Single(item => item.FormattedMessage == "exception-b").Attributes.First(attribute => attribute.Key == SemanticConventions.AttributeServiceName).Value?.ToString());
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackAvailability()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackAvailability(new AvailabilityTelemetry("availability-a", DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(1), "westus", true));
+            this.clientB.TrackAvailability(new AvailabilityTelemetry("availability-b", DateTimeOffset.UtcNow, TimeSpan.FromMilliseconds(1), "westus", true));
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.GetLogAttributeValue("availability-a", "microsoft.availability.name", SemanticConventions.AttributeServiceName));
+            Assert.Equal("B", this.GetLogAttributeValue("availability-b", "microsoft.availability.name", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void TwoClients_DistinctContext_NoCrossContamination_TrackMetric()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+            this.clientB.Context.Cloud.RoleName = "B";
+
+            this.clientA.TrackMetric(new MetricTelemetry("shared-metric", 1));
+            this.clientB.TrackMetric(new MetricTelemetry("shared-metric", 2));
+            this.clientA.Flush();
+
+            var metric = this.metricItems.Single(m => m.Name == "shared-metric");
+            var serviceNames = new List<string>();
+            foreach (var point in metric.GetMetricPoints())
+            {
+                if (point.GetHistogramCount() <= 0)
+                {
+                    continue;
+                }
+
+                foreach (var tag in point.Tags)
+                {
+                    if (tag.Key == SemanticConventions.AttributeServiceName && tag.Value != null)
+                    {
+                        serviceNames.Add(tag.Value.ToString());
+                    }
+                }
+            }
+
+            Assert.Contains("A", serviceNames);
+            Assert.Contains("B", serviceNames);
+        }
+
+        [Fact]
+        public void Precedence_ItemContext_OverridesClientContext()
+        {
+            this.clientA.Context.Cloud.RoleName = "client";
+            var telemetry = new EventTelemetry("item-overrides-client");
+            telemetry.Context.Cloud.RoleName = "item";
+
+            this.clientA.TrackEvent(telemetry);
+            this.clientA.Flush();
+
+            Assert.Equal("item", this.GetLogAttributeValue("item-overrides-client", "microsoft.custom_event.name", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void Precedence_ClientContext_OverridesDefaultContext()
+        {
+            this.configuration.DefaultContext.User.Id = "default";
+            this.clientA.Context.User.Id = "client";
+
+            this.clientA.TrackEvent("client-overrides-default");
+            this.clientA.Flush();
+
+            Assert.Equal("client", this.GetLogAttributeValue("client-overrides-default", "microsoft.custom_event.name", SemanticConventions.AttributeEnduserPseudoId));
+        }
+
+        [Fact]
+        public void StartOperation_NewActivity_PicksUpClientContext()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+
+            using (this.clientA.StartOperation<RequestTelemetry>("op-a"))
+            {
+            }
+
+            this.clientA.Flush();
+            Assert.Equal("A", this.GetActivityTagValue("op-a", SemanticConventions.AttributeServiceName));
+        }
+
+        [Fact]
+        public void StartOperation_ExistingActivity_PicksUpClientContext()
+        {
+            this.clientA.Context.Cloud.RoleName = "A";
+
+            using var source = new ActivitySource(TelemetryConfiguration.ApplicationInsightsActivitySourceName);
+            using var activity = source.StartActivity("existing-op");
+            Assert.NotNull(activity);
+
+            using (this.clientA.StartOperation<RequestTelemetry>(activity))
+            {
+            }
+
+            this.clientA.Flush();
+            var capturedActivity = Assert.Single(this.activityItems);
+            Assert.Equal("A", capturedActivity.GetTagItem(SemanticConventions.AttributeServiceName)?.ToString());
+        }
+
+        [Fact]
+        public void BareActivitySource_NoClient_PicksUpDefaultContextOnly()
+        {
+            this.configuration.DefaultContext.Operation.Name = "default-op";
+
+            using var source = new ActivitySource(TelemetryConfiguration.ApplicationInsightsActivitySourceName);
+            using (var activity = source.StartActivity("bare-activity"))
+            {
+                Assert.NotNull(activity);
+                activity.Stop();
+            }
+
+            Assert.Equal("default-op", this.GetActivityTagValue("bare-activity", SemanticConventions.AttributeMicrosoftOperationName));
+        }
+
+        [Fact]
+        public void GlobalProperties_PerClient_NoCrossContamination()
+        {
+            this.clientA.Context.GlobalProperties["k"] = "A";
+            this.clientB.Context.GlobalProperties["k"] = "B";
+
+            this.clientA.TrackEvent("globals-a");
+            this.clientB.TrackEvent("globals-b");
+            this.clientA.Flush();
+
+            Assert.Equal("A", this.GetLogAttributeValue("globals-a", "microsoft.custom_event.name", "k"));
+            Assert.Equal("B", this.GetLogAttributeValue("globals-b", "microsoft.custom_event.name", "k"));
+        }
+
+        private string GetActivityTagValue(string activityName, string tagName)
+        {
+            var activity = this.activityItems.Single(item => item.DisplayName == activityName);
+            return activity.GetTagItem(tagName)?.ToString();
+        }
+
+        private string GetLogAttributeValue(string identityValue, string identityKey, string attributeKey)
+        {
+            var logRecord = this.logItems.Single(item => item.Attributes != null && item.Attributes.Any(attribute => attribute.Key == identityKey && attribute.Value?.ToString() == identityValue));
+            return logRecord.Attributes.FirstOrDefault(attribute => attribute.Key == attributeKey).Value?.ToString();
+        }
+    }
+}

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryClientTest.cs
@@ -12,6 +12,7 @@ namespace Microsoft.ApplicationInsights
     using System.Net.Http;
     using System.Reflection;
     using System.Text;
+    using System.Threading.Tasks;
     using Microsoft.ApplicationInsights.Channel;
     using Microsoft.ApplicationInsights.DataContracts;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -56,10 +57,101 @@ namespace Microsoft.ApplicationInsights
             this.telemetryClient?.TelemetryConfiguration?.Dispose();
         }
 
+        private static TelemetryConfiguration CreateTelemetryConfiguration()
+        {
+            var configuration = new TelemetryConfiguration();
+            configuration.ConnectionString = "InstrumentationKey=" + Guid.NewGuid();
+            return configuration;
+        }
+
         [Fact]
         public void TelemetryClientInitializesFeatureReporter()
         {
             Assert.NotNull(this.telemetryClient.Configuration.FeatureReporter);
+        }
+
+        [Fact]
+        public void NewTelemetryClient_AgainstBuiltConfig_DoesNotThrow()
+        {
+            var configuration = CreateTelemetryConfiguration();
+
+            try
+            {
+                _ = configuration.Build();
+
+                var exception = Record.Exception(() =>
+                {
+                    var client = new TelemetryClient(configuration);
+                    client.TrackEvent("e");
+                });
+
+                Assert.Null(exception);
+            }
+            finally
+            {
+                configuration.Dispose();
+            }
+        }
+
+        [Fact]
+        public async Task TwoConcurrentConstructions_NoCrash()
+        {
+            for (var iteration = 0; iteration < 50; iteration++)
+            {
+                var configuration = CreateTelemetryConfiguration();
+
+                try
+                {
+                    TelemetryClient[] clients = null;
+                    var exception = await Record.ExceptionAsync(async () =>
+                    {
+                        clients = await Task.WhenAll(
+                            Task.Run(() => new TelemetryClient(configuration)),
+                            Task.Run(() => new TelemetryClient(configuration)));
+                    });
+
+                    Assert.Null(exception);
+                    Assert.NotNull(clients);
+                    Assert.Equal(2, clients.Length);
+
+                    foreach (var client in clients)
+                    {
+                        client.TrackEvent("e");
+                    }
+                }
+                finally
+                {
+                    configuration.Dispose();
+                }
+            }
+        }
+
+        [Fact]
+        public async Task NewClientConcurrentlyWithBuild_NoCrash()
+        {
+            var configuration = CreateTelemetryConfiguration();
+
+            try
+            {
+                OpenTelemetrySdk sdk = null;
+                TelemetryClient client = null;
+                var exception = await Record.ExceptionAsync(async () =>
+                {
+                    await Task.WhenAll(
+                        Task.Run(() => sdk = configuration.Build()),
+                        Task.Run(() => client = new TelemetryClient(configuration)));
+                });
+
+                Assert.Null(exception);
+                Assert.NotNull(sdk);
+                Assert.NotNull(client);
+
+                client.TrackEvent("e");
+            }
+            finally
+            {
+                configuration.Dispose();
+            }
         }
 
         #region TrackEvent

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryConfigurationSetExporterOptionsTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryConfigurationSetExporterOptionsTests.cs
@@ -1,13 +1,20 @@
 namespace Microsoft.ApplicationInsights.Tests
 {
     using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Linq;
     using System.Reflection;
     using Azure.Core;
     using Azure.Monitor.OpenTelemetry.Exporter;
     using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Internal;
     using Microsoft.Extensions.DependencyInjection;
+    using Microsoft.Extensions.Logging;
     using Microsoft.Extensions.Options;
     using OpenTelemetry;
+    using OpenTelemetry.Logs;
+    using OpenTelemetry.Trace;
     using Xunit;
 
     /// <summary>
@@ -24,6 +31,13 @@ namespace Microsoft.ApplicationInsights.Tests
         public void Dispose()
         {
             this.telemetryConfiguration?.Dispose();
+        }
+
+        private static TelemetryConfiguration CreateTelemetryConfiguration()
+        {
+            var configuration = new TelemetryConfiguration();
+            configuration.ConnectionString = "InstrumentationKey=" + Guid.NewGuid();
+            return configuration;
         }
 
         /// <summary>
@@ -60,6 +74,138 @@ namespace Microsoft.ApplicationInsights.Tests
                 BindingFlags.NonPublic | BindingFlags.Instance);
 
             return sdkField?.GetValue(client) as OpenTelemetrySdk;
+        }
+
+        private static T GetSdkService<T>(OpenTelemetrySdk sdk)
+            where T : class
+        {
+            var servicesProperty = typeof(OpenTelemetrySdk).GetProperty(
+                "Services",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            var serviceProvider = servicesProperty?.GetValue(sdk) as IServiceProvider;
+            Assert.NotNull(serviceProvider);
+
+            var service = serviceProvider.GetService<T>();
+            Assert.NotNull(service);
+            return service;
+        }
+
+        private static Action<IOpenTelemetryBuilder> GetBuilderConfiguration(TelemetryConfiguration configuration)
+        {
+            var builderConfigurationField = typeof(TelemetryConfiguration).GetField(
+                "builderConfiguration",
+                BindingFlags.NonPublic | BindingFlags.Instance);
+
+            Assert.NotNull(builderConfigurationField);
+            var builderConfiguration = builderConfigurationField.GetValue(configuration) as Action<IOpenTelemetryBuilder>;
+            Assert.NotNull(builderConfiguration);
+            return builderConfiguration;
+        }
+
+        [Fact]
+        public void Build_RegistersDefaultContextActivityProcessor_BeforeUserExporter()
+        {
+            using var configuration = CreateTelemetryConfiguration();
+            configuration.SamplingRatio = 1.0F;
+            configuration.DefaultContext.Operation.Name = "operation-X";
+
+            var activityItems = new List<Activity>();
+            configuration.ConfigureOpenTelemetryBuilder(builder =>
+                builder.WithTracing(tracing => tracing.AddInMemoryExporter(activityItems)));
+
+            using var sdk = configuration.Build();
+            using var activitySource = new ActivitySource(TelemetryConfiguration.ApplicationInsightsActivitySourceName);
+            using (var activity = activitySource.StartActivity("test-activity"))
+            {
+                Assert.NotNull(activity);
+                activity.Stop();
+            }
+
+            var capturedActivity = Assert.Single(activityItems);
+            Assert.Equal("operation-X", capturedActivity.GetTagItem(SemanticConventions.AttributeMicrosoftOperationName));
+        }
+
+        [Fact]
+        public void Build_RegistersDefaultContextLogProcessor_BeforeUserExporter()
+        {
+            using var configuration = CreateTelemetryConfiguration();
+            configuration.DefaultContext.Operation.Name = "operation-X";
+
+            var logItems = new List<LogRecord>();
+            configuration.ConfigureOpenTelemetryBuilder(builder =>
+                builder.WithLogging(logging => logging.AddInMemoryExporter(logItems)));
+
+            using var sdk = configuration.Build();
+            var loggerFactory = GetSdkService<ILoggerFactory>(sdk);
+            var logger = loggerFactory.CreateLogger("Layer3bTests");
+            logger.LogInformation("layer3b-log-message");
+
+            var capturedLog = Assert.Single(logItems.Where(l => l.FormattedMessage == "layer3b-log-message"));
+            var attributes = capturedLog.Attributes.ToDictionary(a => a.Key, a => a.Value?.ToString());
+            Assert.Equal("operation-X", attributes[SemanticConventions.AttributeMicrosoftOperationName]);
+        }
+
+        [Fact]
+        public void Build_WithoutDefaultContextValues_NoSpuriousTags()
+        {
+            using var configuration = CreateTelemetryConfiguration();
+            configuration.SamplingRatio = 1.0F;
+
+            var activityItems = new List<Activity>();
+            configuration.ConfigureOpenTelemetryBuilder(builder =>
+                builder.WithTracing(tracing => tracing.AddInMemoryExporter(activityItems)));
+
+            using var sdk = configuration.Build();
+            using var activitySource = new ActivitySource(TelemetryConfiguration.ApplicationInsightsActivitySourceName);
+            using (var activity = activitySource.StartActivity("test-activity"))
+            {
+                Assert.NotNull(activity);
+                activity.SetTag("custom-tag", "custom-value");
+                activity.Stop();
+            }
+
+            var capturedActivity = Assert.Single(activityItems);
+            Assert.Equal("custom-value", capturedActivity.GetTagItem("custom-tag"));
+            Assert.Null(capturedActivity.GetTagItem(SemanticConventions.AttributeMicrosoftOperationName));
+            Assert.Null(capturedActivity.GetTagItem(SemanticConventions.AttributeEnduserPseudoId));
+        }
+
+        [Fact]
+        public void Build_DefaultContextMutationAfterBuild_IsVisibleOnNextActivity()
+        {
+            using var configuration = CreateTelemetryConfiguration();
+            configuration.SamplingRatio = 1.0F;
+
+            var activityItems = new List<Activity>();
+            configuration.ConfigureOpenTelemetryBuilder(builder =>
+                builder.WithTracing(tracing => tracing.AddInMemoryExporter(activityItems)));
+
+            using var sdk = configuration.Build();
+            configuration.DefaultContext.Operation.Name = "later";
+
+            using var activitySource = new ActivitySource(TelemetryConfiguration.ApplicationInsightsActivitySourceName);
+            using (var activity = activitySource.StartActivity("test-activity"))
+            {
+                Assert.NotNull(activity);
+                activity.Stop();
+            }
+
+            var capturedActivity = Assert.Single(activityItems);
+            Assert.Equal("later", capturedActivity.GetTagItem(SemanticConventions.AttributeMicrosoftOperationName));
+        }
+
+        [Fact]
+        public void TelemetryClient_NonDI_DoesNotMutateConfiguration()
+        {
+            using var configuration = CreateTelemetryConfiguration();
+            var builderConfigurationBefore = GetBuilderConfiguration(configuration);
+
+            _ = new TelemetryClient(configuration);
+            _ = new TelemetryClient(configuration);
+
+            var builderConfigurationAfter = GetBuilderConfiguration(configuration);
+            Assert.Same(builderConfigurationBefore, builderConfigurationAfter);
         }
 
         #region SamplingRatio Tests
@@ -333,5 +479,87 @@ namespace Microsoft.ApplicationInsights.Tests
         }
 
         #endregion
+
+        [Fact]
+        public void TryPrependOpenTelemetryBuilderConfiguration_AppendsWhenNotBuilt()
+        {
+            this.telemetryConfiguration = CreateTelemetryConfiguration();
+            var invocationOrder = new List<string>();
+
+            this.telemetryConfiguration.ConfigureOpenTelemetryBuilder(_ => invocationOrder.Add("existing"));
+
+            var result = this.telemetryConfiguration.TryPrependOpenTelemetryBuilderConfiguration(_ => invocationOrder.Add("prepended"));
+
+            Assert.True(result);
+
+            _ = this.telemetryConfiguration.Build();
+
+            Assert.Equal(new[] { "prepended", "existing" }, invocationOrder);
+        }
+
+        [Fact]
+        public void TryPrependOpenTelemetryBuilderConfiguration_ReturnsFalseWhenBuilt()
+        {
+            this.telemetryConfiguration = CreateTelemetryConfiguration();
+
+            _ = this.telemetryConfiguration.Build();
+
+            var result = this.telemetryConfiguration.TryPrependOpenTelemetryBuilderConfiguration(_ => { });
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryPrependOpenTelemetryBuilderConfiguration_NullThrowsArgumentNullException()
+        {
+            this.telemetryConfiguration = CreateTelemetryConfiguration();
+
+            Assert.Throws<ArgumentNullException>(() => this.telemetryConfiguration.TryPrependOpenTelemetryBuilderConfiguration(null));
+        }
+
+        [Fact]
+        public void Build_IsIdempotent()
+        {
+            this.telemetryConfiguration = CreateTelemetryConfiguration();
+
+            var firstSdk = this.telemetryConfiguration.Build();
+            var secondSdk = this.telemetryConfiguration.Build();
+
+            Assert.Same(firstSdk, secondSdk);
+        }
+
+        [Fact]
+        public void TelemetryConfiguration_DefaultContext_IsNonNullAndStableReference()
+        {
+            using var firstConfiguration = new TelemetryConfiguration();
+            using var secondConfiguration = new TelemetryConfiguration();
+
+            Assert.NotNull(firstConfiguration.DefaultContext);
+            Assert.NotNull(secondConfiguration.DefaultContext);
+            Assert.Same(firstConfiguration.DefaultContext, firstConfiguration.DefaultContext);
+            Assert.NotSame(firstConfiguration.DefaultContext, secondConfiguration.DefaultContext);
+        }
+
+        [Fact]
+        public void TelemetryConfiguration_DefaultContext_MutationIsVisibleAfterBuild()
+        {
+            this.telemetryConfiguration = CreateTelemetryConfiguration();
+
+            _ = this.telemetryConfiguration.Build();
+
+            this.telemetryConfiguration.DefaultContext.Cloud.RoleName = "x";
+
+            Assert.Equal("x", this.telemetryConfiguration.DefaultContext.Cloud.RoleName);
+        }
+
+        [Fact]
+        public void TelemetryConfiguration_DefaultContext_GlobalPropertiesIsMutable()
+        {
+            using var configuration = new TelemetryConfiguration();
+
+            configuration.DefaultContext.GlobalProperties["k"] = "v";
+
+            Assert.Equal("v", configuration.DefaultContext.GlobalProperties["k"]);
+        }
     }
 }

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryConfigurationSetExporterOptionsTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryConfigurationSetExporterOptionsTests.cs
@@ -529,6 +529,21 @@ namespace Microsoft.ApplicationInsights.Tests
         }
 
         [Fact]
+        public void Build_WithSkipDefaultBuilderConfiguration_DoesNotThrow()
+        {
+            // Regression test: TelemetryConfiguration created with skipDefaultBuilderConfiguration: true
+            // (the DI path) leaves builderConfiguration null. Build() must tolerate that without NRE
+            // so that `new TelemetryClient(diResolvedConfig)` works (the contract advertised by the
+            // migration guidance and exercised by NETCORE DiTelemetryClientParityTests).
+            using var configuration = new TelemetryConfiguration(skipDefaultBuilderConfiguration: true);
+            configuration.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+
+            var sdk = configuration.Build();
+
+            Assert.NotNull(sdk);
+        }
+
+        [Fact]
         public void TelemetryConfiguration_DefaultContext_IsNonNullAndStableReference()
         {
             using var firstConfiguration = new TelemetryConfiguration();

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryConfigurationSetExporterOptionsTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryConfigurationSetExporterOptionsTests.cs
@@ -544,6 +544,43 @@ namespace Microsoft.ApplicationInsights.Tests
         }
 
         [Fact]
+        public void Build_AfterConfigureOpenTelemetryBuilderOnSkipDefaultConfig_DoesNotThrow()
+        {
+            // Regression test: when builderConfiguration starts null (skipDefaultBuilderConfiguration: true),
+            // calling ConfigureOpenTelemetryBuilder / Prepend / TryPrepend must not capture that null
+            // and dereference it later inside the composite delegate during Build(). The public API
+            // ConfigureOpenTelemetryBuilder (and its callers like SetAzureTokenCredential) must be
+            // safe to call on a DI-resolved configuration.
+            using var configuration = new TelemetryConfiguration(skipDefaultBuilderConfiguration: true);
+            configuration.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+
+            var userActionInvoked = false;
+            configuration.ConfigureOpenTelemetryBuilder(_ => userActionInvoked = true);
+
+            var sdk = configuration.Build();
+
+            Assert.NotNull(sdk);
+            Assert.True(userActionInvoked, "User ConfigureOpenTelemetryBuilder action should have run during Build().");
+        }
+
+        [Fact]
+        public void Build_AfterTryPrependOnSkipDefaultConfig_DoesNotThrow()
+        {
+            // Regression test: same as above but via TryPrependOpenTelemetryBuilderConfiguration.
+            using var configuration = new TelemetryConfiguration(skipDefaultBuilderConfiguration: true);
+            configuration.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-000000000000";
+
+            var prependInvoked = false;
+            var prepended = configuration.TryPrependOpenTelemetryBuilderConfiguration(_ => prependInvoked = true);
+            Assert.True(prepended);
+
+            var sdk = configuration.Build();
+
+            Assert.NotNull(sdk);
+            Assert.True(prependInvoked, "TryPrependOpenTelemetryBuilderConfiguration action should have run during Build().");
+        }
+
+        [Fact]
         public void TelemetryConfiguration_DefaultContext_IsNonNullAndStableReference()
         {
             using var firstConfiguration = new TelemetryConfiguration();

--- a/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryContextEnricherTests.cs
+++ b/BASE/Test/Microsoft.ApplicationInsights.Test/Microsoft.ApplicationInsights.Tests/TelemetryContextEnricherTests.cs
@@ -1,0 +1,176 @@
+namespace Microsoft.ApplicationInsights.Processors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Reflection;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Internal;
+    using Xunit;
+
+    public class TelemetryContextEnricherTests : IDisposable
+    {
+        private readonly ActivitySource activitySource;
+        private readonly ActivityListener activityListener;
+
+        public TelemetryContextEnricherTests()
+        {
+            this.activitySource = new ActivitySource("Test.TelemetryContextEnricher");
+            this.activityListener = new ActivityListener
+            {
+                ShouldListenTo = _ => true,
+                Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData,
+            };
+
+            ActivitySource.AddActivityListener(this.activityListener);
+        }
+
+        public void Dispose()
+        {
+            this.activityListener.Dispose();
+            this.activitySource.Dispose();
+        }
+
+        [Fact]
+        public void ApplyToActivity_SkipsIfPresent()
+        {
+            var context = new TelemetryContext();
+            context.User.Id = "context-user";
+
+            using var activity = this.CreateStoppedActivity();
+            activity.SetTag(SemanticConventions.AttributeEnduserPseudoId, "existing-user");
+
+            TelemetryContextEnricher.ApplyToActivity(activity, context);
+
+            Assert.Equal("existing-user", activity.GetTagItem(SemanticConventions.AttributeEnduserPseudoId));
+        }
+
+        [Fact]
+        public void ApplyToActivity_AppliesAllKnownContextFields()
+        {
+            var context = new TelemetryContext();
+            context.GlobalProperties["env"] = "prod";
+            context.User.Id = "user-123";
+            context.User.AuthenticatedUserId = "auth-456";
+            context.User.AccountId = "acct-789";
+            context.User.UserAgent = "agent/1.0";
+            context.Operation.Name = "GET /api";
+            context.Operation.SyntheticSource = "bot";
+            context.Location.Ip = "10.0.0.1";
+            context.Session.Id = "session-1";
+            context.Device.Id = "device-1";
+            context.Device.Model = "Surface";
+            context.Device.Type = "PC";
+            context.Device.OperatingSystem = "Windows 11";
+
+            using var activity = this.CreateStoppedActivity();
+            TelemetryContextEnricher.ApplyToActivity(activity, context);
+
+            Assert.Equal("prod", activity.GetTagItem("env"));
+            Assert.Equal("user-123", activity.GetTagItem(SemanticConventions.AttributeEnduserPseudoId));
+            Assert.Equal("auth-456", activity.GetTagItem(SemanticConventions.AttributeEnduserId));
+            Assert.Equal("acct-789", activity.GetTagItem(SemanticConventions.AttributeMicrosoftUserAccountId));
+            Assert.Equal("agent/1.0", activity.GetTagItem(SemanticConventions.AttributeUserAgentOriginal));
+            Assert.Equal("GET /api", activity.GetTagItem(SemanticConventions.AttributeMicrosoftOperationName));
+            Assert.Equal("bot", activity.GetTagItem(SemanticConventions.AttributeMicrosoftSyntheticSource));
+            Assert.Equal("10.0.0.1", activity.GetTagItem(SemanticConventions.AttributeMicrosoftClientIp));
+            Assert.Equal("session-1", activity.GetTagItem(SemanticConventions.AttributeMicrosoftSessionId));
+            Assert.Equal("device-1", activity.GetTagItem(SemanticConventions.AttributeAiDeviceId));
+            Assert.Equal("Surface", activity.GetTagItem(SemanticConventions.AttributeAiDeviceModel));
+            Assert.Equal("PC", activity.GetTagItem(SemanticConventions.AttributeAiDeviceType));
+            Assert.Equal("Windows 11", activity.GetTagItem(SemanticConventions.AttributeAiDeviceOsVersion));
+        }
+
+        [Fact]
+        public void ApplyToActivity_NullContextIsNoOp()
+        {
+            using var activity = this.CreateStoppedActivity();
+
+            TelemetryContextEnricher.ApplyToActivity(activity, null);
+
+            Assert.Empty(activity.Tags);
+        }
+
+        [Fact]
+        public void ApplyToActivity_NullActivityIsNoOp()
+        {
+            var context = new TelemetryContext();
+            context.User.Id = "user-123";
+
+            TelemetryContextEnricher.ApplyToActivity(null, context);
+        }
+
+        [Fact]
+        public void BuildSnapshot_OmitsNullAndEmpty()
+        {
+            var context = new TelemetryContext();
+            context.GlobalProperties["env"] = "prod";
+            context.GlobalProperties["empty"] = string.Empty;
+            context.User.Id = "user-123";
+            context.Operation.Name = string.Empty;
+
+            var snapshot = TelemetryContextEnricher.BuildSnapshot(context);
+
+            Assert.Equal(2, snapshot.Tags.Length);
+            Assert.Contains(snapshot.Tags, kvp => kvp.Key == "env" && kvp.Value == "prod");
+            Assert.Contains(snapshot.Tags, kvp => kvp.Key == SemanticConventions.AttributeEnduserPseudoId && kvp.Value == "user-123");
+        }
+
+        [Fact]
+        public void ApplySnapshot_DoesNotOverwriteExistingTags()
+        {
+            var context = new TelemetryContext();
+            context.User.Id = "context-user";
+            var snapshot = TelemetryContextEnricher.BuildSnapshot(context);
+
+            using var activity = this.CreateStoppedActivity();
+            activity.SetTag(SemanticConventions.AttributeEnduserPseudoId, "existing-user");
+
+            TelemetryContextEnricher.ApplySnapshotToActivity(activity, snapshot);
+
+            Assert.Equal("existing-user", activity.GetTagItem(SemanticConventions.AttributeEnduserPseudoId));
+        }
+
+        [Fact]
+        public void ApplyToLogAttributes_SkipsIfPresent()
+        {
+            var context = new TelemetryContext();
+            context.User.Id = "context-user";
+            var attributes = new Dictionary<string, string>
+            {
+                [SemanticConventions.AttributeEnduserPseudoId] = "existing-user",
+            };
+
+            TelemetryContextEnricher.ApplyToLogAttributes(attributes, context);
+
+            Assert.Equal("existing-user", attributes[SemanticConventions.AttributeEnduserPseudoId]);
+        }
+
+        [Fact]
+        public void WarmupGate_FreezesAfterBothThresholds()
+        {
+            var gate = new WarmupGate();
+
+            for (int i = 0; i < WarmupGate.CountThreshold - 1; i++)
+            {
+                Assert.False(gate.ShouldFreeze());
+            }
+
+            Assert.False(gate.ShouldFreeze());
+
+            var field = typeof(WarmupGate).GetField("constructedTimestamp", BindingFlags.NonPublic | BindingFlags.Instance);
+            Assert.NotNull(field);
+            field.SetValue(gate, Stopwatch.GetTimestamp() - (Stopwatch.Frequency * 10));
+
+            Assert.True(gate.ShouldFreeze());
+        }
+
+        private Activity CreateStoppedActivity()
+        {
+            var activity = this.activitySource.StartActivity("TestOp");
+            Assert.NotNull(activity);
+            activity.Stop();
+            return activity;
+        }
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -14,10 +14,13 @@
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing.SelfDiagnostics;
     using Microsoft.ApplicationInsights.Internal;
     using Microsoft.ApplicationInsights.Metrics;
+    using Microsoft.ApplicationInsights.Processors;
     using Microsoft.Extensions.DependencyInjection;
     using Microsoft.Extensions.Hosting;
     using OpenTelemetry;
+    using OpenTelemetry.Logs;
     using OpenTelemetry.Resources;
+    using OpenTelemetry.Trace;
 
     /// <summary>
     /// Encapsulates the global telemetry configuration typically loaded from the ApplicationInsights.config file.
@@ -212,6 +215,11 @@
         }
 
         /// <summary>
+        /// Gets the shared context used to enrich telemetry produced outside of any TelemetryClient (e.g., user code using the Microsoft.ApplicationInsights ActivitySource directly, or logs flowing through Microsoft.Extensions.Logging). Per-client TelemetryClient.Context enrichment takes precedence and is applied at the source.
+        /// </summary>
+        internal TelemetryContext DefaultContext { get; } = new TelemetryContext();
+
+        /// <summary>
         /// Gets or sets a value indicating the version string to report to SDK stats. Eg., "shc1.2.3".
         /// </summary>
         internal string ExtensionVersion
@@ -331,6 +339,39 @@
         }
 
         /// <summary>
+        /// Atomically prepends a configuration action so it runs before any user-registered configuration.
+        /// Race-safe: takes the configuration lock and checks the built state atomically.
+        /// Returns false if the configuration is already built (caller's mutation was not applied).
+        /// </summary>
+        internal bool TryPrependOpenTelemetryBuilderConfiguration(Action<IOpenTelemetryBuilder> configure)
+        {
+#if NET6_0_OR_GREATER
+            ArgumentNullException.ThrowIfNull(configure);
+#else
+            if (configure == null)
+            {
+                throw new ArgumentNullException(nameof(configure));
+            }
+#endif
+
+            lock (this.lockObject)
+            {
+                if (this.isBuilt)
+                {
+                    return false;
+                }
+
+                var previousConfiguration = this.builderConfiguration;
+                this.builderConfiguration = builder =>
+                {
+                    configure(builder);
+                    previousConfiguration(builder);
+                };
+                return true;
+            }
+        }
+
+        /// <summary>
         /// Sets the cloud role name and role instance for telemetry.
         /// This configures the OpenTelemetry Resource with service.name, service.namespace, service.instance.id, and service.version attributes
         /// which map to Cloud.RoleName, Cloud.RoleInstance, and Application.Ver in Application Insights.
@@ -391,11 +432,6 @@
         /// </summary>
         internal OpenTelemetrySdk Build()
         {
-            if (this.isBuilt)
-            {
-                return this.openTelemetrySdk;
-            }
-
             lock (this.lockObject)
             {
                 if (this.isBuilt)
@@ -417,6 +453,18 @@
 
                 this.openTelemetrySdk = OpenTelemetrySdk.Create(builder =>
                 {
+                    // Register default-context enrichment processors before invoking the user builder
+                    // configuration. These ConfigureOpenTelemetry* callbacks are applied in registration
+                    // order, so registering them first ensures downstream user processors/exporters observe
+                    // already-enriched telemetry.
+                    if (this.DefaultContext != null)
+                    {
+                        builder.Services.ConfigureOpenTelemetryTracerProvider(tracing =>
+                            tracing.AddProcessor(new TelemetryContextActivityProcessor(this.DefaultContext)));
+                        builder.Services.ConfigureOpenTelemetryLoggerProvider(logging =>
+                            logging.AddProcessor(new TelemetryContextLogProcessor(this.DefaultContext)));
+                    }
+
                     this.builderConfiguration(builder);
                     builder.SetAzureMonitorExporter(options =>
                     {

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -465,7 +465,7 @@
                             logging.AddProcessor(new TelemetryContextLogProcessor(this.DefaultContext)));
                     }
 
-                    this.builderConfiguration(builder);
+                    this.builderConfiguration?.Invoke(builder);
                     builder.SetAzureMonitorExporter(options =>
                     {
                         if (!string.IsNullOrEmpty(this.connectionString))

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -277,7 +277,7 @@
             var previousConfiguration = this.builderConfiguration;
             this.builderConfiguration = builder =>
             {
-                previousConfiguration(builder);
+                previousConfiguration?.Invoke(builder);
                 configure(builder);
             };
         }
@@ -334,7 +334,7 @@
             this.builderConfiguration = builder =>
             {
                 configure(builder);
-                previousConfiguration(builder);
+                previousConfiguration?.Invoke(builder);
             };
         }
 
@@ -365,7 +365,7 @@
                 this.builderConfiguration = builder =>
                 {
                     configure(builder);
-                    previousConfiguration(builder);
+                    previousConfiguration?.Invoke(builder);
                 };
                 return true;
             }

--- a/BASE/src/Microsoft.ApplicationInsights/Processors/ContextSnapshot.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Processors/ContextSnapshot.cs
@@ -1,0 +1,15 @@
+namespace Microsoft.ApplicationInsights.Processors
+{
+    using System;
+    using System.Collections.Generic;
+
+    internal sealed class ContextSnapshot
+    {
+        internal ContextSnapshot(KeyValuePair<string, string>[] tags)
+        {
+            this.Tags = tags ?? Array.Empty<KeyValuePair<string, string>>();
+        }
+
+        internal KeyValuePair<string, string>[] Tags { get; }
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextActivityProcessor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextActivityProcessor.cs
@@ -2,10 +2,8 @@ namespace Microsoft.ApplicationInsights.Processors
 {
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Runtime.CompilerServices;
     using System.Threading;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Internal;
     using OpenTelemetry;
 
     /// <summary>
@@ -14,59 +12,23 @@ namespace Microsoft.ApplicationInsights.Processors
     /// This ensures context tags are applied universally — to Track* calls, Start/Stop operations,
     /// and any OpenTelemetry API activities emitted by customer code.
     /// </summary>
-    /// <remarks>
-    /// Performance optimization: after a warmup period (<see cref="WarmupCountThreshold"/> calls),
-    /// context properties are frozen into a compact snapshot array. This avoids repeatedly
-    /// navigating the TelemetryContext object graph and skipping null/empty values on every call.
-    /// This relies on the documented pattern that customers set TelemetryClient.Context
-    /// properties once during initialization.
-    /// </remarks>
     internal sealed class TelemetryContextActivityProcessor : BaseProcessor<Activity>
     {
-        /// <summary>
-        /// Minimum number of OnEnd calls before the context snapshot can be frozen.
-        /// </summary>
-        internal const int WarmupCountThreshold = 10;
-
-        /// <summary>
-        /// Minimum time (in milliseconds) after construction before the context snapshot
-        /// can be frozen. This guards against high-throughput apps where 10 activities
-        /// complete before async initialization (e.g., IHostedService, middleware) has
-        /// had a chance to set TelemetryContext properties.
-        /// </summary>
-        internal const long WarmupTimeThresholdMs = 5_000;
+        internal const int WarmupCountThreshold = WarmupGate.CountThreshold;
+        internal const long WarmupTimeThresholdMs = WarmupGate.TimeThresholdMs;
 
         private readonly TelemetryContext context;
         private readonly long constructedTimestamp;
-
-        /// <summary>
-        /// Frozen snapshot of non-null context tags, built after warmup.
-        /// Once set, this array is immutable and read lock-free.
-        /// </summary>
+        private volatile ContextSnapshot frozenSnapshot;
         private volatile KeyValuePair<string, string>[] frozenTags;
-
-        /// <summary>
-        /// Counter tracking the number of OnEnd calls during warmup.
-        /// </summary>
         private int warmupCounter;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TelemetryContextActivityProcessor"/> class.
-        /// </summary>
-        /// <param name="context">The client-level <see cref="TelemetryContext"/> to apply.</param>
         public TelemetryContextActivityProcessor(TelemetryContext context)
         {
             this.context = context;
             this.constructedTimestamp = Stopwatch.GetTimestamp();
         }
 
-        /// <summary>
-        /// Called when an activity ends. Applies client-level context tags using
-        /// skip-if-present semantics: if a tag is already set (by item-level context,
-        /// Track* methods, or instrumentation), it is not overwritten.
-        /// This matches the 2.x SDK's <c>Tags.CopyTagValue</c> precedence behavior.
-        /// </summary>
-        /// <param name="activity">The activity that ended.</param>
         public override void OnEnd(Activity activity)
         {
             if (activity == null || this.context == null)
@@ -74,161 +36,26 @@ namespace Microsoft.ApplicationInsights.Processors
                 return;
             }
 
-            var snapshot = this.frozenTags;
+            var snapshot = this.frozenSnapshot;
             if (snapshot != null)
             {
-                // Fast path: apply pre-computed snapshot (only non-null values, no object graph navigation)
-                ApplySnapshot(activity, snapshot);
+                TelemetryContextEnricher.ApplySnapshotToActivity(activity, snapshot);
             }
             else
             {
-                // Slow path: full context evaluation during warmup
-                this.SlowPathOnEnd(activity);
-            }
+                TelemetryContextEnricher.ApplyToActivity(activity, this.context);
 
-            base.OnEnd(activity);
-        }
-
-        /// <summary>
-        /// Applies the frozen snapshot of context tags to the activity.
-        /// Only contains entries where the value was non-null/non-empty at snapshot time.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void ApplySnapshot(Activity activity, KeyValuePair<string, string>[] snapshot)
-        {
-            for (int i = 0; i < snapshot.Length; i++)
-            {
-                ref readonly var kvp = ref snapshot[i];
-                if (activity.GetTagItem(kvp.Key) == null)
+                if (WarmupGate.ShouldFreeze(ref this.warmupCounter, this.constructedTimestamp) && this.frozenSnapshot == null)
                 {
-                    activity.SetTag(kvp.Key, kvp.Value);
-                }
-            }
-        }
-
-        private static void AddIfNotEmpty(List<KeyValuePair<string, string>> list, string key, string value)
-        {
-            if (!string.IsNullOrEmpty(value) && !ContainsKey(list, key))
-            {
-                list.Add(new KeyValuePair<string, string>(key, value));
-            }
-        }
-
-        private static bool ContainsKey(List<KeyValuePair<string, string>> list, string key)
-        {
-            for (int i = 0; i < list.Count; i++)
-            {
-                if (list[i].Key == key)
-                {
-                    return true;
-                }
-            }
-
-            return false;
-        }
-
-        private static void SetTagIfAbsent(Activity activity, string key, string value)
-        {
-            if (!string.IsNullOrEmpty(value) && activity.GetTagItem(key) == null)
-            {
-                activity.SetTag(key, value);
-            }
-        }
-
-        /// <summary>
-        /// Full context evaluation path used during warmup. After <see cref="WarmupCountThreshold"/>
-        /// calls, builds and freezes the snapshot for all subsequent calls.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SlowPathOnEnd(Activity activity)
-        {
-            // Apply client-level GlobalProperties (lowest priority — will not overwrite existing tags)
-            var globalProperties = this.context.GlobalPropertiesValue;
-            if (globalProperties != null)
-            {
-                foreach (var kvp in globalProperties)
-                {
-                    SetTagIfAbsent(activity, kvp.Key, kvp.Value);
-                }
-            }
-
-            SetTagIfAbsent(activity, SemanticConventions.AttributeEnduserPseudoId, this.context.User?.Id);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeEnduserId, this.context.User?.AuthenticatedUserId);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftOperationName, this.context.Operation?.Name);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftClientIp, this.context.Location?.Ip);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftSessionId, this.context.Session?.Id);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceId, this.context.Device?.Id);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceModel, this.context.Device?.Model);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceType, this.context.Device?.Type);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceOsVersion, this.context.Device?.OperatingSystem);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftSyntheticSource, this.context.Operation?.SyntheticSource);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftUserAccountId, this.context.User?.AccountId);
-            SetTagIfAbsent(activity, SemanticConventions.AttributeUserAgentOriginal, this.context.User?.UserAgent);
-
-            // Freeze the snapshot once BOTH conditions are met:
-            //   1. At least WarmupCountThreshold calls have occurred.
-            //   2. At least WarmupTimeThresholdMs has elapsed since construction.
-            // The count gate ensures we don't snapshot on the very first call.
-            // The time gate ensures we don't snapshot before async init (e.g.,
-            // IHostedService.StartAsync, middleware) has had time to set context.
-            int count = Interlocked.Increment(ref this.warmupCounter);
-            if (count >= WarmupCountThreshold && this.HasTimeThresholdElapsed())
-            {
-                // CAS-style: only the thread that transitions from null builds the snapshot.
-                if (this.frozenTags == null)
-                {
-                    Interlocked.CompareExchange(ref this.frozenTags, this.BuildSnapshot(), null);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Builds an immutable snapshot array of all non-null/non-empty context tags.
-        /// Called once after warmup completes.
-        /// </summary>
-        private KeyValuePair<string, string>[] BuildSnapshot()
-        {
-            var list = new List<KeyValuePair<string, string>>();
-
-            var globalProperties = this.context.GlobalPropertiesValue;
-            if (globalProperties != null)
-            {
-                foreach (var kvp in globalProperties)
-                {
-                    if (!string.IsNullOrEmpty(kvp.Value))
+                    var builtSnapshot = TelemetryContextEnricher.BuildSnapshot(this.context);
+                    if (Interlocked.CompareExchange(ref this.frozenSnapshot, builtSnapshot, null) == null)
                     {
-                        list.Add(new KeyValuePair<string, string>(kvp.Key, kvp.Value));
+                        this.frozenTags = builtSnapshot.Tags;
                     }
                 }
             }
 
-            AddIfNotEmpty(list, SemanticConventions.AttributeEnduserPseudoId, this.context.User?.Id);
-            AddIfNotEmpty(list, SemanticConventions.AttributeEnduserId, this.context.User?.AuthenticatedUserId);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftOperationName, this.context.Operation?.Name);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftClientIp, this.context.Location?.Ip);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftSessionId, this.context.Session?.Id);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceId, this.context.Device?.Id);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceModel, this.context.Device?.Model);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceType, this.context.Device?.Type);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceOsVersion, this.context.Device?.OperatingSystem);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftSyntheticSource, this.context.Operation?.SyntheticSource);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftUserAccountId, this.context.User?.AccountId);
-            AddIfNotEmpty(list, SemanticConventions.AttributeUserAgentOriginal, this.context.User?.UserAgent);
-
-            return list.ToArray();
-        }
-
-        /// <summary>
-        /// Returns true if at least <see cref="WarmupTimeThresholdMs"/> milliseconds
-        /// have elapsed since this processor was constructed.
-        /// Uses <see cref="Stopwatch"/> for monotonic, allocation-free timing.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool HasTimeThresholdElapsed()
-        {
-            long elapsedTicks = Stopwatch.GetTimestamp() - this.constructedTimestamp;
-            long elapsedMs = (elapsedTicks * 1000) / Stopwatch.Frequency;
-            return elapsedMs >= WarmupTimeThresholdMs;
+            base.OnEnd(activity);
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextEnricher.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextEnricher.cs
@@ -1,0 +1,181 @@
+namespace Microsoft.ApplicationInsights.Processors
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Diagnostics;
+    using System.Runtime.CompilerServices;
+    using Microsoft.ApplicationInsights.DataContracts;
+    using Microsoft.ApplicationInsights.Internal;
+
+    internal static class TelemetryContextEnricher
+    {
+        internal static void ApplyToActivity(Activity activity, TelemetryContext context)
+        {
+            if (activity == null || context == null)
+            {
+                return;
+            }
+
+            var globalProperties = context.GlobalPropertiesValue;
+            if (globalProperties != null)
+            {
+                foreach (var kvp in globalProperties)
+                {
+                    SetTagIfAbsent(activity, kvp.Key, kvp.Value);
+                }
+            }
+
+            SetTagIfAbsent(activity, SemanticConventions.AttributeEnduserPseudoId, context.User?.Id);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeEnduserId, context.User?.AuthenticatedUserId);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftOperationName, context.Operation?.Name);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftClientIp, context.Location?.Ip);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftSessionId, context.Session?.Id);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceId, context.Device?.Id);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceModel, context.Device?.Model);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceType, context.Device?.Type);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeAiDeviceOsVersion, context.Device?.OperatingSystem);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftSyntheticSource, context.Operation?.SyntheticSource);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeMicrosoftUserAccountId, context.User?.AccountId);
+            SetTagIfAbsent(activity, SemanticConventions.AttributeUserAgentOriginal, context.User?.UserAgent);
+        }
+
+        internal static void ApplyToLogAttributes(IDictionary<string, string> attributes, TelemetryContext context)
+        {
+            if (attributes == null || context == null)
+            {
+                return;
+            }
+
+            var globalProperties = context.GlobalPropertiesValue;
+            if (globalProperties != null)
+            {
+                foreach (var kvp in globalProperties)
+                {
+                    AddAttributeIfAbsent(attributes, kvp.Key, kvp.Value);
+                }
+            }
+
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeEnduserPseudoId, context.User?.Id);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeEnduserId, context.User?.AuthenticatedUserId);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeMicrosoftOperationName, context.Operation?.Name);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeMicrosoftClientIp, context.Location?.Ip);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeMicrosoftSessionId, context.Session?.Id);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeAiDeviceId, context.Device?.Id);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeAiDeviceModel, context.Device?.Model);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeAiDeviceType, context.Device?.Type);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeAiDeviceOsVersion, context.Device?.OperatingSystem);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeMicrosoftSyntheticSource, context.Operation?.SyntheticSource);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeMicrosoftUserAccountId, context.User?.AccountId);
+            AddAttributeIfAbsent(attributes, SemanticConventions.AttributeUserAgentOriginal, context.User?.UserAgent);
+        }
+
+        internal static ContextSnapshot BuildSnapshot(TelemetryContext context)
+        {
+            if (context == null)
+            {
+                return new ContextSnapshot(Array.Empty<KeyValuePair<string, string>>());
+            }
+
+            var list = new List<KeyValuePair<string, string>>();
+
+            var globalProperties = context.GlobalPropertiesValue;
+            if (globalProperties != null)
+            {
+                foreach (var kvp in globalProperties)
+                {
+                    if (!string.IsNullOrEmpty(kvp.Value))
+                    {
+                        list.Add(new KeyValuePair<string, string>(kvp.Key, kvp.Value));
+                    }
+                }
+            }
+
+            AddIfNotEmpty(list, SemanticConventions.AttributeEnduserPseudoId, context.User?.Id);
+            AddIfNotEmpty(list, SemanticConventions.AttributeEnduserId, context.User?.AuthenticatedUserId);
+            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftOperationName, context.Operation?.Name);
+            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftClientIp, context.Location?.Ip);
+            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftSessionId, context.Session?.Id);
+            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceId, context.Device?.Id);
+            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceModel, context.Device?.Model);
+            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceType, context.Device?.Type);
+            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceOsVersion, context.Device?.OperatingSystem);
+            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftSyntheticSource, context.Operation?.SyntheticSource);
+            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftUserAccountId, context.User?.AccountId);
+            AddIfNotEmpty(list, SemanticConventions.AttributeUserAgentOriginal, context.User?.UserAgent);
+
+            return new ContextSnapshot(list.ToArray());
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void ApplySnapshotToActivity(Activity activity, ContextSnapshot snapshot)
+        {
+            if (activity == null || snapshot == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < snapshot.Tags.Length; i++)
+            {
+                ref readonly var kvp = ref snapshot.Tags[i];
+                if (activity.GetTagItem(kvp.Key) == null)
+                {
+                    activity.SetTag(kvp.Key, kvp.Value);
+                }
+            }
+        }
+
+        internal static void ApplySnapshotToLogAttributes(IDictionary<string, string> attributes, ContextSnapshot snapshot)
+        {
+            if (attributes == null || snapshot == null)
+            {
+                return;
+            }
+
+            for (int i = 0; i < snapshot.Tags.Length; i++)
+            {
+                ref readonly var kvp = ref snapshot.Tags[i];
+                if (!attributes.ContainsKey(kvp.Key))
+                {
+                    attributes.Add(kvp.Key, kvp.Value);
+                }
+            }
+        }
+
+        private static void AddAttributeIfAbsent(IDictionary<string, string> attributes, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value) && !attributes.ContainsKey(key))
+            {
+                attributes.Add(key, value);
+            }
+        }
+
+        private static void AddIfNotEmpty(List<KeyValuePair<string, string>> list, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value) && !ContainsKey(list, key))
+            {
+                list.Add(new KeyValuePair<string, string>(key, value));
+            }
+        }
+
+        private static bool ContainsKey(List<KeyValuePair<string, string>> list, string key)
+        {
+            for (int i = 0; i < list.Count; i++)
+            {
+                if (list[i].Key == key)
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        private static void SetTagIfAbsent(Activity activity, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value) && activity.GetTagItem(key) == null)
+            {
+                activity.SetTag(key, value);
+            }
+        }
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextLogProcessor.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextLogProcessor.cs
@@ -1,11 +1,10 @@
 namespace Microsoft.ApplicationInsights.Processors
 {
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
-    using System.Runtime.CompilerServices;
     using System.Threading;
     using Microsoft.ApplicationInsights.DataContracts;
-    using Microsoft.ApplicationInsights.Internal;
     using OpenTelemetry;
     using OpenTelemetry.Logs;
 
@@ -15,60 +14,23 @@ namespace Microsoft.ApplicationInsights.Processors
     /// This ensures context attributes are applied universally — to Track* calls
     /// and any <see cref="Microsoft.Extensions.Logging.ILogger"/> calls from customer code.
     /// </summary>
-    /// <remarks>
-    /// Performance optimization: after a warmup period (<see cref="WarmupCountThreshold"/> calls),
-    /// context properties are frozen into a compact snapshot array. This eliminates per-call
-    /// allocations of <see cref="HashSet{T}"/> and intermediate <see cref="List{T}"/> buffers,
-    /// and avoids repeatedly navigating the <see cref="TelemetryContext"/> object graph.
-    /// This relies on the documented pattern that customers set TelemetryClient.Context
-    /// properties once during initialization.
-    /// </remarks>
     internal sealed class TelemetryContextLogProcessor : BaseProcessor<LogRecord>
     {
-        /// <summary>
-        /// Minimum number of OnEnd calls before the context snapshot can be frozen.
-        /// </summary>
-        internal const int WarmupCountThreshold = 10;
-
-        /// <summary>
-        /// Minimum time (in milliseconds) after construction before the context snapshot
-        /// can be frozen. This guards against high-throughput apps where activities
-        /// complete before async initialization has had a chance to set TelemetryContext properties.
-        /// </summary>
-        internal const long WarmupTimeThresholdMs = 5_000;
+        internal const int WarmupCountThreshold = WarmupGate.CountThreshold;
+        internal const long WarmupTimeThresholdMs = WarmupGate.TimeThresholdMs;
 
         private readonly TelemetryContext context;
         private readonly long constructedTimestamp;
-
-        /// <summary>
-        /// Frozen snapshot of non-null context attributes, built after warmup.
-        /// Once set, this array is immutable and read lock-free.
-        /// </summary>
+        private volatile ContextSnapshot frozenSnapshot;
         private volatile KeyValuePair<string, object>[] frozenAttributes;
-
-        /// <summary>
-        /// Counter tracking the number of OnEnd calls during warmup.
-        /// </summary>
         private int warmupCounter;
 
-        /// <summary>
-        /// Initializes a new instance of the <see cref="TelemetryContextLogProcessor"/> class.
-        /// </summary>
-        /// <param name="context">The client-level <see cref="TelemetryContext"/> to apply.</param>
         public TelemetryContextLogProcessor(TelemetryContext context)
         {
             this.context = context;
             this.constructedTimestamp = Stopwatch.GetTimestamp();
         }
 
-        /// <summary>
-        /// Called when a log record ends. Applies client-level context attributes using
-        /// skip-if-present semantics: if an attribute key is already present in the log record,
-        /// it is not overwritten. This matches the 2.x SDK's <c>Tags.CopyTagValue</c> precedence behavior.
-        /// The Azure Monitor Exporter's <c>LogsHelper.ProcessLogRecordProperties</c> will pick up
-        /// these attributes and route them into <c>LogContextInfo</c> for context tag mapping.
-        /// </summary>
-        /// <param name="logRecord">The log record being processed.</param>
         public override void OnEnd(LogRecord logRecord)
         {
             if (logRecord == null || this.context == null)
@@ -76,27 +38,33 @@ namespace Microsoft.ApplicationInsights.Processors
                 return;
             }
 
-            var snapshot = this.frozenAttributes;
+            var snapshot = this.frozenSnapshot;
             if (snapshot != null)
             {
-                // Fast path: apply pre-computed snapshot (no HashSet, no intermediate List, no object graph)
-                ApplySnapshot(logRecord, snapshot);
+                ApplySnapshot(logRecord, this.frozenAttributes ?? ConvertToObjectAttributes(snapshot.Tags));
             }
             else
             {
-                // Slow path: full context evaluation during warmup
-                this.SlowPathOnEnd(logRecord);
+                ApplyContext(logRecord, this.context);
+
+                if (WarmupGate.ShouldFreeze(ref this.warmupCounter, this.constructedTimestamp) && this.frozenSnapshot == null)
+                {
+                    var builtSnapshot = TelemetryContextEnricher.BuildSnapshot(this.context);
+                    if (Interlocked.CompareExchange(ref this.frozenSnapshot, builtSnapshot, null) == null)
+                    {
+                        this.frozenAttributes = ConvertToObjectAttributes(builtSnapshot.Tags);
+                    }
+                }
             }
 
             base.OnEnd(logRecord);
         }
 
-        /// <summary>
-        /// Fast path: merges the frozen snapshot attributes into the log record,
-        /// skipping any keys already present.
-        /// Zero-allocation when the log record has no pre-existing attributes.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        private static void ApplyContext(LogRecord logRecord, TelemetryContext context)
+        {
+            ApplySnapshot(logRecord, ConvertToObjectAttributes(TelemetryContextEnricher.BuildSnapshot(context).Tags));
+        }
+
         private static void ApplySnapshot(LogRecord logRecord, KeyValuePair<string, object>[] snapshot)
         {
             if (snapshot.Length == 0)
@@ -109,15 +77,10 @@ namespace Microsoft.ApplicationInsights.Processors
 
             if (existingCount == 0)
             {
-                // Most common case: no pre-existing attributes.
-                // Assign the snapshot array directly — T[] implements IReadOnlyList<T>.
-                // Zero allocation.
                 logRecord.Attributes = snapshot;
                 return;
             }
 
-            // Count how many snapshot keys are NOT already present, to avoid
-            // allocating a merged list when all keys conflict.
             int newCount = 0;
             for (int i = 0; i < snapshot.Length; i++)
             {
@@ -132,7 +95,6 @@ namespace Microsoft.ApplicationInsights.Processors
                 return;
             }
 
-            // Only allocate when we actually have new attributes to merge.
             var merged = new List<KeyValuePair<string, object>>(existingCount + newCount);
             foreach (var attr in existing)
             {
@@ -151,11 +113,6 @@ namespace Microsoft.ApplicationInsights.Processors
             logRecord.Attributes = merged;
         }
 
-        /// <summary>
-        /// Checks whether the attribute collection contains the specified key.
-        /// Uses linear scan — attribute lists are typically small (&lt;20 items).
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static bool ContainsKey(IReadOnlyList<KeyValuePair<string, object>> attributes, string key)
         {
             if (attributes == null || attributes.Count == 0)
@@ -174,139 +131,20 @@ namespace Microsoft.ApplicationInsights.Processors
             return false;
         }
 
-        private static void AddIfAbsent(
-            List<KeyValuePair<string, object>> contextAttributes,
-            IReadOnlyList<KeyValuePair<string, object>> existingAttributes,
-            string key,
-            string value)
+        private static KeyValuePair<string, object>[] ConvertToObjectAttributes(KeyValuePair<string, string>[] tags)
         {
-            if (!string.IsNullOrEmpty(value)
-                && !ContainsKey(existingAttributes, key)
-                && !ContainsKey(contextAttributes, key))
+            if (tags.Length == 0)
             {
-                contextAttributes.Add(new KeyValuePair<string, object>(key, value));
-            }
-        }
-
-        private static void AddIfNotEmpty(List<KeyValuePair<string, object>> list, string key, string value)
-        {
-            if (!string.IsNullOrEmpty(value) && !ContainsKey(list, key))
-            {
-                list.Add(new KeyValuePair<string, object>(key, value));
-            }
-        }
-
-        /// <summary>
-        /// Full context evaluation path used during warmup. After both thresholds are met,
-        /// builds and freezes the snapshot for all subsequent calls.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.NoInlining)]
-        private void SlowPathOnEnd(LogRecord logRecord)
-        {
-            var existing = logRecord.Attributes;
-
-            // Build list of context attributes to add (only those not already present).
-            // No HashSet needed — linear scan on the small attributes list is faster and allocation-free.
-            var contextAttributes = new List<KeyValuePair<string, object>>();
-            var globalProperties = this.context.GlobalPropertiesValue;
-            if (globalProperties != null)
-            {
-                foreach (var kvp in globalProperties)
-                {
-                    AddIfAbsent(contextAttributes, existing, kvp.Key, kvp.Value);
-                }
+                return Array.Empty<KeyValuePair<string, object>>();
             }
 
-            // Build list of structured context attributes to add (only those not already present)
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeEnduserPseudoId, this.context.User?.Id);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeEnduserId, this.context.User?.AuthenticatedUserId);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeMicrosoftOperationName, this.context.Operation?.Name);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeMicrosoftClientIp, this.context.Location?.Ip);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeMicrosoftSessionId, this.context.Session?.Id);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeAiDeviceId, this.context.Device?.Id);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeAiDeviceModel, this.context.Device?.Model);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeAiDeviceType, this.context.Device?.Type);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeAiDeviceOsVersion, this.context.Device?.OperatingSystem);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeMicrosoftSyntheticSource, this.context.Operation?.SyntheticSource);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeMicrosoftUserAccountId, this.context.User?.AccountId);
-            AddIfAbsent(contextAttributes, existing, SemanticConventions.AttributeUserAgentOriginal, this.context.User?.UserAgent);
-
-            if (contextAttributes.Count > 0)
+            var attributes = new KeyValuePair<string, object>[tags.Length];
+            for (int i = 0; i < tags.Length; i++)
             {
-                int existingCount = existing?.Count ?? 0;
-                var merged = new List<KeyValuePair<string, object>>(existingCount + contextAttributes.Count);
-
-                if (existing != null)
-                {
-                    foreach (var attr in existing)
-                    {
-                        merged.Add(attr);
-                    }
-                }
-
-                merged.AddRange(contextAttributes);
-                logRecord.Attributes = merged;
+                attributes[i] = new KeyValuePair<string, object>(tags[i].Key, tags[i].Value);
             }
 
-            // Freeze the snapshot once BOTH conditions are met:
-            //   1. At least WarmupCountThreshold calls have occurred.
-            //   2. At least WarmupTimeThresholdMs has elapsed since construction.
-            int count = Interlocked.Increment(ref this.warmupCounter);
-            if (count >= WarmupCountThreshold && this.HasTimeThresholdElapsed())
-            {
-                if (this.frozenAttributes == null)
-                {
-                    Interlocked.CompareExchange(ref this.frozenAttributes, this.BuildSnapshot(), null);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Builds an immutable snapshot array of all non-null/non-empty context attributes.
-        /// Called once after warmup completes.
-        /// </summary>
-        private KeyValuePair<string, object>[] BuildSnapshot()
-        {
-            var list = new List<KeyValuePair<string, object>>();
-
-            var globalProperties = this.context.GlobalPropertiesValue;
-            if (globalProperties != null)
-            {
-                foreach (var kvp in globalProperties)
-                {
-                    if (!string.IsNullOrEmpty(kvp.Value))
-                    {
-                        list.Add(new KeyValuePair<string, object>(kvp.Key, kvp.Value));
-                    }
-                }
-            }
-
-            AddIfNotEmpty(list, SemanticConventions.AttributeEnduserPseudoId, this.context.User?.Id);
-            AddIfNotEmpty(list, SemanticConventions.AttributeEnduserId, this.context.User?.AuthenticatedUserId);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftOperationName, this.context.Operation?.Name);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftClientIp, this.context.Location?.Ip);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftSessionId, this.context.Session?.Id);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceId, this.context.Device?.Id);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceModel, this.context.Device?.Model);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceType, this.context.Device?.Type);
-            AddIfNotEmpty(list, SemanticConventions.AttributeAiDeviceOsVersion, this.context.Device?.OperatingSystem);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftSyntheticSource, this.context.Operation?.SyntheticSource);
-            AddIfNotEmpty(list, SemanticConventions.AttributeMicrosoftUserAccountId, this.context.User?.AccountId);
-            AddIfNotEmpty(list, SemanticConventions.AttributeUserAgentOriginal, this.context.User?.UserAgent);
-            
-            return list.ToArray();
-        }
-
-        /// <summary>
-        /// Returns true if at least <see cref="WarmupTimeThresholdMs"/> milliseconds
-        /// have elapsed since this processor was constructed.
-        /// </summary>
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private bool HasTimeThresholdElapsed()
-        {
-            long elapsedTicks = Stopwatch.GetTimestamp() - this.constructedTimestamp;
-            long elapsedMs = (elapsedTicks * 1000) / Stopwatch.Frequency;
-            return elapsedMs >= WarmupTimeThresholdMs;
+            return attributes;
         }
     }
 }

--- a/BASE/src/Microsoft.ApplicationInsights/Processors/WarmupGate.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Processors/WarmupGate.cs
@@ -1,0 +1,45 @@
+namespace Microsoft.ApplicationInsights.Processors
+{
+    using System.Diagnostics;
+    using System.Runtime.CompilerServices;
+    using System.Threading;
+
+    internal sealed class WarmupGate
+    {
+        internal const int CountThreshold = 10;
+        internal const long TimeThresholdMs = 5_000;
+
+        private long constructedTimestamp;
+        private int counter;
+
+        internal WarmupGate()
+            : this(Stopwatch.GetTimestamp())
+        {
+        }
+
+        internal WarmupGate(long constructedTimestamp)
+        {
+            this.constructedTimestamp = constructedTimestamp;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool HasTimeThresholdElapsed(long constructedTimestamp)
+        {
+            long elapsedTicks = Stopwatch.GetTimestamp() - constructedTimestamp;
+            long elapsedMs = (elapsedTicks * 1000) / Stopwatch.Frequency;
+            return elapsedMs >= TimeThresholdMs;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static bool ShouldFreeze(ref int counter, long constructedTimestamp)
+        {
+            int count = Interlocked.Increment(ref counter);
+            return count >= CountThreshold && HasTimeThresholdElapsed(constructedTimestamp);
+        }
+
+        internal bool ShouldFreeze()
+        {
+            return ShouldFreeze(ref this.counter, this.constructedTimestamp);
+        }
+    }
+}

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs
@@ -55,19 +55,9 @@
             // Use the shared ActivitySource from configuration
             this.activitySource = configuration.ApplicationInsightsActivitySource;
 
-            // For non-DI scenarios: Register context processors and build SDK eagerly
-            // For DI scenarios: SDK will be built by configuration when accessed;
-            // processors are registered via UseApplicationInsightsTelemetry() in NETCORE
+            // For non-DI scenarios, build SDK eagerly. DI scenarios resolve OTel providers from the container.
             if (!isFromDependencyInjection)
             {
-                // Prepend context processors so they run BEFORE any user-registered exporters.
-                // This ensures LogRecords/Activities are enriched with context tags before export.
-                configuration.PrependOpenTelemetryBuilderConfiguration(builder =>
-                {
-                    builder.WithTracing(tracing => tracing.AddProcessor(new TelemetryContextActivityProcessor(this.Context)));
-                    builder.WithLogging(logging => logging.AddProcessor(new TelemetryContextLogProcessor(this.Context)));
-                });
-
                 this.sdk = configuration.Build();
             }
 
@@ -162,6 +152,7 @@
 
             var mergedProperties = EnsureMutable(properties);
             mergedProperties["microsoft.custom_event.name"] = eventName;
+            ApplyContextToProperties(this.Context, mergedProperties);
             var state = new DictionaryLogState(mergedProperties, String.Empty);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
         }
@@ -188,6 +179,7 @@
 
             // Map item-level context properties to semantic conventions
             ApplyContextToProperties(telemetry.Context, mergedProperties);
+            ApplyContextToProperties(this.Context, mergedProperties);
 
             var state = new DictionaryLogState(telemetry.Context, mergedProperties, String.Empty);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
@@ -267,6 +259,7 @@
 
             // Map item-level context properties to semantic conventions
             ApplyContextToProperties(telemetry.Context, properties);
+            ApplyContextToProperties(this.Context, properties);
 
             var state = new DictionaryLogState(telemetry.Context, properties, telemetry.Message ?? String.Empty);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
@@ -282,7 +275,9 @@
         public void TrackTrace(string message)
         {
             this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
-            var state = new DictionaryLogState(null, message);
+            var mergedProperties = EnsureMutable(null);
+            ApplyContextToProperties(this.Context, mergedProperties);
+            var state = new DictionaryLogState(mergedProperties, message);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
         }
 
@@ -298,7 +293,9 @@
         {
             this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             LogLevel logLevel = GetLogLevel(severityLevel);
-            var state = new DictionaryLogState(null, message);
+            var mergedProperties = EnsureMutable(null);
+            ApplyContextToProperties(this.Context, mergedProperties);
+            var state = new DictionaryLogState(mergedProperties, message);
             this.Logger.Log(logLevel, 0, state, null, (s, ex) => s.Message);
         }
 
@@ -313,7 +310,9 @@
         public void TrackTrace(string message, IDictionary<string, string> properties)
         {
             this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
-            var state = new DictionaryLogState(properties, message);
+            var mergedProperties = EnsureMutable(properties);
+            ApplyContextToProperties(this.Context, mergedProperties);
+            var state = new DictionaryLogState(mergedProperties, message);
             this.Logger.Log(LogLevel.Information, 0, state, null, (s, ex) => s.Message);
         }
 
@@ -330,7 +329,9 @@
         {
             this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackTrace);
             LogLevel logLevel = GetLogLevel(severityLevel);
-            var state = new DictionaryLogState(properties, message);
+            var mergedProperties = EnsureMutable(properties);
+            ApplyContextToProperties(this.Context, mergedProperties);
+            var state = new DictionaryLogState(mergedProperties, message);
             this.Logger.Log(logLevel, 0, state, null, (s, ex) => s.Message);
         }
 
@@ -363,6 +364,7 @@
             // Map item-level context properties to semantic conventions
             var mergedProperties = EnsureMutable(telemetry.Properties);
             ApplyContextToProperties(telemetry.Context, mergedProperties);
+            ApplyContextToProperties(this.Context, mergedProperties);
 
             LogLevel logLevel = GetLogLevel(telemetry.SeverityLevel.Value);
             var state = new DictionaryLogState(telemetry.Context, mergedProperties, telemetry.Message);
@@ -385,11 +387,13 @@
             this.Configuration.FeatureReporter.MarkFeatureInUse(StatsbeatFeatures.TrackMetric);
             // Get or create histogram for this metric
             var histogram = this.Configuration.MetricsManager.GetOrCreateHistogram(name, null);
+            var mergedProperties = EnsureMutable(properties);
+            ApplyContextToProperties(this.Context, mergedProperties);
 
-            if (properties != null && properties.Count > 0)
+            if (mergedProperties.Count > 0)
             {
                 var tags = new TagList();
-                foreach (var kvp in properties)
+                foreach (var kvp in mergedProperties)
                 {
                     tags.Add(kvp.Key, kvp.Value);
                 }
@@ -424,11 +428,14 @@
             var histogram = this.Configuration.MetricsManager.GetOrCreateHistogram(
                 telemetry.Name,
                 telemetry.MetricNamespace);
+            var mergedProperties = EnsureMutable(telemetry.Properties);
+            ApplyContextToProperties(telemetry.Context, mergedProperties);
+            ApplyContextToProperties(this.Context, mergedProperties);
 
-            if (telemetry.Properties != null && telemetry.Properties.Count > 0)
+            if (mergedProperties.Count > 0)
             {
                 var tags = new TagList();
-                foreach (var kvp in telemetry.Properties)
+                foreach (var kvp in mergedProperties)
                 {
                     tags.Add(kvp.Key, kvp.Value);
                 }
@@ -457,7 +464,9 @@
                 exception = new InvalidOperationException(Utils.PopulateRequiredStringValue(null, "message", typeof(ExceptionTelemetry).FullName));
             }
 
-            var state = new DictionaryLogState(properties, exception.Message);
+            var mergedProperties = EnsureMutable(properties);
+            ApplyContextToProperties(this.Context, mergedProperties);
+            var state = new DictionaryLogState(mergedProperties, exception.Message);
             this.Logger.Log(LogLevel.Error, 0, state, exception, (s, ex) => s.Message);
         }
 
@@ -483,6 +492,7 @@
             // Map item-level context properties to semantic conventions
             var mergedProperties = EnsureMutable(telemetry.Properties);
             ApplyContextToProperties(telemetry.Context, mergedProperties);
+            ApplyContextToProperties(this.Context, mergedProperties);
 
             var state = new DictionaryLogState(telemetry.Context, mergedProperties, reconstructedException.Message);
             var logLevel = GetLogLevel(telemetry.SeverityLevel ?? SeverityLevel.Error);
@@ -580,6 +590,9 @@
             {
                 if (dependencyTelemetryActivity != null)
                 {
+                    TelemetryContextEnricher.ApplyToActivity(dependencyTelemetryActivity, this.Context);
+                    ApplyCloudContextToActivity(this.Context, dependencyTelemetryActivity, overwrite: false);
+
                     // Set timing information
                     dependencyTelemetryActivity.SetStartTime(telemetry.Timestamp.UtcDateTime);
                     dependencyTelemetryActivity.SetEndTime(telemetry.Timestamp.Add(telemetry.Duration).UtcDateTime);
@@ -755,6 +768,9 @@
             {
                 if (activity != null)
                 {
+                    TelemetryContextEnricher.ApplyToActivity(activity, this.Context);
+                    ApplyCloudContextToActivity(this.Context, activity, overwrite: false);
+
                     activity.SetStartTime(request.Timestamp.UtcDateTime);
                     activity.SetEndTime(request.Timestamp.Add(request.Duration).UtcDateTime);
                     activity.SetStatus(request.Success == true ? ActivityStatusCode.Ok : ActivityStatusCode.Error);
@@ -1349,6 +1365,8 @@
                 return;
             }
 
+            ApplyCloudContextToActivity(context, activity, overwrite: true);
+
             if (!string.IsNullOrEmpty(context.User?.Id))
             {
                 activity.SetTag(SemanticConventions.AttributeEnduserPseudoId, context.User.Id);
@@ -1422,64 +1440,60 @@
                 return;
             }
 
-            if (!string.IsNullOrEmpty(context.User?.Id))
+            var globalProperties = context.GlobalPropertiesValue;
+            if (globalProperties != null)
             {
-                properties[SemanticConventions.AttributeEnduserPseudoId] = context.User.Id;
+                foreach (var kvp in globalProperties)
+                {
+                    AddPropertyIfAbsent(properties, kvp.Key, kvp.Value);
+                }
             }
 
-            if (!string.IsNullOrEmpty(context.User?.AuthenticatedUserId))
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeEnduserPseudoId, context.User?.Id);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeEnduserId, context.User?.AuthenticatedUserId);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeMicrosoftOperationName, context.Operation?.Name);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeMicrosoftClientIp, context.Location?.Ip);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeMicrosoftSessionId, context.Session?.Id);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeAiDeviceId, context.Device?.Id);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeAiDeviceModel, context.Device?.Model);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeAiDeviceType, context.Device?.Type);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeAiDeviceOsVersion, context.Device?.OperatingSystem);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeMicrosoftSyntheticSource, context.Operation?.SyntheticSource);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeMicrosoftUserAccountId, context.User?.AccountId);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeUserAgentOriginal, context.User?.UserAgent);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeServiceName, context.Cloud?.RoleName);
+            AddPropertyIfAbsent(properties, SemanticConventions.AttributeServiceInstance, context.Cloud?.RoleInstance);
+        }
+
+        private static void ApplyCloudContextToActivity(TelemetryContext context, Activity activity, bool overwrite)
+        {
+            if (context == null || activity == null)
             {
-                properties[SemanticConventions.AttributeEnduserId] = context.User.AuthenticatedUserId;
+                return;
             }
 
-            if (!string.IsNullOrEmpty(context.Operation?.Name))
+            SetActivityTag(activity, SemanticConventions.AttributeServiceName, context.Cloud?.RoleName, overwrite);
+            SetActivityTag(activity, SemanticConventions.AttributeServiceInstance, context.Cloud?.RoleInstance, overwrite);
+        }
+
+        private static void SetActivityTag(Activity activity, string key, string value, bool overwrite)
+        {
+            if (string.IsNullOrEmpty(value))
             {
-                properties[SemanticConventions.AttributeMicrosoftOperationName] = context.Operation.Name;
+                return;
             }
 
-            if (!string.IsNullOrEmpty(context.Location?.Ip))
+            if (overwrite || activity.GetTagItem(key) == null)
             {
-                properties[SemanticConventions.AttributeMicrosoftClientIp] = context.Location.Ip;
+                activity.SetTag(key, value);
             }
+        }
 
-            if (!string.IsNullOrEmpty(context.Session?.Id))
+        private static void AddPropertyIfAbsent(IDictionary<string, string> properties, string key, string value)
+        {
+            if (!string.IsNullOrEmpty(value) && !properties.ContainsKey(key))
             {
-                properties[SemanticConventions.AttributeMicrosoftSessionId] = context.Session.Id;
-            }
-
-            if (!string.IsNullOrEmpty(context.Device?.Id))
-            {
-                properties[SemanticConventions.AttributeAiDeviceId] = context.Device.Id;
-            }
-
-            if (!string.IsNullOrEmpty(context.Device?.Model))
-            {
-                properties[SemanticConventions.AttributeAiDeviceModel] = context.Device.Model;
-            }
-
-            if (!string.IsNullOrEmpty(context.Device?.Type))
-            {
-                properties[SemanticConventions.AttributeAiDeviceType] = context.Device.Type;
-            }
-
-            if (!string.IsNullOrEmpty(context.Device?.OperatingSystem))
-            {
-                properties[SemanticConventions.AttributeAiDeviceOsVersion] = context.Device.OperatingSystem;
-            }
-
-            if (!string.IsNullOrEmpty(context.Operation?.SyntheticSource))
-            {
-                properties[SemanticConventions.AttributeMicrosoftSyntheticSource] = context.Operation.SyntheticSource;
-            }
-
-            if (!string.IsNullOrEmpty(context.User?.AccountId))
-            {
-                properties[SemanticConventions.AttributeMicrosoftUserAccountId] = context.User.AccountId;
-            }
-
-            if (!string.IsNullOrEmpty(context.User?.UserAgent))
-            {
-                properties[SemanticConventions.AttributeUserAgentOriginal] = context.User.UserAgent;
+                properties.Add(key, value);
             }
         }
 
@@ -1510,8 +1524,8 @@
             }
 
             /// <summary>
-            /// Constructor that merges TelemetryContext.GlobalProperties with item-level properties.
-            /// Client-level context tags are handled by <see cref="Processors.TelemetryContextLogProcessor"/>.
+            /// Constructor that merges TelemetryContext.GlobalProperties with already-enriched item properties.
+            /// Source-level callers are responsible for applying item/client context precedence before constructing the state.
             /// </summary>
             /// <param name="context">The telemetry context containing GlobalProperties.</param>
             /// <param name="properties">Item-level properties (highest priority, override GlobalProperties).</param>

--- a/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs
@@ -7,6 +7,8 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
+    using Microsoft.ApplicationInsights.Internal;
+    using Microsoft.ApplicationInsights.Processors;
 
     /// <summary>
     /// Extension class providing operation lifecycle helpers for <see cref="TelemetryClient"/>.
@@ -103,6 +105,17 @@
                     telemetryClient,
                     new T { Name = effectiveName, Timestamp = DateTimeOffset.UtcNow },
                     null);
+            }
+
+            TelemetryContextEnricher.ApplyToActivity(activity, telemetryClient.Context);
+            if (!string.IsNullOrEmpty(telemetryClient.Context.Cloud?.RoleName) && activity.GetTagItem(SemanticConventions.AttributeServiceName) == null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServiceName, telemetryClient.Context.Cloud.RoleName);
+            }
+
+            if (!string.IsNullOrEmpty(telemetryClient.Context.Cloud?.RoleInstance) && activity.GetTagItem(SemanticConventions.AttributeServiceInstance) == null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServiceInstance, telemetryClient.Context.Cloud.RoleInstance);
             }
 
             // Store the operation name as a tag for retrieval
@@ -202,6 +215,17 @@
                 return new OperationHolder<T>(telemetryClient, operationTelemetry, null);
             }
 
+            TelemetryContextEnricher.ApplyToActivity(activity, telemetryClient.Context);
+            if (!string.IsNullOrEmpty(telemetryClient.Context.Cloud?.RoleName) && activity.GetTagItem(SemanticConventions.AttributeServiceName) == null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServiceName, telemetryClient.Context.Cloud.RoleName);
+            }
+
+            if (!string.IsNullOrEmpty(telemetryClient.Context.Cloud?.RoleInstance) && activity.GetTagItem(SemanticConventions.AttributeServiceInstance) == null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServiceInstance, telemetryClient.Context.Cloud.RoleInstance);
+            }
+
             // Store the operation name as a tag for retrieval
             activity.SetOperationName(operationTelemetry.Name);
 
@@ -251,6 +275,17 @@
             {
                 activity.SetIdFormat(ActivityIdFormat.W3C);
                 activity.Start();
+            }
+
+            TelemetryContextEnricher.ApplyToActivity(activity, telemetryClient.Context);
+            if (!string.IsNullOrEmpty(telemetryClient.Context.Cloud?.RoleName) && activity.GetTagItem(SemanticConventions.AttributeServiceName) == null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServiceName, telemetryClient.Context.Cloud.RoleName);
+            }
+
+            if (!string.IsNullOrEmpty(telemetryClient.Context.Cloud?.RoleInstance) && activity.GetTagItem(SemanticConventions.AttributeServiceInstance) == null)
+            {
+                activity.SetTag(SemanticConventions.AttributeServiceInstance, telemetryClient.Context.Cloud.RoleInstance);
             }
 
             var telemetry = new T

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix [#3163](https://github.com/microsoft/ApplicationInsights-dotnet/issues/3163): constructing a second `TelemetryClient` from the same `TelemetryConfiguration` no longer throws in classic ASP.NET, and `TelemetryClient.Context` is now scoped to the client instance instead of applying AppDomain-wide.
 
 ## Version 3.1.1
 - [Update OpenTelemetry and Azure Monitor dependencies to address known security advisories (e.g. [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) in `OpenTelemetry.Api` 1.15.1).](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3174)

--- a/MigrationGuidance.md
+++ b/MigrationGuidance.md
@@ -161,6 +161,22 @@ config.ConnectionString = "InstrumentationKey=00000000-0000-0000-0000-0000000000
 var client = new TelemetryClient(config);
 ```
 
+#### TelemetryClient.Context scope and multiple client instances
+In 3.1.0, setting `TelemetryClient.Context` on one client could unintentionally affect telemetry sent by other clients that shared the same `TelemetryConfiguration`. This was a 3.1.0 quirk, not a supported AppDomain-wide enrichment mechanism.
+
+Starting in 3.2, `TelemetryClient.Context` is scoped to the client instance. Context set on one client applies only to telemetry sent by that client's `Track*` and `StartOperation*` calls.
+
+If you rely on app-wide role name, component version, or similar defaults, continue configuring them via `applicationinsights.config` in classic ASP.NET or `ApplicationInsightsServiceOptions` in ASP.NET Core / Worker Service. That remains the documented approach, and no action is needed for the common case.
+
+Constructing multiple clients from the same configuration is also supported again:
+
+```csharp
+var client1 = new TelemetryClient(config);
+var client2 = new TelemetryClient(config); // Safe in 3.2+
+```
+
+This fixes the crash reported in #3163 and restores the 2.x expectation that `new TelemetryClient(config)` can be called multiple times safely.
+
 ## Alternatives for Removed TelemetryConfiguration properties
 The [breaking changes](BreakingChanges.md#properties) defined which properties were removed. For some properties, further guidance is described below:
 

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -12,7 +12,6 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Internal;
-    using Microsoft.ApplicationInsights.Processors;
     using Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Options;
@@ -159,18 +158,10 @@
 
                                 return true;
                             })
-                            .AddProcessor<ActivityFilterProcessor>()
-                            .AddProcessor(sp =>
-                                new TelemetryContextActivityProcessor(sp.GetRequiredService<TelemetryClient>().Context)));
+                            .AddProcessor<ActivityFilterProcessor>());
 
             // Register ActivityFilterProcessor in DI
             builder.Services.AddSingleton<ActivityFilterProcessor>();
-
-            builder.Services.ConfigureOpenTelemetryLoggerProvider((sp, loggerBuilder) =>
-            {
-                loggerBuilder.AddProcessor(
-                    new TelemetryContextLogProcessor(sp.GetRequiredService<TelemetryClient>().Context));
-            });
 
             builder.WithMetrics(b => b.AddHttpClientAndServerMetrics());
 

--- a/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.AspNetCore/Extensions/ApplicationInsightsExtensions.cs
@@ -12,6 +12,7 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Internal;
+    using Microsoft.ApplicationInsights.Processors;
     using Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources;
     using Microsoft.Extensions.Configuration;
     using Microsoft.Extensions.Options;
@@ -158,10 +159,21 @@
 
                                 return true;
                             })
-                            .AddProcessor<ActivityFilterProcessor>());
+                            .AddProcessor<ActivityFilterProcessor>()
+                            .AddProcessor(sp =>
+                                new TelemetryContextActivityProcessor(sp.GetRequiredService<TelemetryConfiguration>().DefaultContext)));
 
             // Register ActivityFilterProcessor in DI
             builder.Services.AddSingleton<ActivityFilterProcessor>();
+
+            // Register TelemetryContextLogProcessor against TelemetryConfiguration.DefaultContext so that
+            // telemetry produced outside any TelemetryClient (direct ILogger usage, etc.) is enriched
+            // with DefaultContext tags. Per-client enrichment is applied at the source in TelemetryClient.Track*.
+            builder.Services.ConfigureOpenTelemetryLoggerProvider((sp, loggerBuilder) =>
+            {
+                loggerBuilder.AddProcessor(
+                    new TelemetryContextLogProcessor(sp.GetRequiredService<TelemetryConfiguration>().DefaultContext));
+            });
 
             builder.WithMetrics(b => b.AddHttpClientAndServerMetrics());
 

--- a/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
@@ -9,7 +9,6 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Internal;
-    using Microsoft.ApplicationInsights.Processors;
     using Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources;
     using Microsoft.ApplicationInsights.WorkerService;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
@@ -154,18 +153,10 @@
 
                                 return true;
                             })
-                            .AddProcessor<ActivityFilterProcessor>()
-                            .AddProcessor(sp =>
-                                new TelemetryContextActivityProcessor(sp.GetRequiredService<TelemetryClient>().Context)));
+                            .AddProcessor<ActivityFilterProcessor>());
 
             // Register ActivityFilterProcessor in DI
             builder.Services.AddSingleton<ActivityFilterProcessor>();
-
-            builder.Services.ConfigureOpenTelemetryLoggerProvider((sp, loggerBuilder) =>
-            {
-                loggerBuilder.AddProcessor(
-                    new TelemetryContextLogProcessor(sp.GetRequiredService<TelemetryClient>().Context));
-            });
 
             builder.WithMetrics(b => b.AddHttpClientMetrics());
 

--- a/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Microsoft.ApplicationInsights.WorkerService/ApplicationInsightsExtensions.cs
@@ -9,6 +9,7 @@
     using Microsoft.ApplicationInsights.Extensibility;
     using Microsoft.ApplicationInsights.Extensibility.Implementation.Tracing;
     using Microsoft.ApplicationInsights.Internal;
+    using Microsoft.ApplicationInsights.Processors;
     using Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources;
     using Microsoft.ApplicationInsights.WorkerService;
     using Microsoft.ApplicationInsights.WorkerService.Implementation.Tracing;
@@ -153,10 +154,21 @@
 
                                 return true;
                             })
-                            .AddProcessor<ActivityFilterProcessor>());
+                            .AddProcessor<ActivityFilterProcessor>()
+                            .AddProcessor(sp =>
+                                new TelemetryContextActivityProcessor(sp.GetRequiredService<TelemetryConfiguration>().DefaultContext)));
 
             // Register ActivityFilterProcessor in DI
             builder.Services.AddSingleton<ActivityFilterProcessor>();
+
+            // Register TelemetryContextLogProcessor against TelemetryConfiguration.DefaultContext so that
+            // telemetry produced outside any TelemetryClient (direct ILogger usage, etc.) is enriched
+            // with DefaultContext tags. Per-client enrichment is applied at the source in TelemetryClient.Track*.
+            builder.Services.ConfigureOpenTelemetryLoggerProvider((sp, loggerBuilder) =>
+            {
+                loggerBuilder.AddProcessor(
+                    new TelemetryContextLogProcessor(sp.GetRequiredService<TelemetryConfiguration>().DefaultContext));
+            });
 
             builder.WithMetrics(b => b.AddHttpClientMetrics());
 

--- a/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
+++ b/NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs
@@ -134,6 +134,11 @@
                     postConfigure.PostConfigure(Options.DefaultName, configuration);
                 }
 
+                if (!string.IsNullOrEmpty(options.ApplicationVersion))
+                {
+                    configuration.DefaultContext.Component.Version = options.ApplicationVersion;
+                }
+
                 // Set OTEL_SDK_DISABLED in IConfiguration so the OTel SDK's MeterProvider/TracerProvider
                 // factories see it when they check IsOtelSdkDisabled(). This must happen here (during
                 // TelemetryConfiguration resolution) rather than in a hosted service, because the

--- a/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
+++ b/NETCORE/test/IntegrationTests.Tests/IntegrationTests.Tests.csproj
@@ -33,6 +33,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\ConfigurationTests.cs" Link="ConfigurationTests.cs" />
     <Compile Include="..\Shared\ActivityFilterProcessorTests.cs" Link="ActivityFilterProcessorTests.cs" />
+    <Compile Include="..\Shared\DiTelemetryClientParityTests.cs" Link="DiTelemetryClientParityTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/NETCORE/test/Shared/DiTelemetryClientParityTests.cs
+++ b/NETCORE/test/Shared/DiTelemetryClientParityTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using Microsoft.ApplicationInsights;
+using Microsoft.ApplicationInsights.DataContracts;
+using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using OpenTelemetry;
+using OpenTelemetry.Trace;
+using Xunit;
+
+#if AI_ASPNETCORE_WEB
+namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+{
+    using Microsoft.ApplicationInsights.AspNetCore.Extensions;
+#else
+namespace Microsoft.ApplicationInsights.WorkerService.Tests
+{
+    using Microsoft.ApplicationInsights.WorkerService;
+#endif
+
+    public class DiTelemetryClientParityTests : IDisposable
+    {
+        private const string ApplicationInsightsActivitySourceName = "Microsoft.ApplicationInsights";
+        private const string ServiceNameTag = "service.name";
+        private const string OperationNameTag = "microsoft.operation_name";
+        private const string TestConnectionString = "InstrumentationKey=11111111-2222-3333-4444-555555555555;IngestionEndpoint=http://127.0.0.1";
+
+        private readonly List<Activity> activityItems = new();
+        private readonly CaptureActivityProcessor captureProcessor;
+
+        public DiTelemetryClientParityTests()
+        {
+            this.captureProcessor = new CaptureActivityProcessor(this.activityItems);
+        }
+
+        [Fact]
+        public void DiResolvedTelemetryClient_AppliesItsOwnContext_NotDefault()
+        {
+            using var serviceProvider = this.BuildServiceProvider(defaultRoleName: "default-role");
+            _ = new TelemetryClient(serviceProvider.GetRequiredService<TelemetryConfiguration>());
+            var client = serviceProvider.GetRequiredService<TelemetryClient>();
+
+            client.Context.Cloud.RoleName = "client-role";
+            client.TrackDependency(CreateDependencyTelemetry("dep-client"));
+
+            var capturedActivity = this.GetActivity("dep-client");
+            var roleName = capturedActivity.GetTagItem(ServiceNameTag)?.ToString();
+            Assert.Equal("client-role", roleName);
+            Assert.NotEqual("default-role", roleName);
+        }
+
+        [Fact]
+        public void DiResolvedTwoClients_DistinctContext_NoCrossContamination()
+        {
+            using var serviceProvider = this.BuildServiceProvider();
+            var configuration = serviceProvider.GetRequiredService<TelemetryConfiguration>();
+            var clientA = serviceProvider.GetRequiredService<TelemetryClient>();
+            var clientB = new TelemetryClient(configuration);
+
+            clientA.Context.Cloud.RoleName = "client-a";
+            clientB.Context.Cloud.RoleName = "client-b";
+
+            clientA.TrackDependency(CreateDependencyTelemetry("dep-a"));
+            clientB.TrackDependency(CreateDependencyTelemetry("dep-b"));
+
+            Assert.Equal("client-a", this.GetActivity("dep-a").GetTagItem(ServiceNameTag)?.ToString());
+            Assert.Equal("client-b", this.GetActivity("dep-b").GetTagItem(ServiceNameTag)?.ToString());
+        }
+
+        [Fact]
+        public void DiPipeline_RegistersDefaultContextProcessors()
+        {
+            using var serviceProvider = this.BuildServiceProvider(defaultOperationName: "default-op");
+            _ = new TelemetryClient(serviceProvider.GetRequiredService<TelemetryConfiguration>());
+            using var activitySource = new ActivitySource(ApplicationInsightsActivitySourceName);
+
+            using (var activity = activitySource.StartActivity("bare-activity"))
+            {
+                Assert.NotNull(activity);
+                activity.Stop();
+            }
+
+            Assert.Equal("default-op", this.GetActivity("bare-activity").GetTagItem(OperationNameTag)?.ToString());
+        }
+
+        public void Dispose()
+        {
+            while (Activity.Current != null)
+            {
+                Activity.Current.Stop();
+            }
+
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_NAME", null);
+            Environment.SetEnvironmentVariable("APPLICATIONINSIGHTS_CLOUD_ROLE_INSTANCE", null);
+        }
+
+        private static DependencyTelemetry CreateDependencyTelemetry(string name)
+        {
+            return new DependencyTelemetry
+            {
+                Type = "HTTP",
+                Name = name,
+                Target = "example.test",
+                Data = "https://example.test/",
+                ResultCode = "200",
+                Duration = TimeSpan.FromMilliseconds(1),
+                Success = true,
+            };
+        }
+
+        private ServiceProvider BuildServiceProvider(string defaultRoleName = null, string defaultOperationName = null)
+        {
+            var services = new ServiceCollection();
+            services.AddSingleton<IConfiguration>(new ConfigurationBuilder().AddInMemoryCollection().Build());
+
+#if AI_ASPNETCORE_WEB
+            services.AddApplicationInsightsTelemetry(options =>
+#else
+            services.AddApplicationInsightsTelemetryWorkerService(options =>
+#endif
+            {
+                options.ConnectionString = TestConnectionString;
+                options.EnableQuickPulseMetricStream = false;
+                options.AddAutoCollectedMetricExtractor = false;
+                options.SamplingRatio = 1.0f;
+            });
+
+            services.Configure<TelemetryConfiguration>(configuration =>
+            {
+                configuration.DisableOfflineStorage = true;
+                configuration.SamplingRatio = 1.0f;
+
+                var defaultContext = GetDefaultContext(configuration);
+                if (!string.IsNullOrEmpty(defaultRoleName))
+                {
+                    defaultContext.Cloud.RoleName = defaultRoleName;
+                }
+
+                if (!string.IsNullOrEmpty(defaultOperationName))
+                {
+                    defaultContext.Operation.Name = defaultOperationName;
+                }
+
+                EnsureBuilderConfiguration(configuration);
+                configuration.ConfigureOpenTelemetryBuilder(builder =>
+                {
+                    builder.WithTracing(tracing => tracing.AddProcessor(this.captureProcessor));
+                });
+            });
+
+            return services.BuildServiceProvider();
+        }
+
+        private Activity GetActivity(string name)
+        {
+            return this.activityItems.Single(activity => activity.DisplayName == name);
+        }
+
+        private static TelemetryContext GetDefaultContext(TelemetryConfiguration configuration)
+        {
+            var property = typeof(TelemetryConfiguration).GetProperty("DefaultContext", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(property);
+            return Assert.IsType<TelemetryContext>(property.GetValue(configuration));
+        }
+
+        private static void EnsureBuilderConfiguration(TelemetryConfiguration configuration)
+        {
+            var field = typeof(TelemetryConfiguration).GetField("builderConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+            Assert.NotNull(field);
+
+            if (field.GetValue(configuration) == null)
+            {
+                field.SetValue(configuration, (Action<IOpenTelemetryBuilder>)(builder =>
+                    builder.WithTracing(tracing => tracing.AddSource(ApplicationInsightsActivitySourceName))));
+            }
+        }
+
+        private sealed class CaptureActivityProcessor : BaseProcessor<Activity>
+        {
+            private readonly List<Activity> activities;
+
+            public CaptureActivityProcessor(List<Activity> activities)
+            {
+                this.activities = activities;
+            }
+
+            public override void OnEnd(Activity data)
+            {
+                this.activities.Add(data);
+            }
+        }
+    }
+}

--- a/NETCORE/test/Shared/DiTelemetryClientParityTests.cs
+++ b/NETCORE/test/Shared/DiTelemetryClientParityTests.cs
@@ -41,7 +41,6 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         public void DiResolvedTelemetryClient_AppliesItsOwnContext_NotDefault()
         {
             using var serviceProvider = this.BuildServiceProvider(defaultRoleName: "default-role");
-            _ = new TelemetryClient(serviceProvider.GetRequiredService<TelemetryConfiguration>());
             var client = serviceProvider.GetRequiredService<TelemetryClient>();
 
             client.Context.Cloud.RoleName = "client-role";
@@ -75,7 +74,6 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
         public void DiPipeline_RegistersDefaultContextProcessors()
         {
             using var serviceProvider = this.BuildServiceProvider(defaultOperationName: "default-op");
-            _ = new TelemetryClient(serviceProvider.GetRequiredService<TelemetryConfiguration>());
             using var activitySource = new ActivitySource(ApplicationInsightsActivitySourceName);
 
             using (var activity = activitySource.StartActivity("bare-activity"))
@@ -144,15 +142,24 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
                 {
                     defaultContext.Operation.Name = defaultOperationName;
                 }
-
-                EnsureBuilderConfiguration(configuration);
-                configuration.ConfigureOpenTelemetryBuilder(builder =>
-                {
-                    builder.WithTracing(tracing => tracing.AddProcessor(this.captureProcessor));
-                });
             });
 
-            return services.BuildServiceProvider();
+            // Wire the capture processor directly into the DI-owned OpenTelemetry pipeline so
+            // these tests validate the actual DI registration (not a parallel non-DI Build()
+            // pipeline). Register as the LAST processor so it observes activities after
+            // TelemetryContextActivityProcessor has applied DefaultContext enrichment.
+            services.ConfigureOpenTelemetryTracerProvider((sp, tracing) =>
+            {
+                tracing.AddSource(ApplicationInsightsActivitySourceName);
+                tracing.AddProcessor(this.captureProcessor);
+            });
+
+            var provider = services.BuildServiceProvider();
+
+            // Resolve TracerProvider eagerly so the DI-owned pipeline starts listening on the
+            // ApplicationInsights ActivitySource before tests start activities on it.
+            _ = provider.GetRequiredService<TracerProvider>();
+            return provider;
         }
 
         private Activity GetActivity(string name)
@@ -165,18 +172,6 @@ namespace Microsoft.ApplicationInsights.WorkerService.Tests
             var property = typeof(TelemetryConfiguration).GetProperty("DefaultContext", BindingFlags.Instance | BindingFlags.NonPublic);
             Assert.NotNull(property);
             return Assert.IsType<TelemetryContext>(property.GetValue(configuration));
-        }
-
-        private static void EnsureBuilderConfiguration(TelemetryConfiguration configuration)
-        {
-            var field = typeof(TelemetryConfiguration).GetField("builderConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
-            Assert.NotNull(field);
-
-            if (field.GetValue(configuration) == null)
-            {
-                field.SetValue(configuration, (Action<IOpenTelemetryBuilder>)(builder =>
-                    builder.WithTracing(tracing => tracing.AddSource(ApplicationInsightsActivitySourceName))));
-            }
         }
 
         private sealed class CaptureActivityProcessor : BaseProcessor<Activity>

--- a/NETCORE/test/WorkerIntegrationTests.Tests/WorkerIntegrationTests.Tests.csproj
+++ b/NETCORE/test/WorkerIntegrationTests.Tests/WorkerIntegrationTests.Tests.csproj
@@ -22,6 +22,7 @@
   <ItemGroup>
     <Compile Include="..\Shared\ConfigurationTests.cs" Link="ConfigurationTests.cs" />
     <Compile Include="..\Shared\ActivityFilterProcessorTests.cs" Link="ActivityFilterProcessorTests.cs" />
+    <Compile Include="..\Shared\DiTelemetryClientParityTests.cs" Link="DiTelemetryClientParityTests.cs" />
   </ItemGroup>
 
   <ItemGroup>

--- a/WEB/Src/Web/Web.Tests/ApplicationInsightsHttpModuleTests.cs
+++ b/WEB/Src/Web/Web.Tests/ApplicationInsightsHttpModuleTests.cs
@@ -1,9 +1,13 @@
 namespace Microsoft.ApplicationInsights.Web.Tests
 {
     using System;
+    using System.Collections.Concurrent;
     using System.IO;
+    using System.Linq;
     using System.Reflection;
+    using System.Runtime.ExceptionServices;
     using System.Threading;
+    using System.Threading.Tasks;
     using System.Web;
     using Azure.Monitor.OpenTelemetry.Exporter;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -284,6 +288,110 @@ namespace Microsoft.ApplicationInsights.Web.Tests
         }
 
         [Fact]
+        public void OnBeginRequest_ReusesSharedTelemetryClient_AcrossModuleInstances()
+        {
+            // Arrange
+            string configContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
+    <ConnectionString>InstrumentationKey=test</ConnectionString>
+</ApplicationInsights>";
+
+            CreateConfigInTestDirectory(configContent);
+
+            var module1 = new ApplicationInsightsHttpModule();
+            var module2 = new ApplicationInsightsHttpModule();
+            module1.Init(CreateMockHttpApplication());
+            module2.Init(CreateMockHttpApplication());
+
+            // Act
+            var firstException = Record.Exception(() => InvokeOnBeginRequest(module1));
+            var clientAfterFirstRequest = GetSharedTelemetryClient();
+            var secondException = Record.Exception(() => InvokeOnBeginRequest(module2));
+            var clientAfterSecondRequest = GetSharedTelemetryClient();
+
+            // Assert
+            Assert.Null(firstException);
+            Assert.Null(secondException);
+            Assert.NotNull(clientAfterFirstRequest);
+            Assert.Same(clientAfterFirstRequest, clientAfterSecondRequest);
+        }
+
+        [Fact]
+        public void OnBeginRequest_PublishesOneSharedTelemetryClient_UnderParallelLoad()
+        {
+            // Arrange
+            string configContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
+    <ConnectionString>InstrumentationKey=test</ConnectionString>
+</ApplicationInsights>";
+
+            CreateConfigInTestDirectory(configContent);
+
+            var modules = Enumerable.Range(0, 16)
+                .Select(_ =>
+                {
+                    var module = new ApplicationInsightsHttpModule();
+                    module.Init(CreateMockHttpApplication());
+                    return module;
+                })
+                .ToArray();
+            var observedClients = new ConcurrentBag<TelemetryClient>();
+
+            // Act
+            var exception = Record.Exception(() =>
+                Parallel.For(0, 64, i =>
+                {
+                    InvokeOnBeginRequest(modules[i % modules.Length]);
+                    observedClients.Add(GetSharedTelemetryClient());
+                }));
+
+            var sharedClient = GetSharedTelemetryClient();
+
+            // Assert
+            Assert.Null(exception);
+            Assert.NotNull(sharedClient);
+            Assert.Single(observedClients.Distinct());
+            var trackException = Record.Exception(() => sharedClient.TrackEvent("ParallelRace"));
+            Assert.Null(trackException);
+        }
+
+        [Fact]
+        public void OnBeginRequest_RetriesTelemetryClientConstruction_AfterFailure()
+        {
+            // Arrange
+            string configContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
+<ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
+    <ConnectionString>InstrumentationKey=test</ConnectionString>
+</ApplicationInsights>";
+
+            CreateConfigInTestDirectory(configContent);
+
+            var module = new ApplicationInsightsHttpModule();
+            module.Init(CreateMockHttpApplication());
+            var initialConfiguration = GetTelemetryConfigurationFromModule(module);
+            ForceBuildTelemetryConfiguration(initialConfiguration);
+
+            // Act
+            var firstException = Record.Exception(() => InvokeOnBeginRequest(module));
+            var clientAfterFailure = GetSharedTelemetryClient();
+
+            var replacementConfiguration = new TelemetryConfiguration
+            {
+                ConnectionString = "InstrumentationKey=test",
+            };
+
+            SetTelemetryConfigurationOnModule(module, replacementConfiguration);
+            var secondException = Record.Exception(() => InvokeOnBeginRequest(module));
+            var clientAfterRetry = GetSharedTelemetryClient();
+
+            // Assert
+            Assert.IsType<InvalidOperationException>(firstException);
+            Assert.Null(clientAfterFailure);
+            Assert.Null(secondException);
+            Assert.NotNull(clientAfterRetry);
+        }
+
+        [Fact]
         public void Init_ConfiguresOpenTelemetryBuilder_WhenConfigOptionsProvided()
         {
             // Arrange
@@ -441,6 +549,38 @@ namespace Microsoft.ApplicationInsights.Web.Tests
             return (TelemetryConfiguration)field?.GetValue(module);
         }
 
+        private TelemetryClient GetSharedTelemetryClient()
+        {
+            var field = typeof(ApplicationInsightsHttpModule).GetField("sharedTelemetryClient", BindingFlags.Static | BindingFlags.NonPublic);
+            return (TelemetryClient)field?.GetValue(null);
+        }
+
+        private void SetTelemetryConfigurationOnModule(ApplicationInsightsHttpModule module, TelemetryConfiguration configuration)
+        {
+            var field = typeof(ApplicationInsightsHttpModule).GetField("telemetryConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
+            field?.SetValue(module, configuration);
+        }
+
+        private void InvokeOnBeginRequest(ApplicationInsightsHttpModule module)
+        {
+            var method = typeof(ApplicationInsightsHttpModule).GetMethod("OnBeginRequest", BindingFlags.Instance | BindingFlags.NonPublic);
+
+            try
+            {
+                method?.Invoke(module, new object[] { module, EventArgs.Empty });
+            }
+            catch (TargetInvocationException ex) when (ex.InnerException != null)
+            {
+                ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
+            }
+        }
+
+        private void ForceBuildTelemetryConfiguration(TelemetryConfiguration configuration)
+        {
+            var method = typeof(TelemetryConfiguration).GetMethod("Build", BindingFlags.Instance | BindingFlags.NonPublic);
+            method?.Invoke(configuration, null);
+        }
+
         private void ResetStaticState()
         {
             // Use reflection to reset static state for test isolation
@@ -450,6 +590,12 @@ namespace Microsoft.ApplicationInsights.Web.Tests
             if (sharedConfigField != null)
             {
                 sharedConfigField.SetValue(null, null);
+            }
+
+            var sharedClientField = type.GetField("sharedTelemetryClient", BindingFlags.Static | BindingFlags.NonPublic);
+            if (sharedClientField != null)
+            {
+                sharedClientField.SetValue(null, null);
             }
 
             var isInitializedField = type.GetField("isInitialized", BindingFlags.Static | BindingFlags.NonPublic);

--- a/WEB/Src/Web/Web.Tests/ApplicationInsightsHttpModuleTests.cs
+++ b/WEB/Src/Web/Web.Tests/ApplicationInsightsHttpModuleTests.cs
@@ -356,42 +356,6 @@ namespace Microsoft.ApplicationInsights.Web.Tests
         }
 
         [Fact]
-        public void OnBeginRequest_RetriesTelemetryClientConstruction_AfterFailure()
-        {
-            // Arrange
-            string configContent = @"<?xml version=""1.0"" encoding=""utf-8""?>
-<ApplicationInsights xmlns=""http://schemas.microsoft.com/ApplicationInsights/2013/Settings"">
-    <ConnectionString>InstrumentationKey=test</ConnectionString>
-</ApplicationInsights>";
-
-            CreateConfigInTestDirectory(configContent);
-
-            var module = new ApplicationInsightsHttpModule();
-            module.Init(CreateMockHttpApplication());
-            var initialConfiguration = GetTelemetryConfigurationFromModule(module);
-            ForceBuildTelemetryConfiguration(initialConfiguration);
-
-            // Act
-            var firstException = Record.Exception(() => InvokeOnBeginRequest(module));
-            var clientAfterFailure = GetSharedTelemetryClient();
-
-            var replacementConfiguration = new TelemetryConfiguration
-            {
-                ConnectionString = "InstrumentationKey=test",
-            };
-
-            SetTelemetryConfigurationOnModule(module, replacementConfiguration);
-            var secondException = Record.Exception(() => InvokeOnBeginRequest(module));
-            var clientAfterRetry = GetSharedTelemetryClient();
-
-            // Assert
-            Assert.IsType<InvalidOperationException>(firstException);
-            Assert.Null(clientAfterFailure);
-            Assert.Null(secondException);
-            Assert.NotNull(clientAfterRetry);
-        }
-
-        [Fact]
         public void Init_ConfiguresOpenTelemetryBuilder_WhenConfigOptionsProvided()
         {
             // Arrange
@@ -555,12 +519,6 @@ namespace Microsoft.ApplicationInsights.Web.Tests
             return (TelemetryClient)field?.GetValue(null);
         }
 
-        private void SetTelemetryConfigurationOnModule(ApplicationInsightsHttpModule module, TelemetryConfiguration configuration)
-        {
-            var field = typeof(ApplicationInsightsHttpModule).GetField("telemetryConfiguration", BindingFlags.Instance | BindingFlags.NonPublic);
-            field?.SetValue(module, configuration);
-        }
-
         private void InvokeOnBeginRequest(ApplicationInsightsHttpModule module)
         {
             var method = typeof(ApplicationInsightsHttpModule).GetMethod("OnBeginRequest", BindingFlags.Instance | BindingFlags.NonPublic);
@@ -573,12 +531,6 @@ namespace Microsoft.ApplicationInsights.Web.Tests
             {
                 ExceptionDispatchInfo.Capture(ex.InnerException).Throw();
             }
-        }
-
-        private void ForceBuildTelemetryConfiguration(TelemetryConfiguration configuration)
-        {
-            var method = typeof(TelemetryConfiguration).GetMethod("Build", BindingFlags.Instance | BindingFlags.NonPublic);
-            method?.Invoke(configuration, null);
         }
 
         private void ResetStaticState()

--- a/WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs
+++ b/WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Reflection;
+    using System.Threading;
     using System.Web;
     using Azure.Monitor.OpenTelemetry.Exporter;
     using Microsoft.ApplicationInsights.Extensibility;
@@ -23,11 +24,10 @@
         private static readonly object StaticLockObject = new object();
         private static int initializationCount = 0;
         private static TelemetryConfiguration sharedTelemetryConfiguration;
+        private static TelemetryClient sharedTelemetryClient;
         private static bool isInitialized = false;
 
-        private readonly object lockObject = new object();
         private TelemetryConfiguration telemetryConfiguration;
-        private TelemetryClient telemetryClient;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="ApplicationInsightsHttpModule"/> class.
@@ -50,14 +50,10 @@
             lock (StaticLockObject)
             {
                 initializationCount++;
-                System.Diagnostics.Debug.WriteLine($"Module Init called #{initializationCount} at {DateTime.Now:HH:mm:ss.fff}");
-                System.Diagnostics.Debug.WriteLine($"AppDomain: {AppDomain.CurrentDomain.Id}");
 
                 // Only initialize the shared configuration once per AppDomain
                 if (!isInitialized)
                 {
-                    System.Diagnostics.Debug.WriteLine("Performing first-time initialization");
-
                     sharedTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
 
                     sharedTelemetryConfiguration.ExtensionVersion = VersionUtils.ExtensionLabelShimWeb + VersionUtils.GetVersion(typeof(ApplicationInsightsExtensions));
@@ -118,6 +114,11 @@
                             sharedTelemetryConfiguration.EnableLiveMetrics = configOptions.EnableQuickPulseMetricStream.Value;
                         }
 
+                        if (!string.IsNullOrEmpty(configOptions.ApplicationVersion))
+                        {
+                            sharedTelemetryConfiguration.DefaultContext.Component.Version = configOptions.ApplicationVersion;
+                        }
+
                         // Configure OpenTelemetry builder for properties that require OpenTelemetry API
                         sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
                             builder => ConfigureOpenTelemetryWithOptions(builder, configOptions));
@@ -131,10 +132,6 @@
                     }
 
                     isInitialized = true;
-                }
-                else
-                {
-                    System.Diagnostics.Debug.WriteLine("Skipping duplicate initialization - using shared configuration");
                 }
 
                 // Use the shared configuration for this instance
@@ -154,7 +151,6 @@
             // It will be cleaned up when the AppDomain unloads
 
             // Note: If you need to dispose, you'd need a reference counting mechanism
-            System.Diagnostics.Debug.WriteLine("Dispose called");
         }
 
         /// <summary>
@@ -232,14 +228,17 @@
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            // Ensure TelemetryClient is created only once per module instance using double-check locking pattern
-            if (this.telemetryClient == null)
+            var client = Volatile.Read(ref sharedTelemetryClient);
+            if (client == null)
             {
-                lock (this.lockObject)
+                lock (StaticLockObject)
                 {
-                    if (this.telemetryClient == null)
+                    client = sharedTelemetryClient;
+                    if (client == null)
                     {
-                        this.telemetryClient = new TelemetryClient(this.telemetryConfiguration);
+                        var newClient = new TelemetryClient(this.telemetryConfiguration);
+                        Volatile.Write(ref sharedTelemetryClient, newClient);
+                        client = newClient;
                     }
                 }
             }


### PR DESCRIPTION
Fixes #3163.

## Symptom

Under classic ASP.NET with `Microsoft.ApplicationInsights.Web` 3.1.0, every HTTP request after the first throws:

```
InvalidOperationException: Configuration cannot be modified after it has been built.
   at TelemetryConfiguration.ThrowIfBuilt() ... TelemetryConfiguration.cs:505
   at TelemetryConfiguration.PrependOpenTelemetryBuilderConfiguration ... line 325
   at TelemetryClient..ctor ... TelemetryClient.cs:71
   at ApplicationInsightsHttpModule.OnBeginRequest ... ApplicationInsightsHttpModule.cs:242
```

## Root cause

ASP.NET classic instantiates many `HttpApplication` (and thus `IHttpModule`) instances per AppDomain. `ApplicationInsightsHttpModule` kept a **shared static** `TelemetryConfiguration` but a **per-instance** `telemetryClient` field. Each instance's first request would call `new TelemetryClient(sharedConfig)`. In 3.1.0 the non-DI `TelemetryClient` constructor (introduced by #3128) mutated and built the configuration via `PrependOpenTelemetryBuilderConfiguration`. The second module's lazy construction then hit `ThrowIfBuilt` and crashed.

3.0.0 worked because the constructor was non-mutating then.

## Fix overview

Three layered changes plus follow-up corrections from review:

1. **HttpModule hotfix.** `ApplicationInsightsHttpModule.telemetryClient` becomes static, published under `StaticLockObject` with `Volatile.Read`/`Volatile.Write` double-check (deliberately not `Lazy<T>` to avoid cached-exception poisoning if construction transiently fails).

2. **Race-safe configuration guard.** New internal `TelemetryConfiguration.TryPrependOpenTelemetryBuilderConfiguration(...)` is atomic  takes `lockObject`, checks `isBuilt`, returns `false` instead of throwing. `Build()` is now race-safe and idempotent.

3. **Per-client context scoping redesign.** `TelemetryClient.Context` is now scoped to the individual client (the 3.1.0 quirk that made one client's context apply AppDomain-wide is gone).
   - New internal `TelemetryConfiguration.DefaultContext` (mutable shared `TelemetryContext`) populated by the HttpModule and the NETCORE DI extension from existing config inputs.
   - `TelemetryContextActivityProcessor(DefaultContext)` / `TelemetryContextLogProcessor(DefaultContext)` are registered in **both** `TelemetryConfiguration.Build()` (non-DI path) and the NETCORE DI extensions (DI path), prepended before user `ConfigureOpenTelemetryBuilder` actions so user exporters see enriched telemetry.
   - `TelemetryClient`'s constructor no longer mutates the configuration.
   - Per-client enrichment now happens at the source in every `Track*` and `StartOperation*` call.
   - New `TelemetryContextEnricher` static helper + `ContextSnapshot` + `WarmupGate`; both processors delegate to it.

**Precedence (highest  lowest):** item-level `telemetry.Context` > client-level `this.Context` > `DefaultContext`. Skip-if-present throughout.

**Public API:** none added. New surface is internal-only.

## Behavioural change

In 3.1.0, setting `TelemetryClient.Context` on any client silently enriched all telemetry in the AppDomain (a side effect of the first client's constructor registering a pipeline-wide processor over its own context). This was undocumented and was the proximate cause of #3163.

Starting in 3.2:

- `TelemetryClient.Context` only enriches telemetry produced by that specific client's `Track*`/`StartOperation*` calls.
- AppDomain-wide defaults continue to flow via `applicationinsights.config` (classic ASP.NET) and `ApplicationInsightsServiceOptions` (ASP.NET Core / Worker Service)  no user action required for the common case.
- `new TelemetryClient(config)` constructed multiple times no longer throws (restoring the 2.x contract).

Documented in `MigrationGuidance.md`.

## Multi-round code review

Branch was reviewed in **four rounds** by three models in parallel (Opus 4.7, Opus 4.6, GPT-5.5). Each round found a real defect that subsequent commits address:

| Round | Finding | Caught by | Commit |
| --- | --- | --- | --- |
| 1 | `DefaultContext` processors not registered in DI mode (`Build()` never runs there) | Opus 4.7, GPT-5.5 | `33cf46f8` |
| 2 | `NullReferenceException` in `Build()` against DI-resolved config | Opus 4.6, GPT-5.5 | `ac3f2e7b` |
| 3 | Deferred NRE in three builder-chaining methods | Opus 4.7, Opus 4.6, GPT-5.5 (unanimous) | `1252d96c` |
| 4 | Obsolete WEB.Tests retry test asserting old broken behaviour | GPT-5.5 | `8b637606` |

The "missing" model rotated between rounds, so single-model review would have shipped at least one ship-blocker. The PR's final state has been verified after each round.

## Files changed (final state)

- `BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs`  `DefaultContext`, `TryPrepend...`, idempotent `Build()`, null-safe `builderConfiguration?.Invoke` in all four sites, `Build()` registers default-enrichment processors.
- `BASE/src/Microsoft.ApplicationInsights/TelemetryClient.cs`  constructor stops mutating configuration; per-client source enrichment added to all `Track*`; cloud-context applied separately.
- `BASE/src/Microsoft.ApplicationInsights/TelemetryClientExtensions.cs`  `StartOperation` overloads enrich with client context at source.
- `BASE/src/Microsoft.ApplicationInsights/Processors/{TelemetryContextEnricher,ContextSnapshot,WarmupGate}.cs`  new helpers (internal).
- `BASE/src/Microsoft.ApplicationInsights/Processors/TelemetryContextActivityProcessor.cs` & `TelemetryContextLogProcessor.cs`  delegate to the new helper.
- `NETCORE/src/Shared/Extensions/ApplicationInsightsExtensions.cs`  populates `DefaultContext` from options.
- `NETCORE/src/Microsoft.ApplicationInsights.{AspNetCore,WorkerService}/...ApplicationInsightsExtensions.cs`  registers default-context processors against `DefaultContext` (rather than per-client `Context`).
- `WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs`  static shared `TelemetryClient` with safe-publish double-check; cleaned dev-only `Debug.WriteLine` traces.
- `MigrationGuidance.md` & `CHANGELOG.md`  documented the behavioural change and the #3163 fix.

## Tests

New tests (all in existing test projects):

- **WEB**: HttpModule #3163 regression  sequential two-instance + parallel race.
- **BASE**: `TryPrepend...` success/failure/null paths; `Build()` idempotence; defensive `new TelemetryClient(builtConfig)`; concurrent construction; concurrent `Build()`-vs-construction race; `Build_WithSkipDefaultBuilderConfiguration_DoesNotThrow`; `Build_AfterConfigureOpenTelemetryBuilderOnSkipDefaultConfig_DoesNotThrow`; `Build_AfterTryPrependOnSkipDefaultConfig_DoesNotThrow`; `DefaultContext` shape and mutation-after-build; full per-client scoping matrix across all `Track*` and `StartOperation` overloads; precedence (item > client > default); `TelemetryContextEnricher` parity.
- **NETCORE**: shared `DiTelemetryClientParityTests` linked into both AspNetCore and WorkerService integration test projects  DI-resolved client uses its own context (not default); two DI-resolved clients don't cross-contaminate; bare `ActivitySource` activity picks up `DefaultContext` via the DI pipeline.

## Validation

`dotnet build Everything.sln` clean (0 errors, 4 pre-existing CS8632 warnings unrelated to this change). All new tests pass on net462/net8.0/net9.0/net10.0 where applicable. Pre-existing flaky failures (`FeatureMetricEmissionHelperTests.ReportsFeaturesSeen`, `SelfDiagnosticsConfigRefresherTest.SelfDiagnosticsConfigRefresher_OmitAsConfigured`, intermittent `TelemetryClientContextTags*`) reproduce on unmodified `origin/main` and are not regressions introduced here.

## Commits

1. `350908d7`  three-layer #3163 fix
2. `33cf46f8`  DI processor registration (round 1)
3. `ac3f2e7b`  Build NRE guard (round 2)
4. `1252d96c`  Deferred NRE in chaining (round 3, unanimous)
5. `8b637606`  Remove obsolete retry test (round 4)
