### PR TITLE
Fix #3163: TelemetryConfiguration.CreateDefault() now loads applicationinsights.config on classic ASP.NET

### DIFF
--- a/.publicApi/Microsoft.AI.Web.dll/Stable/PublicAPI.Unshipped.txt
+++ b/.publicApi/Microsoft.AI.Web.dll/Stable/PublicAPI.Unshipped.txt
@@ -1,0 +1,2 @@
+Microsoft.ApplicationInsights.Web.WebApplicationInsightsInitializer
+static Microsoft.ApplicationInsights.Web.WebApplicationInsightsInitializer.Initialize() -> void

--- a/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
+++ b/BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs
@@ -320,14 +320,15 @@
         /// </summary>
         internal void PrependOpenTelemetryBuilderConfiguration(Action<IOpenTelemetryBuilder> configure)
         {
-            this.ThrowIfBuilt();
-
-            var previousConfiguration = this.builderConfiguration;
-            this.builderConfiguration = builder =>
+            if (!this.isBuilt)
             {
-                configure(builder);
-                previousConfiguration(builder);
-            };
+                var previousConfiguration = this.builderConfiguration;
+                this.builderConfiguration = builder =>
+                {
+                    configure(builder);
+                    previousConfiguration(builder);
+                };
+            }
         }
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [Fix #3163: `TelemetryConfiguration.CreateDefault()` on classic ASP.NET now returns a configuration already populated from `ApplicationInsights.config` (connection string, sampling, storage, live metrics, request/dependency tracking, etc.). A new `PreApplicationStartMethod` (`WebApplicationInsightsInitializer`) materializes and populates the singleton before `Application_Start` runs, so customer code calling `TelemetryConfiguration.CreateDefault()` from `Global.asax.cs` no longer gets an empty configuration. The `ApplicationInsightsHttpModule` no longer carries the config-reading bookkeeping. `TelemetryConfiguration.PrependOpenTelemetryBuilderConfiguration` no longer throws if the configuration was already built — it silently skips, so a second `TelemetryClient` constructed against an already-built configuration no longer throws `InvalidOperationException`.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3183)
 
 ## Version 3.1.1
 - [Update OpenTelemetry and Azure Monitor dependencies to address known security advisories (e.g. [GHSA-g94r-2vxg-569j](https://github.com/advisories/GHSA-g94r-2vxg-569j) in `OpenTelemetry.Api` 1.15.1).](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3174)

--- a/WEB/Src/Web/Web.Tests/ApplicationInsightsConfigurationReaderTests.cs
+++ b/WEB/Src/Web/Web.Tests/ApplicationInsightsConfigurationReaderTests.cs
@@ -6,6 +6,7 @@ namespace Microsoft.ApplicationInsights.Web.Tests
     using Microsoft.ApplicationInsights.Web.Implementation;
     using Xunit;
 
+    [Collection("ApplicationInsightsHttpModule")] // Same collection as ApplicationInsightsHttpModuleTests; both write the same ApplicationInsights.config file in the test base directory.
     public class ApplicationInsightsConfigurationReaderTests : IDisposable
     {
         private readonly string configFilePath;

--- a/WEB/Src/Web/Web.Tests/ApplicationInsightsHttpModuleTests.cs
+++ b/WEB/Src/Web/Web.Tests/ApplicationInsightsHttpModuleTests.cs
@@ -443,36 +443,24 @@ namespace Microsoft.ApplicationInsights.Web.Tests
 
         private void ResetStaticState()
         {
-            // Use reflection to reset static state for test isolation
-            var type = typeof(ApplicationInsightsHttpModule);
-            
-            var sharedConfigField = type.GetField("sharedTelemetryConfiguration", BindingFlags.Static | BindingFlags.NonPublic);
-            if (sharedConfigField != null)
-            {
-                sharedConfigField.SetValue(null, null);
-            }
-
-            var isInitializedField = type.GetField("isInitialized", BindingFlags.Static | BindingFlags.NonPublic);
+            // Use reflection to reset static state for test isolation.
+            // The HTTP module no longer carries its own static state; configuration loading
+            // moved to WebApplicationInsightsInitializer, which has its own one-shot guard.
+            var initializerType = typeof(WebApplicationInsightsInitializer);
+            var isInitializedField = initializerType.GetField("isInitialized", BindingFlags.Static | BindingFlags.NonPublic);
             if (isInitializedField != null)
             {
                 isInitializedField.SetValue(null, false);
             }
 
-            var initCountField = type.GetField("initializationCount", BindingFlags.Static | BindingFlags.NonPublic);
-            if (initCountField != null)
-            {
-                initCountField.SetValue(null, 0);
-            }
-
             // This next block is added because of tests that check the value of exporter options for sampling settings.
-            // Also reset the TelemetryConfiguration.DefaultInstance static Lazy field
-            // This is necessary because CreateDefault() returns a singleton that can only be built once
+            // Also reset the TelemetryConfiguration.DefaultInstance static Lazy field.
+            // This is necessary because CreateDefault() returns a singleton that can only be built once.
             var telemetryConfigType = typeof(TelemetryConfiguration);
             var defaultInstanceField = telemetryConfigType.GetField("DefaultInstance", BindingFlags.Static | BindingFlags.NonPublic);
             if (defaultInstanceField != null)
             {
-                // Create a new Lazy<TelemetryConfiguration> instance to replace the existing one
-                var lazyType = typeof(Lazy<TelemetryConfiguration>);
+                // Create a new Lazy<TelemetryConfiguration> instance to replace the existing one.
                 var newLazy = new Lazy<TelemetryConfiguration>(() => new TelemetryConfiguration(), LazyThreadSafetyMode.ExecutionAndPublication);
                 defaultInstanceField.SetValue(null, newLazy);
             }

--- a/WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs
+++ b/WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs
@@ -1,30 +1,20 @@
 ﻿namespace Microsoft.ApplicationInsights.Web
 {
     using System;
-    using System.Collections.Generic;
-    using System.Reflection;
     using System.Web;
-    using Azure.Monitor.OpenTelemetry.Exporter;
     using Microsoft.ApplicationInsights.Extensibility;
-    using Microsoft.ApplicationInsights.Internal;
-    using Microsoft.ApplicationInsights.Web.Extensions;
-    using Microsoft.ApplicationInsights.Web.Implementation;
-    using Microsoft.Extensions.DependencyInjection;
-    using OpenTelemetry;
-    using OpenTelemetry.Resources;
-    using OpenTelemetry.Trace;
 
     /// <summary>
     /// Platform agnostic module for web application instrumentation.
     /// </summary>
+    /// <remarks>
+    /// The shared <see cref="TelemetryConfiguration"/> is populated from
+    /// <c>ApplicationInsights.config</c> by <see cref="WebApplicationInsightsInitializer"/>,
+    /// which ASP.NET invokes before <c>Application_Start</c> via
+    /// <see cref="System.Web.PreApplicationStartMethodAttribute"/>.
+    /// </remarks>
     public sealed class ApplicationInsightsHttpModule : IHttpModule
     {
-        // Static fields to track initialization across all module instances
-        private static readonly object StaticLockObject = new object();
-        private static int initializationCount = 0;
-        private static TelemetryConfiguration sharedTelemetryConfiguration;
-        private static bool isInitialized = false;
-
         private readonly object lockObject = new object();
         private TelemetryConfiguration telemetryConfiguration;
         private TelemetryClient telemetryClient;
@@ -47,101 +37,14 @@
                 throw new ArgumentNullException(nameof(context));
             }
 
-            lock (StaticLockObject)
-            {
-                initializationCount++;
-                System.Diagnostics.Debug.WriteLine($"Module Init called #{initializationCount} at {DateTime.Now:HH:mm:ss.fff}");
-                System.Diagnostics.Debug.WriteLine($"AppDomain: {AppDomain.CurrentDomain.Id}");
+            // Defensive: PreApplicationStartMethod normally runs before this, but call again
+            // in case the module is loaded without our assembly being scanned early.
+            // Initialize() is idempotent.
+            WebApplicationInsightsInitializer.Initialize();
 
-                // Only initialize the shared configuration once per AppDomain
-                if (!isInitialized)
-                {
-                    System.Diagnostics.Debug.WriteLine("Performing first-time initialization");
+            // CreateDefault returns the singleton already populated by the initializer above.
+            this.telemetryConfiguration = TelemetryConfiguration.CreateDefault();
 
-                    sharedTelemetryConfiguration = TelemetryConfiguration.CreateDefault();
-
-                    sharedTelemetryConfiguration.ExtensionVersion = VersionUtils.ExtensionLabelShimWeb + VersionUtils.GetVersion(typeof(ApplicationInsightsExtensions));
-                    
-                    // Read all configuration options from applicationinsights.config
-                    ApplicationInsightsConfigOptions configOptions = ApplicationInsightsConfigurationReader.GetConfigurationOptions();
-                    
-                    if (configOptions != null)
-                    {
-                        // Apply Group 1: Direct TelemetryConfiguration properties (before Build)
-                        if (!string.IsNullOrEmpty(configOptions.ConnectionString))
-                        {
-                            sharedTelemetryConfiguration.ConnectionString = configOptions.ConnectionString;
-                            WebEventSource.Log.ConnectionStringLoadedFromConfig(configOptions.ConnectionString);
-                        }
-                        else
-                        {
-                            WebEventSource.Log.NoConnectionStringFoundInConfig();
-                        }
-
-                        if (configOptions.DisableTelemetry.HasValue)
-                        {
-                            sharedTelemetryConfiguration.DisableTelemetry = configOptions.DisableTelemetry.Value;
-                        }
-
-                        if (configOptions.TracesPerSecond.HasValue)
-                        {
-                            sharedTelemetryConfiguration.TracesPerSecond = configOptions.TracesPerSecond.Value;
-                        }
-
-                        if (configOptions.SamplingRatio.HasValue)
-                        {
-                            sharedTelemetryConfiguration.SamplingRatio = configOptions.SamplingRatio.Value;
-                            if (!configOptions.TracesPerSecond.HasValue)
-                            {
-                                sharedTelemetryConfiguration.TracesPerSecond = null;
-                            }
-                        }
-
-                        if (!string.IsNullOrEmpty(configOptions.StorageDirectory))
-                        {
-                            sharedTelemetryConfiguration.StorageDirectory = configOptions.StorageDirectory;
-                        }
-
-                        if (configOptions.DisableOfflineStorage.HasValue)
-                        {
-                            sharedTelemetryConfiguration.DisableOfflineStorage = configOptions.DisableOfflineStorage.Value;
-                        }
-
-                        if (configOptions.EnableTraceBasedLogsSampler.HasValue)
-                        {
-                            sharedTelemetryConfiguration.EnableTraceBasedLogsSampler = configOptions.EnableTraceBasedLogsSampler.Value;
-                        }
-
-                        // EnableQuickPulseMetricStream -> EnableLiveMetrics (TelemetryConfiguration property)
-                        if (configOptions.EnableQuickPulseMetricStream.HasValue)
-                        {
-                            sharedTelemetryConfiguration.EnableLiveMetrics = configOptions.EnableQuickPulseMetricStream.Value;
-                        }
-
-                        // Configure OpenTelemetry builder for properties that require OpenTelemetry API
-                        sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
-                            builder => ConfigureOpenTelemetryWithOptions(builder, configOptions));
-                    }
-                    else
-                    {
-                        WebEventSource.Log.NoConnectionStringFoundInConfig();
-
-                        sharedTelemetryConfiguration.ConfigureOpenTelemetryBuilder(
-                            builder => builder.UseApplicationInsightsAspNetTelemetry());
-                    }
-
-                    isInitialized = true;
-                }
-                else
-                {
-                    System.Diagnostics.Debug.WriteLine("Skipping duplicate initialization - using shared configuration");
-                }
-
-                // Use the shared configuration for this instance
-                this.telemetryConfiguration = sharedTelemetryConfiguration;
-            }
-
-            // Subscribe to events (this is safe to do multiple times as ASP.NET handles duplicate subscriptions)
             context.BeginRequest += this.OnBeginRequest;
         }
 
@@ -150,89 +53,13 @@
         /// </summary>
         public void Dispose()
         {
-            // Don't dispose the shared configuration, as other instances might still be using it
-            // It will be cleaned up when the AppDomain unloads
-
-            // Note: If you need to dispose, you'd need a reference counting mechanism
-            System.Diagnostics.Debug.WriteLine("Dispose called");
-        }
-
-        /// <summary>
-        /// Configures OpenTelemetry builder with options that require OpenTelemetry API access.
-        /// Note: Classic ASP.NET doesn't use DI, so we can only configure things through the builder's direct API.
-        /// </summary>
-        private static void ConfigureOpenTelemetryWithOptions(IOpenTelemetryBuilder builder, ApplicationInsightsConfigOptions configOptions)
-        {
-            builder.UseApplicationInsightsAspNetTelemetry();
-
-            // Configure AzureMonitorExporterOptions for internal properties using reflection
-            // Even though classic ASP.NET doesn't use DI, the OpenTelemetry builder does internally
-            builder.Services.Configure<AzureMonitorExporterOptions>(exporterOptions =>
-            {
-                // EnablePerformanceCounterCollectionModule -> EnablePerfCounters (internal property)
-                if (configOptions.EnablePerformanceCounterCollectionModule.HasValue)
-                {
-                    TrySetInternalProperty(exporterOptions, "EnablePerfCounters", configOptions.EnablePerformanceCounterCollectionModule.Value);
-                }
-
-                // AddAutoCollectedMetricExtractor -> EnableStandardMetrics (internal property)
-                if (configOptions.AddAutoCollectedMetricExtractor.HasValue)
-                {
-                    TrySetInternalProperty(exporterOptions, "EnableStandardMetrics", configOptions.AddAutoCollectedMetricExtractor.Value);
-                }
-            });
-
-            // Handle EnableDependencyTrackingTelemetryModule and EnableRequestTrackingTelemetryModule - add activity filter processor
-            bool enableDependencyTracking = configOptions.EnableDependencyTrackingTelemetryModule ?? true;
-            bool enableRequestTracking = configOptions.EnableRequestTrackingTelemetryModule ?? true;
-
-            // Only add processor if either feature is disabled
-            if (!enableDependencyTracking || !enableRequestTracking)
-            {
-                // Use WithTracing to get TracerProviderBuilder which has AddProcessor method
-                builder.WithTracing(tracerBuilder =>
-                {
-                    tracerBuilder.AddProcessor(new ActivityFilterProcessor(enableDependencyTracking, enableRequestTracking));
-                });
-            }
-
-            // Handle ApplicationVersion - add to resource attributes
-            if (!string.IsNullOrEmpty(configOptions.ApplicationVersion))
-            {
-                builder.ConfigureResource(resourceBuilder =>
-                {
-                    resourceBuilder.AddAttributes(new[] 
-                    { 
-                        new KeyValuePair<string, object>("service.version", configOptions.ApplicationVersion), 
-                    });
-                });
-            }
-        }
-
-        /// <summary>
-        /// Tries to set an internal property on an object using reflection.
-        /// Used to configure internal properties on AzureMonitorExporterOptions.
-        /// </summary>
-        private static void TrySetInternalProperty(object target, string propertyName, bool value)
-        {
-            try
-            {
-                var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
-                if (property != null && property.CanWrite && property.PropertyType == typeof(bool))
-                {
-                    property.SetValue(target, value);
-                }
-            }
-            catch
-            {
-                // Silently ignore if property doesn't exist or can't be set
-                // This allows forward/backward compatibility across versions
-            }
+            // The shared TelemetryConfiguration singleton is owned by TelemetryConfiguration
+            // itself and is cleaned up on AppDomain unload. Nothing to dispose here.
         }
 
         private void OnBeginRequest(object sender, EventArgs eventArgs)
         {
-            // Ensure TelemetryClient is created only once per module instance using double-check locking pattern
+            // Ensure TelemetryClient is created only once per module instance using double-check locking.
             if (this.telemetryClient == null)
             {
                 lock (this.lockObject)

--- a/WEB/Src/Web/Web/WebApplicationInsightsInitializer.cs
+++ b/WEB/Src/Web/Web/WebApplicationInsightsInitializer.cs
@@ -65,25 +65,38 @@ namespace Microsoft.ApplicationInsights.Web
                     return;
                 }
 
-                // Materialize the singleton. Any subsequent call to
-                // TelemetryConfiguration.CreateDefault() returns this same instance.
-                TelemetryConfiguration cfg = TelemetryConfiguration.CreateDefault();
-
-                cfg.ExtensionVersion = VersionUtils.ExtensionLabelShimWeb
-                    + VersionUtils.GetVersion(typeof(ApplicationInsightsExtensions));
-
-                ApplicationInsightsConfigOptions configOptions =
-                    ApplicationInsightsConfigurationReader.GetConfigurationOptions();
-
-                if (configOptions != null)
+                try
                 {
-                    ApplyConfigOptions(cfg, configOptions);
+                    // Materialize the singleton. Any subsequent call to
+                    // TelemetryConfiguration.CreateDefault() returns this same instance.
+                    TelemetryConfiguration cfg = TelemetryConfiguration.CreateDefault();
+
+                    cfg.ExtensionVersion = VersionUtils.ExtensionLabelShimWeb
+                        + VersionUtils.GetVersion(typeof(ApplicationInsightsExtensions));
+
+                    ApplicationInsightsConfigOptions configOptions =
+                        ApplicationInsightsConfigurationReader.GetConfigurationOptions();
+
+                    if (configOptions != null)
+                    {
+                        ApplyConfigOptions(cfg, configOptions);
+                    }
+                    else
+                    {
+                        WebEventSource.Log.NoConnectionStringFoundInConfig();
+                        cfg.ConfigureOpenTelemetryBuilder(
+                            builder => builder.UseApplicationInsightsAspNetTelemetry());
+                    }
                 }
-                else
+                catch (InvalidOperationException ex)
                 {
-                    WebEventSource.Log.NoConnectionStringFoundInConfig();
-                    cfg.ConfigureOpenTelemetryBuilder(
-                        builder => builder.UseApplicationInsightsAspNetTelemetry());
+                    // The singleton TelemetryConfiguration was already built by user code
+                    // (e.g., a TelemetryClient was constructed before PreApplicationStartMethod
+                    // ran). Property setters and builder-config registrations throw in that
+                    // state. There is nothing we can apply at this point — surface a
+                    // diagnostic and move on. Subsequent calls become no-ops via isInitialized.
+                    WebEventSource.Log.ApplicationInsightsConfigReadError(
+                        "WebApplicationInsightsInitializer skipped: TelemetryConfiguration was already built. " + ex.Message);
                 }
 
                 isInitialized = true;
@@ -217,10 +230,15 @@ namespace Microsoft.ApplicationInsights.Web
                     property.SetValue(target, value);
                 }
             }
-            catch
+            catch (Exception ex) when (
+                ex is AmbiguousMatchException
+                || ex is TargetException
+                || ex is TargetInvocationException
+                || ex is ArgumentException
+                || ex is MethodAccessException)
             {
-                // Silently ignore if property doesn't exist or can't be set.
-                // This allows forward/backward compatibility across versions.
+                // Silently ignore if the property is missing or cannot be set.
+                // This allows forward/backward compatibility across exporter versions.
             }
         }
     }

--- a/WEB/Src/Web/Web/WebApplicationInsightsInitializer.cs
+++ b/WEB/Src/Web/Web/WebApplicationInsightsInitializer.cs
@@ -1,0 +1,227 @@
+// <copyright file="WebApplicationInsightsInitializer.cs" company="Microsoft">
+// Copyright © Microsoft. All Rights Reserved.
+// </copyright>
+
+[assembly: System.Web.PreApplicationStartMethod(
+    typeof(Microsoft.ApplicationInsights.Web.WebApplicationInsightsInitializer),
+    nameof(Microsoft.ApplicationInsights.Web.WebApplicationInsightsInitializer.Initialize))]
+
+namespace Microsoft.ApplicationInsights.Web
+{
+    using System;
+    using System.Collections.Generic;
+    using System.ComponentModel;
+    using System.Reflection;
+    using Azure.Monitor.OpenTelemetry.Exporter;
+    using Microsoft.ApplicationInsights.Extensibility;
+    using Microsoft.ApplicationInsights.Internal;
+    using Microsoft.ApplicationInsights.Web.Extensions;
+    using Microsoft.ApplicationInsights.Web.Implementation;
+    using Microsoft.Extensions.DependencyInjection;
+    using OpenTelemetry;
+    using OpenTelemetry.Resources;
+    using OpenTelemetry.Trace;
+
+    /// <summary>
+    /// Configures the default <see cref="TelemetryConfiguration"/> for classic ASP.NET
+    /// from <c>ApplicationInsights.config</c> before the application's <c>Application_Start</c>
+    /// runs. This is invoked automatically by ASP.NET via
+    /// <see cref="System.Web.PreApplicationStartMethodAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// This type is public only because <see cref="System.Web.PreApplicationStartMethodAttribute"/>
+    /// requires the target type and method to be public. It is not intended to be called
+    /// directly by user code. Customers should call <see cref="TelemetryConfiguration.CreateDefault"/>,
+    /// which returns the singleton already populated by this initializer.
+    /// </remarks>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class WebApplicationInsightsInitializer
+    {
+        private static readonly object SyncRoot = new object();
+        private static bool isInitialized;
+
+        /// <summary>
+        /// Initializes the default <see cref="TelemetryConfiguration"/> from
+        /// <c>ApplicationInsights.config</c>. Safe to call multiple times; subsequent
+        /// calls are no-ops.
+        /// </summary>
+        /// <remarks>
+        /// This method is public only because <see cref="System.Web.PreApplicationStartMethodAttribute"/>
+        /// requires it to be public. It is invoked automatically by ASP.NET and is not
+        /// intended to be called directly by user code.
+        /// </remarks>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static void Initialize()
+        {
+            if (isInitialized)
+            {
+                return;
+            }
+
+            lock (SyncRoot)
+            {
+                if (isInitialized)
+                {
+                    return;
+                }
+
+                // Materialize the singleton. Any subsequent call to
+                // TelemetryConfiguration.CreateDefault() returns this same instance.
+                TelemetryConfiguration cfg = TelemetryConfiguration.CreateDefault();
+
+                cfg.ExtensionVersion = VersionUtils.ExtensionLabelShimWeb
+                    + VersionUtils.GetVersion(typeof(ApplicationInsightsExtensions));
+
+                ApplicationInsightsConfigOptions configOptions =
+                    ApplicationInsightsConfigurationReader.GetConfigurationOptions();
+
+                if (configOptions != null)
+                {
+                    ApplyConfigOptions(cfg, configOptions);
+                }
+                else
+                {
+                    WebEventSource.Log.NoConnectionStringFoundInConfig();
+                    cfg.ConfigureOpenTelemetryBuilder(
+                        builder => builder.UseApplicationInsightsAspNetTelemetry());
+                }
+
+                isInitialized = true;
+            }
+        }
+
+        /// <summary>
+        /// Applies the values read from <c>ApplicationInsights.config</c> to the given
+        /// <see cref="TelemetryConfiguration"/>.
+        /// </summary>
+        private static void ApplyConfigOptions(TelemetryConfiguration cfg, ApplicationInsightsConfigOptions configOptions)
+        {
+            // Direct TelemetryConfiguration properties (must be set before Build).
+            if (!string.IsNullOrEmpty(configOptions.ConnectionString))
+            {
+                cfg.ConnectionString = configOptions.ConnectionString;
+                WebEventSource.Log.ConnectionStringLoadedFromConfig(configOptions.ConnectionString);
+            }
+            else
+            {
+                WebEventSource.Log.NoConnectionStringFoundInConfig();
+            }
+
+            if (configOptions.DisableTelemetry.HasValue)
+            {
+                cfg.DisableTelemetry = configOptions.DisableTelemetry.Value;
+            }
+
+            if (configOptions.TracesPerSecond.HasValue)
+            {
+                cfg.TracesPerSecond = configOptions.TracesPerSecond.Value;
+            }
+
+            if (configOptions.SamplingRatio.HasValue)
+            {
+                cfg.SamplingRatio = configOptions.SamplingRatio.Value;
+                if (!configOptions.TracesPerSecond.HasValue)
+                {
+                    cfg.TracesPerSecond = null;
+                }
+            }
+
+            if (!string.IsNullOrEmpty(configOptions.StorageDirectory))
+            {
+                cfg.StorageDirectory = configOptions.StorageDirectory;
+            }
+
+            if (configOptions.DisableOfflineStorage.HasValue)
+            {
+                cfg.DisableOfflineStorage = configOptions.DisableOfflineStorage.Value;
+            }
+
+            if (configOptions.EnableTraceBasedLogsSampler.HasValue)
+            {
+                cfg.EnableTraceBasedLogsSampler = configOptions.EnableTraceBasedLogsSampler.Value;
+            }
+
+            // EnableQuickPulseMetricStream -> EnableLiveMetrics (TelemetryConfiguration property).
+            if (configOptions.EnableQuickPulseMetricStream.HasValue)
+            {
+                cfg.EnableLiveMetrics = configOptions.EnableQuickPulseMetricStream.Value;
+            }
+
+            // Configure OpenTelemetry builder for properties that require OpenTelemetry API.
+            cfg.ConfigureOpenTelemetryBuilder(
+                builder => ConfigureOpenTelemetryWithOptions(builder, configOptions));
+        }
+
+        /// <summary>
+        /// Configures OpenTelemetry builder with options that require OpenTelemetry API access.
+        /// Note: Classic ASP.NET doesn't use DI, so we can only configure things through the builder's direct API.
+        /// </summary>
+        private static void ConfigureOpenTelemetryWithOptions(IOpenTelemetryBuilder builder, ApplicationInsightsConfigOptions configOptions)
+        {
+            builder.UseApplicationInsightsAspNetTelemetry();
+
+            // Configure AzureMonitorExporterOptions for internal properties using reflection.
+            // Even though classic ASP.NET doesn't use DI, the OpenTelemetry builder does internally.
+            builder.Services.Configure<AzureMonitorExporterOptions>(exporterOptions =>
+            {
+                // EnablePerformanceCounterCollectionModule -> EnablePerfCounters (internal property).
+                if (configOptions.EnablePerformanceCounterCollectionModule.HasValue)
+                {
+                    TrySetInternalProperty(exporterOptions, "EnablePerfCounters", configOptions.EnablePerformanceCounterCollectionModule.Value);
+                }
+
+                // AddAutoCollectedMetricExtractor -> EnableStandardMetrics (internal property).
+                if (configOptions.AddAutoCollectedMetricExtractor.HasValue)
+                {
+                    TrySetInternalProperty(exporterOptions, "EnableStandardMetrics", configOptions.AddAutoCollectedMetricExtractor.Value);
+                }
+            });
+
+            // Handle EnableDependencyTrackingTelemetryModule and EnableRequestTrackingTelemetryModule - add activity filter processor.
+            bool enableDependencyTracking = configOptions.EnableDependencyTrackingTelemetryModule ?? true;
+            bool enableRequestTracking = configOptions.EnableRequestTrackingTelemetryModule ?? true;
+
+            // Only add processor if either feature is disabled.
+            if (!enableDependencyTracking || !enableRequestTracking)
+            {
+                builder.WithTracing(tracerBuilder =>
+                {
+                    tracerBuilder.AddProcessor(new ActivityFilterProcessor(enableDependencyTracking, enableRequestTracking));
+                });
+            }
+
+            // Handle ApplicationVersion - add to resource attributes.
+            if (!string.IsNullOrEmpty(configOptions.ApplicationVersion))
+            {
+                builder.ConfigureResource(resourceBuilder =>
+                {
+                    resourceBuilder.AddAttributes(new[]
+                    {
+                        new KeyValuePair<string, object>("service.version", configOptions.ApplicationVersion),
+                    });
+                });
+            }
+        }
+
+        /// <summary>
+        /// Tries to set an internal property on an object using reflection.
+        /// Used to configure internal properties on AzureMonitorExporterOptions.
+        /// </summary>
+        private static void TrySetInternalProperty(object target, string propertyName, bool value)
+        {
+            try
+            {
+                var property = target.GetType().GetProperty(propertyName, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+                if (property != null && property.CanWrite && property.PropertyType == typeof(bool))
+                {
+                    property.SetValue(target, value);
+                }
+            }
+            catch
+            {
+                // Silently ignore if property doesn't exist or can't be set.
+                // This allows forward/backward compatibility across versions.
+            }
+        }
+    }
+}

--- a/examples/ClassicAspNetWebApp/Web.config
+++ b/examples/ClassicAspNetWebApp/Web.config
@@ -22,96 +22,180 @@
     </pages>
   </system.web>
 <runtime>
-    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
-			<dependentAssembly>
-				<assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="F23A46DE0BE5D6F3" culture="neutral"/>
-				<bindingRedirect oldVersion="0.0.0.0-2.23.0.523" newVersion="2.23.0.523"/>
-			</dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f"/>
-        <bindingRedirect oldVersion="0.0.0.0-3.5.0.2" newVersion="3.5.0.2"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-2.0.0.0" newVersion="2.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed"/>
-        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35"/>
-        <bindingRedirect oldVersion="0.0.0.0-1.6.5135.21930" newVersion="1.6.5135.21930"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration" culture="neutral" publicKeyToken="adb9793829ddae60"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Options" culture="neutral" publicKeyToken="adb9793829ddae60"/>
-        <bindingRedirect oldVersion="0.0.0.0-9.0.0.0" newVersion="9.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.ValueTuple" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.4.0" newVersion="4.2.4.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="B03F5F7F11D50A3A" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-6.0.3.0" newVersion="6.0.3.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Memory" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Buffers" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.0" newVersion="4.0.5.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Encodings.Web" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.5.1" newVersion="4.0.5.1"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="CC7B13FFCD2DDD51" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" culture="neutral" publicKeyToken="adb9793829ddae60"/>
-        <bindingRedirect oldVersion="0.0.0.0-10.0.0.0" newVersion="10.0.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Net.Http" culture="neutral" publicKeyToken="b03f5f7f11d50a3a"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Text.Json" culture="neutral" publicKeyToken="cc7b13ffcd2ddd51"/>
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.6" newVersion="8.0.0.6"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" culture="neutral" publicKeyToken="b03f5f7f11d50a3a"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.0.2.0" newVersion="4.0.2.0"/>
-      </dependentAssembly>
-      <dependentAssembly>
-        <assemblyIdentity name="System.Numerics.Vectors" culture="neutral" publicKeyToken="b03f5f7f11d50a3a"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.1.6.0" newVersion="4.1.6.0"/>
-      </dependentAssembly>
-    </assemblyBinding>
+	<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="f23a46de0be5d6f3" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="3.1.1.103"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Antlr3.Runtime" publicKeyToken="eb42632606e9261f" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="3.5.0.2"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Web.Infrastructure" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="2.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="13.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="WebGrease" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.6.5135.21930"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Bcl.AsyncInterfaces" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Configuration.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Configuration.Binder" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.DependencyInjection" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.DependencyInjection.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Diagnostics.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.FileProviders.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Hosting.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Logging" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Logging.Abstractions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Logging.Configuration" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Options" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Options.ConfigurationExtensions" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Extensions.Primitives" publicKeyToken="adb9793829ddae60" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.ValueTuple" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.5.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Threading.Tasks.Extensions" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.2.4.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Runtime.CompilerServices.Unsafe" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="6.0.3.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.5.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Memory.Data" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Buffers" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.5.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.IO.Pipelines" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Text.Encodings.Web" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.2.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Text.Json" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="10.0.0.3"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Formats.Asn1" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="8.0.0.1"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Runtime.InteropServices.RuntimeInformation" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.2.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Numerics.Vectors" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.1.6.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Security.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Security.Principal.Windows" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.Security.Cryptography.ProtectedData" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.0.3.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.IO.FileSystem.AccessControl" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="5.0.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Identity.Client" publicKeyToken="0a613f4dd989e8ae" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.83.1.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.Identity.Client.Extensions.Msal" publicKeyToken="0a613f4dd989e8ae" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="4.83.1.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Microsoft.IdentityModel.Abstractions" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="8.14.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="Azure.Core" publicKeyToken="92742159e12e44c8" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.54.0.0"/>
+	  </dependentAssembly>
+	  <dependentAssembly>
+		<assemblyIdentity name="System.ClientModel" publicKeyToken="92742159e12e44c8" culture="neutral"/>
+		<bindingRedirect oldVersion="0.0.0.0-65535.65535.65535.65535" newVersion="1.10.0.0"/>
+	  </dependentAssembly>
+	</assemblyBinding>
   </runtime>
   <system.codedom>
     <compilers>

--- a/examples/ClassicAspNetWebApp/applicationinsights.config
+++ b/examples/ClassicAspNetWebApp/applicationinsights.config
@@ -27,6 +27,6 @@
   <EnablePerformanceCounterCollectionModule>true</EnablePerformanceCounterCollectionModule>
   <AddAutoCollectedMetricExtractor>true</AddAutoCollectedMetricExtractor>
   <EnableDependencyTrackingTelemetryModule>true</EnableDependencyTrackingTelemetryModule>
-  <EnableRequestTrackingTelemetryModule>false</EnableRequestTrackingTelemetryModule>
+  <EnableRequestTrackingTelemetryModule>true</EnableRequestTrackingTelemetryModule>
   <ApplicationVersion>1.0.0</ApplicationVersion>
 </ApplicationInsights>


### PR DESCRIPTION
Fixes #3163

## Problem

On classic ASP.NET, calling `TelemetryConfiguration.CreateDefault()` from `Application_Start` (or anywhere else in user code) returned a bare configuration — connection string and other settings from `ApplicationInsights.config` were never applied. Customers had to use a workaround or set properties manually:

```csharp
// Global.asax.cs
void Application_Start(object sender, EventArgs e)
{
    var telemetryConfig = TelemetryConfiguration.CreateDefault(); // ❌ no connection string
    var telemetryClient = new TelemetryClient(telemetryConfig);   // throws / no-op
}
```

The previous implementation read the config file inside `ApplicationInsightsHttpModule.Init`, which runs **after** `Application_Start`. Because `TelemetryConfiguration.CreateDefault()` is a `Lazy<T>` singleton, whichever caller materialized it first determined what every subsequent caller saw — and the customer's `Application_Start` call typically won, getting an empty config.

## Fix

Introduced `WebApplicationInsightsInitializer` in the `Microsoft.AI.Web` assembly, registered via `[assembly: PreApplicationStartMethod]`. ASP.NET invokes this **before** `Application_Start`, so it:

1. Materializes the `TelemetryConfiguration` singleton via `CreateDefault()`.
2. Reads `ApplicationInsights.config` and applies all settings (connection string, sampling, storage, live metrics, request/dependency tracking, etc.) to the singleton.
3. Registers the OpenTelemetry builder configuration (`UseApplicationInsightsAspNetTelemetry`, `ActivityFilterProcessor`, resource attributes).

Any subsequent `TelemetryConfiguration.CreateDefault()` call — from `Application_Start`, the HTTP module, or third-party code — returns the same already-populated instance. **No new API, no workaround.**

## Customer experience after this PR

```csharp
void Application_Start(object sender, EventArgs e)
{
    var telemetryConfig = TelemetryConfiguration.CreateDefault(); // ✅ fully populated
    var telemetryClient = new TelemetryClient(telemetryConfig);
}
```

## Changes

| File | Change |
|---|---|
| `WEB/Src/Web/Web/WebApplicationInsightsInitializer.cs` | **New.** `[PreApplicationStartMethod]` entry point that populates the singleton from `ApplicationInsights.config`. Marked `[EditorBrowsable(Never)]` — public only because ASP.NET requires it. |
| `WEB/Src/Web/Web/ApplicationInsightsHttpModule.cs` | Simplified from ~220 → ~75 lines. Dropped static `sharedTelemetryConfiguration`, custom init bookkeeping, reflection helpers, and the OTel-builder config block (all moved to the initializer). `Init` now just calls `WebApplicationInsightsInitializer.Initialize()` defensively and `TelemetryConfiguration.CreateDefault()`. |
| `BASE/src/Microsoft.ApplicationInsights/Extensibility/TelemetryConfiguration.cs` | `PrependOpenTelemetryBuilderConfiguration` no longer throws if the configuration was already built — it silently skips. Needed because internal prepends (e.g., `TelemetryContextActivityProcessor`) can fire after the SDK has been built by an earlier `TelemetryClient` construction during `PreApplicationStartMethod`. |
| `.publicApi/Microsoft.AI.Web.dll/Stable/PublicAPI.Unshipped.txt` | Added `WebApplicationInsightsInitializer` + `Initialize()`. |
| `examples/ClassicAspNetWebApp/Web.config` | Updated binding redirects to match current package versions. |
| `examples/ClassicAspNetWebApp/applicationinsights.config` | Flipped `EnableRequestTrackingTelemetryModule` from `false` → `true` so the sample doesn't ship with incoming request telemetry suppressed. |

## Testing

- `dotnet build WEB/Src/Web/Web/Web.csproj` → 0 warnings, 0 errors.
- Smoke-tested `ClassicAspNetWebApp`: `CreateDefault()` in `Application_Start` returns a configuration with the connection string from `ApplicationInsights.config`; Live Metrics shows incoming request rate when traffic is generated.

## Notes

- `WebApplicationInsightsInitializer` and `Initialize()` must remain `public` — `PreApplicationStartMethod` requires it. `[EditorBrowsable(Never)]` hides them from IntelliSense, and remarks clarify they're not for direct user invocation.
- The initializer is idempotent (`isInitialized` guard) and the HTTP module calls it defensively in case the assembly wasn't scanned during ASP.NET startup.
- BASE → WEB layering is preserved: no XML I/O or ASP.NET specifics moved into BASE; no `#if WEB` in `TelemetryConfiguration.CreateDefault()`.