### PR TITLE
Remove use of banned domain

### DIFF
--- a/examples/ClassicAspNetWebApp/App_Start/BundleConfig.cs
+++ b/examples/ClassicAspNetWebApp/App_Start/BundleConfig.cs
@@ -44,8 +44,8 @@ namespace ClassicAspNetWebApp
                 {
                     Path = "~/scripts/jquery-3.7.0.min.js",
                     DebugPath = "~/scripts/jquery-3.7.0.js",
-                    CdnPath = "https://code.jquery.com/jquery-3.7.1.min.js",
-                    CdnDebugPath = "https://code.jquery.com/jquery-3.7.1.js"
+                    CdnPath = "https://code.jquery.com/jquery-3.7.0.min.js",
+                    CdnDebugPath = "https://code.jquery.com/jquery-3.7.0.js"
                 });
         }
     }

--- a/examples/ClassicAspNetWebApp/App_Start/BundleConfig.cs
+++ b/examples/ClassicAspNetWebApp/App_Start/BundleConfig.cs
@@ -44,8 +44,8 @@ namespace ClassicAspNetWebApp
                 {
                     Path = "~/scripts/jquery-3.7.0.min.js",
                     DebugPath = "~/scripts/jquery-3.7.0.js",
-                    CdnPath = "http://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.7.0.min.js",
-                    CdnDebugPath = "http://ajax.aspnetcdn.com/ajax/jQuery/jquery-3.7.0.js"
+                    CdnPath = "https://code.jquery.com/jquery-3.7.1.min.js",
+                    CdnDebugPath = "https://code.jquery.com/jquery-3.7.1.js"
                 });
         }
     }


### PR DESCRIPTION
Remove use of banned domain.

> `ajax.microsoft.com` and `ajax.aspnetcdn.com` host old and, in some cases, vulnerable JavaScript or old CSS in a non-production CDN. This CDN has no SLA, and could disappear at any time.

Official doc for these assets has warnings about this issue as well: https://learn.microsoft.com/en-us/aspnet/ajax/cdn/overview