### PR TITLE
Skip Azure VM resource detection on App Service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- [Fix #3179: Skip Azure VM resource detection on Azure App Service to prevent unnecessary IMDS requests.](https://github.com/microsoft/ApplicationInsights-dotnet/issues/3179)
 - [Fix #3197: `NullReferenceException` when using TelemetryClient APIs when no connection string is provided.](https://github.com/microsoft/ApplicationInsights-dotnet/pull/3199)
 
 ## Version 3.1.2

--- a/NETCORE/src/Shared/Vendoring/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
+++ b/NETCORE/src/Shared/Vendoring/OpenTelemetry.Resources.Azure/AzureVMResourceDetector.cs
@@ -4,6 +4,7 @@
 
 namespace Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources.Azure
 {
+    using System;
     using System.Collections.Generic;
     using global::OpenTelemetry;
     using global::OpenTelemetry.Resources;
@@ -36,6 +37,11 @@ namespace Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources
         {
             try
             {
+                if (Environment.GetEnvironmentVariable(ResourceAttributeConstants.AppServiceSiteNameEnvVar) != null)
+                {
+                    return Resource.Empty;
+                }
+
                 if (vmResource != null)
                 {
                     return vmResource;

--- a/NETCORE/test/IntegrationTests.Tests/AzureVMResourceDetectorTests.cs
+++ b/NETCORE/test/IntegrationTests.Tests/AzureVMResourceDetectorTests.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Reflection;
+using Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources.Azure;
+using OpenTelemetry.Resources;
+using Xunit;
+
+namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+{
+    public class AzureVMResourceDetectorTests : IDisposable
+    {
+        private readonly string? originalWebsiteSiteName;
+        private readonly Func<AzureVmMetadataResponse?> originalGetAzureVmMetaDataResponse;
+        private readonly FieldInfo vmResourceField;
+        private readonly Resource? originalVmResource;
+
+        public AzureVMResourceDetectorTests()
+        {
+            this.originalWebsiteSiteName = Environment.GetEnvironmentVariable(
+                ResourceAttributeConstants.AppServiceSiteNameEnvVar);
+
+            this.originalGetAzureVmMetaDataResponse =
+                AzureVmMetaDataRequestor.GetAzureVmMetaDataResponse;
+
+            this.vmResourceField = typeof(AzureVMResourceDetector).GetField(
+                "vmResource",
+                BindingFlags.NonPublic | BindingFlags.Static)!;
+
+            this.originalVmResource =
+                (Resource?)this.vmResourceField.GetValue(null);
+
+            this.vmResourceField.SetValue(null, null);
+        }
+
+        [Fact]
+        public void DetectDoesNotRequestAzureVmMetadataWhenRunningOnAppService()
+        {
+            // ARRANGE
+            var metadataWasRequested = false;
+
+            Environment.SetEnvironmentVariable(
+                ResourceAttributeConstants.AppServiceSiteNameEnvVar,
+                "test-app-service");
+
+            AzureVmMetaDataRequestor.GetAzureVmMetaDataResponse = () =>
+            {
+                metadataWasRequested = true;
+                return null;
+            };
+
+            var detector = new AzureVMResourceDetector();
+
+            // ACT
+            detector.Detect();
+
+            // ASSERT
+            Assert.False(
+                metadataWasRequested,
+                "The Azure VM detector should not query IMDS when App Service has already been detected.");
+        }
+
+        public void Dispose()
+        {
+            Environment.SetEnvironmentVariable(
+                ResourceAttributeConstants.AppServiceSiteNameEnvVar,
+                this.originalWebsiteSiteName);
+
+            AzureVmMetaDataRequestor.GetAzureVmMetaDataResponse =
+                this.originalGetAzureVmMetaDataResponse;
+
+            this.vmResourceField.SetValue(null, this.originalVmResource);
+        }
+    }
+}

--- a/NETCORE/test/IntegrationTests.Tests/AzureVMResourceDetectorTests.cs
+++ b/NETCORE/test/IntegrationTests.Tests/AzureVMResourceDetectorTests.cs
@@ -4,8 +4,12 @@ using Microsoft.ApplicationInsights.Shared.Vendoring.OpenTelemetry.Resources.Azu
 using OpenTelemetry.Resources;
 using Xunit;
 
-namespace Microsoft.ApplicationInsights.AspNetCore.Tests
+namespace IntegrationTests.Tests
 {
+    [CollectionDefinition("AzureVMResourceDetectorTests", DisableParallelization = true)]
+    public class AzureVMResourceDetectorTestsCollectionDefinition { }
+
+    [Collection("AzureVMResourceDetectorTests")]
     public class AzureVMResourceDetectorTests : IDisposable
     {
         private readonly string? originalWebsiteSiteName;


### PR DESCRIPTION
Fixes #3179.

## Changes

* Skip Azure VM resource detection when the `WEBSITE_SITE_NAME` environment variable identifies the application as running on Azure App Service.
* Prevent the VM resource detector from making an unnecessary request to the Azure Instance Metadata Service.
* Add a regression test verifying that VM metadata is not requested when running on App Service.

### Checklist

* [x] I ran Unit Tests locally.
* [X] CHANGELOG.md updated with one line description of the fix, and a link to the original issue if available.
